### PR TITLE
Add docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+ARG GOLANG_VERSION=0.0.0
+FROM golang:${GOLANG_VERSION}
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        patch \
+    && rm -rf /var/lib/apt/lists/*
+
+# Get the supported version of c-for-go. Here we force the use of `GO111MODULE` for go get
+# to support the @VERSION syntax.
+ARG C_FOR_GO_TAG=master
+RUN GO111MODULE=on go get github.com/xlab/c-for-go@${C_FOR_GO_TAG}
+# Set the permissions on the go module path to ensure that this is accessible from
+# our user containers.
+RUN chmod -R a+rx /go/pkg/mod

--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-GEN_DIR = $(PWD)/gen
-PKG_DIR = $(PWD)/pkg
-GEN_BINDINGS_DIR = $(GEN_DIR)/nvml
-PKG_BINDINGS_DIR = $(PKG_DIR)/nvml
+DOCKER ?= docker
+GOLANG_VERSION ?= 1.14.4
+C_FOR_GO_TAG ?= 8eeee8c3b71f9c3c90c4a73db54ed08b0bba971d
+BUILDIMAGE ?= nvidia/go-nvml-devel:$(GOLANG_VERSION)-$(C_FOR_GO_TAG)
+
+PWD := $(shell pwd)
+GEN_DIR := $(PWD)/gen
+PKG_DIR := $(PWD)/pkg
+GEN_BINDINGS_DIR := $(GEN_DIR)/nvml
+PKG_BINDINGS_DIR := $(PKG_DIR)/nvml
 
 SOURCES = $(shell find $(GEN_BINDINGS_DIR) -type f)
 
-.PHONY: all test clean
-.PHONY: bindings test-bindings clean-bindings
+TARGETS := all test clean bindings test-bindings clean-bindings
+DOCKER_TARGETS := $(patsubst %, docker-%, $(TARGETS))
+.PHONY: $(TARGETS) $(DOCKER_TARGETS)
+
+.DEFAULT_GOAL = all
 
 all: bindings
 test: test-bindings
@@ -46,3 +55,50 @@ test-bindings: $(PKG_BINDINGS_DIR)
 
 clean-bindings:
 	rm -rf $(PKG_BINDINGS_DIR)
+
+# Generate an image for containerized builds
+# Note: This image is local only
+.build-image: Dockerfile
+	$(DOCKER) build \
+		--progress=plain \
+		--build-arg GOLANG_VERSION="$(GOLANG_VERSION)" \
+		--build-arg C_FOR_GO_TAG="$(C_FOR_GO_TAG)" \
+		--tag $(BUILDIMAGE) \
+		.
+
+# A target for executing make targets in a docker container
+$(DOCKER_TARGETS): docker-%: .build-image
+	@echo "Running 'make $(*)' in docker container $(BUILDIMAGE)"
+	$(DOCKER) run \
+		--rm \
+		-e GOCACHE=/tmp/.cache \
+		-v $(PWD):$(PWD) \
+		-w $(PWD) \
+		--user $$(id -u):$$(id -g) \
+		$(BUILDIMAGE) \
+			make $(*)
+
+# A make target to set up an interactive docker environment as the current user.
+# This is useful for debugging issues in the make process in the container.
+.docker-shell: .build-image
+	$(DOCKER) run \
+		-ti \
+		--rm \
+		-e GOCACHE=/tmp/.cache \
+		-v $(PWD):$(PWD) \
+		-w $(PWD) \
+		--user $$(id -u):$$(id -g) \
+		$(BUILDIMAGE) \
+			bash
+
+# A make target to set up an interactive docker environment as root.
+# This is useful for debugging issues in dependencies or the container build process
+.docker-root-shell: .build-image
+	$(DOCKER) run \
+		-ti \
+		--rm \
+		-e GOCACHE=/tmp/.cache \
+		-v $(PWD):$(PWD) \
+		-w $(PWD) \
+		$(BUILDIMAGE) \
+			bash

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - [Contributing](#contributing)
 
 ## Overview
- 
+
 This repository provides Go bindings for the [NVIDIA Management Library API
 (NVML)](https://docs.nvidia.com/deploy/nvml-api/).
 
@@ -35,8 +35,8 @@ any version of `libnvidia-ml.so` installed on your system.
 compile code that imports these bindings. However, you will get a runtime error
 if `libnvidia-ml.so` is not available in your library path at runtime.
 
-Please see the following link for documentation on the full NVML Go API:  
-http://godoc.org/github.com/NVIDIA/go-nvml/pkg/nvml 
+Please see the following link for documentation on the full NVML Go API:
+http://godoc.org/github.com/NVIDIA/go-nvml/pkg/nvml
 
 ## Quick Start
 
@@ -466,6 +466,8 @@ The test coverage is fairly sparse and could be greatly improved.
 Building and testing the bindings is fairly straight-forward. The only
 prerequisite is a working installation of `c-for-go` from
 https://github.com/xlab/c-for-go.
+
+**Note**: Please check the `Makefile` for the specific version of `c-for-go` used.
 
 Once this is available, just run the sequence below to build and test these
 NVML Go bindings. The generated bindings will be placed under `go-nvml/pkg/nvml`.


### PR DESCRIPTION
This change adds a basic Dockerfile that includes the c-for-go
dependency to allow the generation of bindings without installing
this dependency.

A generic make target `docker-%` is added to run any of the recognised
make targets in the container.

```bash
$ make \t\t
all                    clean                  docker-all             docker-clean           docker-test            image                  test-bindings
bindings               clean-bindings         docker-bindings        docker-clean-bindings  docker-test-bindings   test
```

Note that this pins:
* The GO version to 1.14.4
* The c-for-go commit to 8eeee8c3b71f9c3c90c4a73db54ed08b0bba971d

To ensure that this does not introduce any changes when generating
the bindings.