### PR TITLE
Update Return type with an exrtra API call and fix bug in versioned APIs

### DIFF
--- a/gen/nvml/init.go
+++ b/gen/nvml/init.go
@@ -91,50 +91,50 @@ var nvmlEventSetWait = nvmlEventSetWait_v1
 
 // updateVersionedSymbols()
 func updateVersionedSymbols() {
-	ret := nvml.Lookup("nvmlInit_v2")
-	if ret == SUCCESS {
+	err := nvml.Lookup("nvmlInit_v2")
+	if err == nil {
 		nvmlInit = nvmlInit_v2
 	}
-	ret = nvml.Lookup("nvmlDeviceGetPciInfo_v2")
-	if ret == SUCCESS {
+	err = nvml.Lookup("nvmlDeviceGetPciInfo_v2")
+	if err == nil {
 		nvmlDeviceGetPciInfo = nvmlDeviceGetPciInfo_v2
 	}
-	ret = nvml.Lookup("nvmlDeviceGetPciInfo_v3")
-	if ret == SUCCESS {
+	err = nvml.Lookup("nvmlDeviceGetPciInfo_v3")
+	if err == nil {
 		nvmlDeviceGetPciInfo = nvmlDeviceGetPciInfo_v3
 	}
-	ret = nvml.Lookup("nvmlDeviceGetCount_v2")
-	if ret == SUCCESS {
+	err = nvml.Lookup("nvmlDeviceGetCount_v2")
+	if err == nil {
 		nvmlDeviceGetCount = nvmlDeviceGetCount_v2
 	}
-	ret = nvml.Lookup("nvmlDeviceGetHandleByIndex_v2")
-	if ret == SUCCESS {
+	err = nvml.Lookup("nvmlDeviceGetHandleByIndex_v2")
+	if err == nil {
 		nvmlDeviceGetHandleByIndex = nvmlDeviceGetHandleByIndex_v2
 	}
-	ret = nvml.Lookup("nvmlDeviceGetHandleByPciBusId_v2")
-	if ret == SUCCESS {
+	err = nvml.Lookup("nvmlDeviceGetHandleByPciBusId_v2")
+	if err == nil {
 		nvmlDeviceGetHandleByPciBusId = nvmlDeviceGetHandleByPciBusId_v2
 	}
-	ret = nvml.Lookup("nvmlDeviceGetNvLinkRemotePciInfo_v2")
-	if ret == SUCCESS {
+	err = nvml.Lookup("nvmlDeviceGetNvLinkRemotePciInfo_v2")
+	if err == nil {
 		nvmlDeviceGetNvLinkRemotePciInfo = nvmlDeviceGetNvLinkRemotePciInfo_v2
 	}
 	// Unable to overwrite nvmlDeviceRemoveGpu() because the v2 function takes
 	// a different set of parameters than the v1 function.
-	//ret = nvml.Lookup("nvmlDeviceRemoveGpu_v2")
-	//if ret == SUCCESS {
+	//err = nvml.Lookup("nvmlDeviceRemoveGpu_v2")
+	//if err == nil {
 	//    nvmlDeviceRemoveGpu = nvmlDeviceRemoveGpu_v2
 	//}
-	ret = nvml.Lookup("nvmlDeviceGetGridLicensableFeatures_v2")
-	if ret == SUCCESS {
+	err = nvml.Lookup("nvmlDeviceGetGridLicensableFeatures_v2")
+	if err == nil {
 		nvmlDeviceGetGridLicensableFeatures = nvmlDeviceGetGridLicensableFeatures_v2
 	}
-	ret = nvml.Lookup("nvmlDeviceGetGridLicensableFeatures_v3")
-	if ret == SUCCESS {
+	err = nvml.Lookup("nvmlDeviceGetGridLicensableFeatures_v3")
+	if err == nil {
 		nvmlDeviceGetGridLicensableFeatures = nvmlDeviceGetGridLicensableFeatures_v3
 	}
-	ret = nvml.Lookup("nvmlEventSetWait_v2")
-	if ret == SUCCESS {
+	err = nvml.Lookup("nvmlEventSetWait_v2")
+	if err == nil {
 		nvmlEventSetWait = nvmlEventSetWait_v2
 	}
 }

--- a/gen/nvml/return.go
+++ b/gen/nvml/return.go
@@ -19,6 +19,10 @@ func ErrorString(Result Return) string {
 	return nvmlErrorString(Result)
 }
 
+func (r Return) Value() Return {
+	return r
+}
+
 func (r Return) String() string {
 	return ErrorString(r)
 }


### PR DESCRIPTION
```
Author: Kevin Klues <kklues@nvidia.com>
Date:   Tue Jan 19 16:28:58 2021 +0000

    Fix error check in call to set versioned API calls

    Previously, it was checking them against nvml.Return types (which was
    wrong on many levels). It only happened wot work on my tests because I
    had a machine with the latest API calls for everything.

    Signed-off-by: Kevin Klues <kklues@nvidia.com>
```
```
Author: Kevin Klues <kklues@nvidia.com>
Date:   Tue Jan 19 16:27:06 2021 +0000

    Add Value() call to nvml.Return type

    Not necessary when using the package API directly, but helps with
    mocking out the Return type in higher level libraries and then having
    them be able to easily swap in the package based implementation at a
    later time.

    Signed-off-by: Kevin Klues <kklues@nvidia.com>
```