### PR TITLE
Check for ERROR_INSUFFICIENT_SIZE for GetProcessUtilization

### DIFF
--- a/gen/nvml/device.go
+++ b/gen/nvml/device.go
@@ -1468,7 +1468,7 @@ func (Device Device) GetGridLicensableFeatures() (GridLicensableFeatures, Return
 func DeviceGetProcessUtilization(Device Device, LastSeenTimeStamp uint64) ([]ProcessUtilizationSample, Return) {
 	var ProcessSamplesCount uint32
 	ret := nvmlDeviceGetProcessUtilization(Device, nil, &ProcessSamplesCount, LastSeenTimeStamp)
-	if ret != SUCCESS {
+	if ret != ERROR_INSUFFICIENT_SIZE {
 		return nil, ret
 	}
 	if ProcessSamplesCount == 0 {
@@ -1476,7 +1476,7 @@ func DeviceGetProcessUtilization(Device Device, LastSeenTimeStamp uint64) ([]Pro
 	}
 	Utilization := make([]ProcessUtilizationSample, ProcessSamplesCount)
 	ret = nvmlDeviceGetProcessUtilization(Device, &Utilization[0], &ProcessSamplesCount, LastSeenTimeStamp)
-	return Utilization, ret
+	return Utilization[:ProcessSamplesCount], ret
 }
 
 func (Device Device) GetProcessUtilization(LastSeenTimeStamp uint64) ([]ProcessUtilizationSample, Return) {


### PR DESCRIPTION
The initial call to nvmlDeviceGetProcessUtilization to determine the number
of samples for which a buffer must be allocated returns ERROR_INSUFFICIENT_SIZE
and not SUCCESS.

Addresses #11 

Signed-off-by: Evan Lezar <elezar@nvidia.com>