### PR TITLE
Run go mod init to set up go-nvml as a Go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/NVIDIA/go-nvml
+
+go 1.15


### PR DESCRIPTION
This change adds a `go.mod` file to the repository created by running `go mod init`. This allows for the package to be used as a module (and consumed as such).

It also means that the package does not need to be in the GOPATH to develop.

Before:
```
$ make test
cd /home/elezar/src/go-nvml/pkg/nvml; \
        go test -v .; \
cd -> /dev/null
init.go:19:2: cannot find package "github.com/NVIDIA/go-nvml/pkg/dl" in any of:
        /usr/local/go/src/github.com/NVIDIA/go-nvml/pkg/dl (from $GOROOT)
        /home/elezar/go/src/github.com/NVIDIA/go-nvml/pkg/dl (from $GOPATH)
```

After
```
$ make test
cd /home/elezar/src/go-nvml/pkg/nvml; \
        go test -v .; \
cd -> /dev/null
=== RUN   TestInit
--- FAIL: TestInit (0.00s)
panic: error opening libnvidia-ml.so.1: libnvidia-ml.so.1: cannot open shared object file: No such file or directory [recovered]
        panic: error opening libnvidia-ml.so.1: libnvidia-ml.so.1: cannot open shared object file: No such file or directory

goroutine 6 [running]:
testing.tRunner.func1.1(0x535980, 0xc00004e4e0)
        /usr/local/go/src/testing/testing.go:1072 +0x30d
testing.tRunner.func1(0xc000001b00)
        /usr/local/go/src/testing/testing.go:1075 +0x41a
panic(0x535980, 0xc00004e4e0)
        /usr/local/go/src/runtime/panic.go:969 +0x1b9
github.com/NVIDIA/go-nvml/pkg/nvml.Init(0x21ed6108)
        /home/elezar/src/go-nvml/pkg/nvml/init.go:40 +0x177
github.com/NVIDIA/go-nvml/pkg/nvml.TestInit(0xc000001b00)
        /home/elezar/src/go-nvml/pkg/nvml/nvml_test.go:22 +0x26
testing.tRunner(0xc000001b00, 0x56ace8)
        /usr/local/go/src/testing/testing.go:1123 +0xef
created by testing.(*T).Run
        /usr/local/go/src/testing/testing.go:1168 +0x2b3
FAIL    github.com/NVIDIA/go-nvml/pkg/nvml      0.008s
FAIL
```
(Note that the failure is expected as this is not run on a machine with NVML installed).