### PR TITLE
Fix errors from 11.2 update and add examples

### DIFF
--- a/examples/compute-processes/main.go
+++ b/examples/compute-processes/main.go
@@ -1,0 +1,58 @@
+/**
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+)
+
+func main() {
+	ret := nvml.Init()
+	if ret != nvml.SUCCESS {
+		log.Fatalf("Unable to initialize NVML: %v", nvml.ErrorString(ret))
+	}
+	defer func() {
+		ret := nvml.Shutdown()
+		if ret != nvml.SUCCESS {
+			log.Fatalf("Unable to shutdown NVML: %v", nvml.ErrorString(ret))
+		}
+	}()
+
+	count, ret := nvml.DeviceGetCount()
+	if ret != nvml.SUCCESS {
+		log.Fatalf("Unable to get device count: %v", nvml.ErrorString(ret))
+	}
+
+	for di := 0; di < count; di++ {
+		device, ret := nvml.DeviceGetHandleByIndex(di)
+		if ret != nvml.SUCCESS {
+			log.Fatalf("Unable to get device at index %d: %v", di, nvml.ErrorString(ret))
+		}
+
+		processInfos, ret := device.GetComputeRunningProcesses()
+		if ret != nvml.SUCCESS {
+			log.Fatalf("Unable to get process info for device at index %d: %v", di, nvml.ErrorString(ret))
+		}
+		fmt.Printf("Found %d processes on device %d\n", len(processInfos), di)
+		for pi, processInfo := range processInfos {
+			fmt.Printf("\t[%2d] ProcessInfo: %+v\n", pi, processInfo)
+		}
+	}
+}

--- a/examples/devices/main.go
+++ b/examples/devices/main.go
@@ -1,0 +1,56 @@
+/*
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+)
+
+func main() {
+	ret := nvml.Init()
+	if ret != nvml.SUCCESS {
+		log.Fatalf("Unable to initialize NVML: %v", nvml.ErrorString(ret))
+	}
+	defer func() {
+		ret := nvml.Shutdown()
+		if ret != nvml.SUCCESS {
+			log.Fatalf("Unable to shutdown NVML: %v", nvml.ErrorString(ret))
+		}
+	}()
+
+	count, ret := nvml.DeviceGetCount()
+	if ret != nvml.SUCCESS {
+		log.Fatalf("Unable to get device count: %v", nvml.ErrorString(ret))
+	}
+
+	for i := 0; i < count; i++ {
+		device, ret := nvml.DeviceGetHandleByIndex(i)
+		if ret != nvml.SUCCESS {
+			log.Fatalf("Unable to get device at index %d: %v", i, nvml.ErrorString(ret))
+		}
+
+		uuid, ret := device.GetUUID()
+		if ret != nvml.SUCCESS {
+			log.Fatalf("Unable to get uuid of device at index %d: %v", i, nvml.ErrorString(ret))
+		}
+
+		fmt.Printf("%v\n", uuid)
+	}
+}

--- a/gen/nvml/device.go
+++ b/gen/nvml/device.go
@@ -552,7 +552,8 @@ func (Device Device) GetTemperatureThreshold(ThresholdType TemperatureThresholds
 
 // nvml.DeviceSetTemperatureThreshold()
 func DeviceSetTemperatureThreshold(Device Device, ThresholdType TemperatureThresholds, Temp int) Return {
-	ret := nvmlDeviceSetTemperatureThreshold(Device, ThresholdType, &Temp)
+	t := int32(Temp)
+	ret := nvmlDeviceSetTemperatureThreshold(Device, ThresholdType, &t)
 	return ret
 }
 

--- a/gen/nvml/vgpu.go
+++ b/gen/nvml/vgpu.go
@@ -316,7 +316,7 @@ func (VgpuInstance VgpuInstance) GetFBCSessions() (int, FBCSessionInfo, Return) 
 func VgpuInstanceGetGpuInstanceId(VgpuInstance VgpuInstance) (int, Return) {
 	var gpuInstanceId uint32
 	ret := nvmlVgpuInstanceGetGpuInstanceId(VgpuInstance, &gpuInstanceId)
-	return int(gpuInstanceId), SessionInfo, ret
+	return int(gpuInstanceId), ret
 }
 
 func (VgpuInstance VgpuInstance) GetGpuInstanceId() (int, Return) {

--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -552,7 +552,8 @@ func (Device Device) GetTemperatureThreshold(ThresholdType TemperatureThresholds
 
 // nvml.DeviceSetTemperatureThreshold()
 func DeviceSetTemperatureThreshold(Device Device, ThresholdType TemperatureThresholds, Temp int) Return {
-	ret := nvmlDeviceSetTemperatureThreshold(Device, ThresholdType, &Temp)
+	t := int32(Temp)
+	ret := nvmlDeviceSetTemperatureThreshold(Device, ThresholdType, &t)
 	return ret
 }
 

--- a/pkg/nvml/vgpu.go
+++ b/pkg/nvml/vgpu.go
@@ -316,7 +316,7 @@ func (VgpuInstance VgpuInstance) GetFBCSessions() (int, FBCSessionInfo, Return) 
 func VgpuInstanceGetGpuInstanceId(VgpuInstance VgpuInstance) (int, Return) {
 	var gpuInstanceId uint32
 	ret := nvmlVgpuInstanceGetGpuInstanceId(VgpuInstance, &gpuInstanceId)
-	return int(gpuInstanceId), SessionInfo, ret
+	return int(gpuInstanceId), ret
 }
 
 func (VgpuInstance VgpuInstance) GetGpuInstanceId() (int, Return) {


### PR DESCRIPTION
This changes fixes errors introduced in the update to NVML 11.2 and adds examples to allow these errors to be detected earlier.