### PR TITLE
Fix GetComputeRunningProcesses on CUDA 10.x

### DIFF
--- a/gen/nvml/device.go
+++ b/gen/nvml/device.go
@@ -933,18 +933,44 @@ func (Device Device) GetBridgeChipInfo() (BridgeChipHierarchy, Return) {
 
 // nvml.DeviceGetComputeRunningProcesses()
 func DeviceGetComputeRunningProcesses(Device Device) ([]ProcessInfo, Return) {
+	var Infos []ProcessInfo  // This is the v2 version of process info data structure
 	var InfoCount uint32 = 1 // Will be reduced upon returning
+	var ret = SUCCESS        // Will be changed upon returning
 	for {
-		Infos := make([]ProcessInfo, InfoCount)
-		ret := nvmlDeviceGetComputeRunningProcesses(Device, &InfoCount, &Infos[0])
+		if usesNvmlDeviceGetComputeRunningProcesses_v1 {
+			var v1Infos = make([]ProcessInfo_v1, InfoCount)
+			ret = nvmlDeviceGetComputeRunningProcesses_v1(Device, &InfoCount, (*ProcessInfo)(unsafe.Pointer(&v1Infos[0]))) // Call v1 version
+			if ret == SUCCESS && InfoCount > 0 {
+				// Convert process info data structure from v1 to v2
+				for i := range v1Infos {
+					pv1 := v1Infos[i]
+					pv2 := ProcessInfo{
+						Pid:               pv1.Pid,
+						UsedGpuMemory:     pv1.UsedGpuMemory,
+						GpuInstanceId:     0xFFFFFFFF, // GPU instance ID is invalid in v1
+						ComputeInstanceId: 0xFFFFFFFF, // Compute instance ID is invalid in v1
+					}
+					Infos = append(Infos, pv2)
+				}
+				break
+			}
+		} else {
+			Infos = make([]ProcessInfo, InfoCount)
+			ret = nvmlDeviceGetComputeRunningProcesses(Device, &InfoCount, &Infos[0]) // Call v2 version directly
+		}
 		if ret == SUCCESS {
-			return Infos[:InfoCount], ret
+			break
 		}
 		if ret != ERROR_INSUFFICIENT_SIZE {
 			return nil, ret
 		}
 		InfoCount *= 2
 	}
+
+	if InfoCount == 0 {
+		return []ProcessInfo{}, SUCCESS
+	}
+	return Infos[:InfoCount], SUCCESS
 }
 
 func (Device Device) GetComputeRunningProcesses() ([]ProcessInfo, Return) {
@@ -953,18 +979,44 @@ func (Device Device) GetComputeRunningProcesses() ([]ProcessInfo, Return) {
 
 // nvml.DeviceGetGraphicsRunningProcesses()
 func DeviceGetGraphicsRunningProcesses(Device Device) ([]ProcessInfo, Return) {
+	var Infos []ProcessInfo  // This is the v2 version of process info data structure
 	var InfoCount uint32 = 1 // Will be reduced upon returning
+	var ret = SUCCESS        // Will be changed upon returning
 	for {
-		Infos := make([]ProcessInfo, InfoCount)
-		ret := nvmlDeviceGetGraphicsRunningProcesses(Device, &InfoCount, &Infos[0])
+		if usesNvmlDeviceGetComputeRunningProcesses_v1 {
+			var v1Infos = make([]ProcessInfo_v1, InfoCount)
+			ret = nvmlDeviceGetGraphicsRunningProcesses_v1(Device, &InfoCount, (*ProcessInfo)(unsafe.Pointer(&v1Infos[0]))) // Call v1 version
+			if ret == SUCCESS && InfoCount > 0 {
+				// Convert process info data structure from v1 to v2
+				for i := range v1Infos {
+					pv1 := v1Infos[i]
+					pv2 := ProcessInfo{
+						Pid:               pv1.Pid,
+						UsedGpuMemory:     pv1.UsedGpuMemory,
+						GpuInstanceId:     0xFFFFFFFF, // GPU instance ID is invalid in v1
+						ComputeInstanceId: 0xFFFFFFFF, // Compute instance ID is invalid in v1
+					}
+					Infos = append(Infos, pv2)
+				}
+				break
+			}
+		} else {
+			Infos = make([]ProcessInfo, InfoCount)
+			ret = nvmlDeviceGetGraphicsRunningProcesses(Device, &InfoCount, &Infos[0]) // Call v2 version directly
+		}
 		if ret == SUCCESS {
-			return Infos[:InfoCount], ret
+			break
 		}
 		if ret != ERROR_INSUFFICIENT_SIZE {
 			return nil, ret
 		}
 		InfoCount *= 2
 	}
+
+	if InfoCount == 0 {
+		return []ProcessInfo{}, SUCCESS
+	}
+	return Infos[:InfoCount], SUCCESS
 }
 
 func (Device Device) GetGraphicsRunningProcesses() ([]ProcessInfo, Return) {

--- a/gen/nvml/device.go
+++ b/gen/nvml/device.go
@@ -931,6 +931,21 @@ func (Device Device) GetBridgeChipInfo() (BridgeChipHierarchy, Return) {
 	return DeviceGetBridgeChipInfo(Device)
 }
 
+// Helper function for DeviceGet{Compute,Graphics}RunningProcesses
+func (p *ProcessInfo_v1) AsProcessInfoPointer() *ProcessInfo {
+	return (*ProcessInfo)(unsafe.Pointer(p))
+}
+
+// Helper function for DeviceGet{Compute,Graphics}RunningProcesses
+func (p ProcessInfo_v1) ToProcessInfo() ProcessInfo {
+	return ProcessInfo{
+		Pid:               p.Pid,
+		UsedGpuMemory:     p.UsedGpuMemory,
+		GpuInstanceId:     0xFFFFFFFF, // GPU instance ID is invalid in v1
+		ComputeInstanceId: 0xFFFFFFFF, // Compute instance ID is invalid in v1
+	}
+}
+
 // nvml.DeviceGetComputeRunningProcesses()
 func DeviceGetComputeRunningProcesses(Device Device) ([]ProcessInfo, Return) {
 	var Infos []ProcessInfo  // This is the v2 version of process info data structure
@@ -939,27 +954,20 @@ func DeviceGetComputeRunningProcesses(Device Device) ([]ProcessInfo, Return) {
 	for {
 		if usesNvmlDeviceGetComputeRunningProcesses_v1 {
 			var v1Infos = make([]ProcessInfo_v1, InfoCount)
-			ret = nvmlDeviceGetComputeRunningProcesses_v1(Device, &InfoCount, (*ProcessInfo)(unsafe.Pointer(&v1Infos[0]))) // Call v1 version
-			if ret == SUCCESS && InfoCount > 0 {
+			ret = nvmlDeviceGetComputeRunningProcesses_v1(Device, &InfoCount, (&v1Infos[0]).AsProcessInfoPointer()) // Call v1 version
+			if ret == SUCCESS {
 				// Convert process info data structure from v1 to v2
-				for i := range v1Infos {
-					pv1 := v1Infos[i]
-					pv2 := ProcessInfo{
-						Pid:               pv1.Pid,
-						UsedGpuMemory:     pv1.UsedGpuMemory,
-						GpuInstanceId:     0xFFFFFFFF, // GPU instance ID is invalid in v1
-						ComputeInstanceId: 0xFFFFFFFF, // Compute instance ID is invalid in v1
-					}
-					Infos = append(Infos, pv2)
+				for i := uint32(0); i < InfoCount; i++ {
+					Infos = append(Infos, v1Infos[i].ToProcessInfo())
 				}
 				break
 			}
 		} else {
 			Infos = make([]ProcessInfo, InfoCount)
 			ret = nvmlDeviceGetComputeRunningProcesses(Device, &InfoCount, &Infos[0]) // Call v2 version directly
-		}
-		if ret == SUCCESS {
-			break
+			if ret == SUCCESS {
+				break
+			}
 		}
 		if ret != ERROR_INSUFFICIENT_SIZE {
 			return nil, ret
@@ -983,29 +991,22 @@ func DeviceGetGraphicsRunningProcesses(Device Device) ([]ProcessInfo, Return) {
 	var InfoCount uint32 = 1 // Will be reduced upon returning
 	var ret = SUCCESS        // Will be changed upon returning
 	for {
-		if usesNvmlDeviceGetComputeRunningProcesses_v1 {
+		if usesNvmlDeviceGetGraphicsRunningProcesses_v1 {
 			var v1Infos = make([]ProcessInfo_v1, InfoCount)
-			ret = nvmlDeviceGetGraphicsRunningProcesses_v1(Device, &InfoCount, (*ProcessInfo)(unsafe.Pointer(&v1Infos[0]))) // Call v1 version
-			if ret == SUCCESS && InfoCount > 0 {
+			ret = nvmlDeviceGetGraphicsRunningProcesses_v1(Device, &InfoCount, (&v1Infos[0]).AsProcessInfoPointer()) // Call v1 version
+			if ret == SUCCESS {
 				// Convert process info data structure from v1 to v2
-				for i := range v1Infos {
-					pv1 := v1Infos[i]
-					pv2 := ProcessInfo{
-						Pid:               pv1.Pid,
-						UsedGpuMemory:     pv1.UsedGpuMemory,
-						GpuInstanceId:     0xFFFFFFFF, // GPU instance ID is invalid in v1
-						ComputeInstanceId: 0xFFFFFFFF, // Compute instance ID is invalid in v1
-					}
-					Infos = append(Infos, pv2)
+				for i := uint32(0); i < InfoCount; i++ {
+					Infos = append(Infos, v1Infos[i].ToProcessInfo())
 				}
 				break
 			}
 		} else {
 			Infos = make([]ProcessInfo, InfoCount)
 			ret = nvmlDeviceGetGraphicsRunningProcesses(Device, &InfoCount, &Infos[0]) // Call v2 version directly
-		}
-		if ret == SUCCESS {
-			break
+			if ret == SUCCESS {
+				break
+			}
 		}
 		if ret != ERROR_INSUFFICIENT_SIZE {
 			return nil, ret

--- a/gen/nvml/init.go
+++ b/gen/nvml/init.go
@@ -94,6 +94,15 @@ var nvmlComputeInstanceGetInfo = nvmlComputeInstanceGetInfo_v1
 var nvmlDeviceGetComputeRunningProcesses = nvmlDeviceGetComputeRunningProcesses_v1
 var nvmlDeviceGetGraphicsRunningProcesses = nvmlDeviceGetGraphicsRunningProcesses_v1
 
+type ProcessInfo_v1 struct {
+	Pid           uint32
+	UsedGpuMemory uint64
+}
+type ProcessInfo_v2 ProcessInfo  // Set from cgo (always v2)
+
+var usesNvmlDeviceGetComputeRunningProcesses_v1 = true
+var usesNvmlDeviceGetGraphicsRunningProcesses_v1 = true
+
 // updateVersionedSymbols()
 func updateVersionedSymbols() {
 	err := nvml.Lookup("nvmlInit_v2")
@@ -153,10 +162,12 @@ func updateVersionedSymbols() {
 	err = nvml.Lookup("nvmlDeviceGetComputeRunningProcesses_v2")
 	if err == nil {
 		nvmlDeviceGetComputeRunningProcesses = nvmlDeviceGetComputeRunningProcesses_v2
+		usesNvmlDeviceGetComputeRunningProcesses_v1 = false
 	}
 	err = nvml.Lookup("nvmlDeviceGetGraphicsRunningProcesses_v2")
 	if err == nil {
 		nvmlDeviceGetGraphicsRunningProcesses = nvmlDeviceGetGraphicsRunningProcesses_v2
+		usesNvmlDeviceGetGraphicsRunningProcesses_v1 = false
 	}
 
 }

--- a/gen/nvml/init.go
+++ b/gen/nvml/init.go
@@ -94,11 +94,12 @@ var nvmlComputeInstanceGetInfo = nvmlComputeInstanceGetInfo_v1
 var nvmlDeviceGetComputeRunningProcesses = nvmlDeviceGetComputeRunningProcesses_v1
 var nvmlDeviceGetGraphicsRunningProcesses = nvmlDeviceGetGraphicsRunningProcesses_v1
 
+// ProcessInfo_v1 matches the ProcessInfo_st definition before CUDA 11.
 type ProcessInfo_v1 struct {
 	Pid           uint32
 	UsedGpuMemory uint64
 }
-type ProcessInfo_v2 ProcessInfo  // Set from cgo (always v2)
+type ProcessInfo_v2 ProcessInfo // Defined by cgo from nvml.h (always v2)
 
 var usesNvmlDeviceGetComputeRunningProcesses_v1 = true
 var usesNvmlDeviceGetGraphicsRunningProcesses_v1 = true

--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -933,18 +933,44 @@ func (Device Device) GetBridgeChipInfo() (BridgeChipHierarchy, Return) {
 
 // nvml.DeviceGetComputeRunningProcesses()
 func DeviceGetComputeRunningProcesses(Device Device) ([]ProcessInfo, Return) {
+	var Infos []ProcessInfo  // This is the v2 version of process info data structure
 	var InfoCount uint32 = 1 // Will be reduced upon returning
+	var ret = SUCCESS        // Will be changed upon returning
 	for {
-		Infos := make([]ProcessInfo, InfoCount)
-		ret := nvmlDeviceGetComputeRunningProcesses(Device, &InfoCount, &Infos[0])
+		if usesNvmlDeviceGetComputeRunningProcesses_v1 {
+			var v1Infos = make([]ProcessInfo_v1, InfoCount)
+			ret = nvmlDeviceGetComputeRunningProcesses_v1(Device, &InfoCount, (*ProcessInfo)(unsafe.Pointer(&v1Infos[0]))) // Call v1 version
+			if ret == SUCCESS && InfoCount > 0 {
+				// Convert process info data structure from v1 to v2
+				for i := range v1Infos {
+					pv1 := v1Infos[i]
+					pv2 := ProcessInfo{
+						Pid:               pv1.Pid,
+						UsedGpuMemory:     pv1.UsedGpuMemory,
+						GpuInstanceId:     0xFFFFFFFF, // GPU instance ID is invalid in v1
+						ComputeInstanceId: 0xFFFFFFFF, // Compute instance ID is invalid in v1
+					}
+					Infos = append(Infos, pv2)
+				}
+				break
+			}
+		} else {
+			Infos = make([]ProcessInfo, InfoCount)
+			ret = nvmlDeviceGetComputeRunningProcesses(Device, &InfoCount, &Infos[0]) // Call v2 version directly
+		}
 		if ret == SUCCESS {
-			return Infos[:InfoCount], ret
+			break
 		}
 		if ret != ERROR_INSUFFICIENT_SIZE {
 			return nil, ret
 		}
 		InfoCount *= 2
 	}
+
+	if InfoCount == 0 {
+		return []ProcessInfo{}, SUCCESS
+	}
+	return Infos[:InfoCount], SUCCESS
 }
 
 func (Device Device) GetComputeRunningProcesses() ([]ProcessInfo, Return) {
@@ -953,18 +979,44 @@ func (Device Device) GetComputeRunningProcesses() ([]ProcessInfo, Return) {
 
 // nvml.DeviceGetGraphicsRunningProcesses()
 func DeviceGetGraphicsRunningProcesses(Device Device) ([]ProcessInfo, Return) {
+	var Infos []ProcessInfo  // This is the v2 version of process info data structure
 	var InfoCount uint32 = 1 // Will be reduced upon returning
+	var ret = SUCCESS        // Will be changed upon returning
 	for {
-		Infos := make([]ProcessInfo, InfoCount)
-		ret := nvmlDeviceGetGraphicsRunningProcesses(Device, &InfoCount, &Infos[0])
+		if usesNvmlDeviceGetComputeRunningProcesses_v1 {
+			var v1Infos = make([]ProcessInfo_v1, InfoCount)
+			ret = nvmlDeviceGetGraphicsRunningProcesses_v1(Device, &InfoCount, (*ProcessInfo)(unsafe.Pointer(&v1Infos[0]))) // Call v1 version
+			if ret == SUCCESS && InfoCount > 0 {
+				// Convert process info data structure from v1 to v2
+				for i := range v1Infos {
+					pv1 := v1Infos[i]
+					pv2 := ProcessInfo{
+						Pid:               pv1.Pid,
+						UsedGpuMemory:     pv1.UsedGpuMemory,
+						GpuInstanceId:     0xFFFFFFFF, // GPU instance ID is invalid in v1
+						ComputeInstanceId: 0xFFFFFFFF, // Compute instance ID is invalid in v1
+					}
+					Infos = append(Infos, pv2)
+				}
+				break
+			}
+		} else {
+			Infos = make([]ProcessInfo, InfoCount)
+			ret = nvmlDeviceGetGraphicsRunningProcesses(Device, &InfoCount, &Infos[0]) // Call v2 version directly
+		}
 		if ret == SUCCESS {
-			return Infos[:InfoCount], ret
+			break
 		}
 		if ret != ERROR_INSUFFICIENT_SIZE {
 			return nil, ret
 		}
 		InfoCount *= 2
 	}
+
+	if InfoCount == 0 {
+		return []ProcessInfo{}, SUCCESS
+	}
+	return Infos[:InfoCount], SUCCESS
 }
 
 func (Device Device) GetGraphicsRunningProcesses() ([]ProcessInfo, Return) {

--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -931,6 +931,21 @@ func (Device Device) GetBridgeChipInfo() (BridgeChipHierarchy, Return) {
 	return DeviceGetBridgeChipInfo(Device)
 }
 
+// Helper function for DeviceGet{Compute,Graphics}RunningProcesses
+func (p *ProcessInfo_v1) AsProcessInfoPointer() *ProcessInfo {
+	return (*ProcessInfo)(unsafe.Pointer(p))
+}
+
+// Helper function for DeviceGet{Compute,Graphics}RunningProcesses
+func (p ProcessInfo_v1) ToProcessInfo() ProcessInfo {
+	return ProcessInfo{
+		Pid:               p.Pid,
+		UsedGpuMemory:     p.UsedGpuMemory,
+		GpuInstanceId:     0xFFFFFFFF, // GPU instance ID is invalid in v1
+		ComputeInstanceId: 0xFFFFFFFF, // Compute instance ID is invalid in v1
+	}
+}
+
 // nvml.DeviceGetComputeRunningProcesses()
 func DeviceGetComputeRunningProcesses(Device Device) ([]ProcessInfo, Return) {
 	var Infos []ProcessInfo  // This is the v2 version of process info data structure
@@ -939,27 +954,20 @@ func DeviceGetComputeRunningProcesses(Device Device) ([]ProcessInfo, Return) {
 	for {
 		if usesNvmlDeviceGetComputeRunningProcesses_v1 {
 			var v1Infos = make([]ProcessInfo_v1, InfoCount)
-			ret = nvmlDeviceGetComputeRunningProcesses_v1(Device, &InfoCount, (*ProcessInfo)(unsafe.Pointer(&v1Infos[0]))) // Call v1 version
-			if ret == SUCCESS && InfoCount > 0 {
+			ret = nvmlDeviceGetComputeRunningProcesses_v1(Device, &InfoCount, (&v1Infos[0]).AsProcessInfoPointer()) // Call v1 version
+			if ret == SUCCESS {
 				// Convert process info data structure from v1 to v2
-				for i := range v1Infos {
-					pv1 := v1Infos[i]
-					pv2 := ProcessInfo{
-						Pid:               pv1.Pid,
-						UsedGpuMemory:     pv1.UsedGpuMemory,
-						GpuInstanceId:     0xFFFFFFFF, // GPU instance ID is invalid in v1
-						ComputeInstanceId: 0xFFFFFFFF, // Compute instance ID is invalid in v1
-					}
-					Infos = append(Infos, pv2)
+				for i := uint32(0); i < InfoCount; i++ {
+					Infos = append(Infos, v1Infos[i].ToProcessInfo())
 				}
 				break
 			}
 		} else {
 			Infos = make([]ProcessInfo, InfoCount)
 			ret = nvmlDeviceGetComputeRunningProcesses(Device, &InfoCount, &Infos[0]) // Call v2 version directly
-		}
-		if ret == SUCCESS {
-			break
+			if ret == SUCCESS {
+				break
+			}
 		}
 		if ret != ERROR_INSUFFICIENT_SIZE {
 			return nil, ret
@@ -983,29 +991,22 @@ func DeviceGetGraphicsRunningProcesses(Device Device) ([]ProcessInfo, Return) {
 	var InfoCount uint32 = 1 // Will be reduced upon returning
 	var ret = SUCCESS        // Will be changed upon returning
 	for {
-		if usesNvmlDeviceGetComputeRunningProcesses_v1 {
+		if usesNvmlDeviceGetGraphicsRunningProcesses_v1 {
 			var v1Infos = make([]ProcessInfo_v1, InfoCount)
-			ret = nvmlDeviceGetGraphicsRunningProcesses_v1(Device, &InfoCount, (*ProcessInfo)(unsafe.Pointer(&v1Infos[0]))) // Call v1 version
-			if ret == SUCCESS && InfoCount > 0 {
+			ret = nvmlDeviceGetGraphicsRunningProcesses_v1(Device, &InfoCount, (&v1Infos[0]).AsProcessInfoPointer()) // Call v1 version
+			if ret == SUCCESS {
 				// Convert process info data structure from v1 to v2
-				for i := range v1Infos {
-					pv1 := v1Infos[i]
-					pv2 := ProcessInfo{
-						Pid:               pv1.Pid,
-						UsedGpuMemory:     pv1.UsedGpuMemory,
-						GpuInstanceId:     0xFFFFFFFF, // GPU instance ID is invalid in v1
-						ComputeInstanceId: 0xFFFFFFFF, // Compute instance ID is invalid in v1
-					}
-					Infos = append(Infos, pv2)
+				for i := uint32(0); i < InfoCount; i++ {
+					Infos = append(Infos, v1Infos[i].ToProcessInfo())
 				}
 				break
 			}
 		} else {
 			Infos = make([]ProcessInfo, InfoCount)
 			ret = nvmlDeviceGetGraphicsRunningProcesses(Device, &InfoCount, &Infos[0]) // Call v2 version directly
-		}
-		if ret == SUCCESS {
-			break
+			if ret == SUCCESS {
+				break
+			}
 		}
 		if ret != ERROR_INSUFFICIENT_SIZE {
 			return nil, ret

--- a/pkg/nvml/init.go
+++ b/pkg/nvml/init.go
@@ -94,6 +94,15 @@ var nvmlComputeInstanceGetInfo = nvmlComputeInstanceGetInfo_v1
 var nvmlDeviceGetComputeRunningProcesses = nvmlDeviceGetComputeRunningProcesses_v1
 var nvmlDeviceGetGraphicsRunningProcesses = nvmlDeviceGetGraphicsRunningProcesses_v1
 
+type ProcessInfo_v1 struct {
+	Pid           uint32
+	UsedGpuMemory uint64
+}
+type ProcessInfo_v2 ProcessInfo  // Set from cgo (always v2)
+
+var usesNvmlDeviceGetComputeRunningProcesses_v1 = true
+var usesNvmlDeviceGetGraphicsRunningProcesses_v1 = true
+
 // updateVersionedSymbols()
 func updateVersionedSymbols() {
 	err := nvml.Lookup("nvmlInit_v2")
@@ -153,10 +162,12 @@ func updateVersionedSymbols() {
 	err = nvml.Lookup("nvmlDeviceGetComputeRunningProcesses_v2")
 	if err == nil {
 		nvmlDeviceGetComputeRunningProcesses = nvmlDeviceGetComputeRunningProcesses_v2
+		usesNvmlDeviceGetComputeRunningProcesses_v1 = false
 	}
 	err = nvml.Lookup("nvmlDeviceGetGraphicsRunningProcesses_v2")
 	if err == nil {
 		nvmlDeviceGetGraphicsRunningProcesses = nvmlDeviceGetGraphicsRunningProcesses_v2
+		usesNvmlDeviceGetGraphicsRunningProcesses_v1 = false
 	}
 
 }

--- a/pkg/nvml/init.go
+++ b/pkg/nvml/init.go
@@ -94,11 +94,12 @@ var nvmlComputeInstanceGetInfo = nvmlComputeInstanceGetInfo_v1
 var nvmlDeviceGetComputeRunningProcesses = nvmlDeviceGetComputeRunningProcesses_v1
 var nvmlDeviceGetGraphicsRunningProcesses = nvmlDeviceGetGraphicsRunningProcesses_v1
 
+// ProcessInfo_v1 matches the ProcessInfo_st definition before CUDA 11.
 type ProcessInfo_v1 struct {
 	Pid           uint32
 	UsedGpuMemory uint64
 }
-type ProcessInfo_v2 ProcessInfo  // Set from cgo (always v2)
+type ProcessInfo_v2 ProcessInfo // Defined by cgo from nvml.h (always v2)
 
 var usesNvmlDeviceGetComputeRunningProcesses_v1 = true
 var usesNvmlDeviceGetGraphicsRunningProcesses_v1 = true


### PR DESCRIPTION
The definition of `struct nvmlProcessInfo_st` has introduce two new fields `gpuInstanceId` and `computeInstanceId` in newer NVIDIA drivers (CUDA 11.x). And this changes will break the backward compatibility for old NVIDIA drivers (CUDA 10.x).

This PR fixes issue #21 for `nvmlDeviceGetComputeRunningProcesses` `nvmlDeviceGetGraphicsRunningProcesses` on CUDA 10.x caused by the data structure size change. It simply calls the v1 version function (feed with v1 data structure) and convert the results into v2 ones on CUDA 10.x. And for CUDA 11.x, call the v2 version directly.

There is another solution (PR #22) that calls the v1 version (but feed with v2 data structure) and correct the results with some adjustments on CUDA 10.x. As commented in https://github.com/NVIDIA/go-nvml/issues/21#issuecomment-897657714, this implementation should cover a large number of configuration situations (different CPU bit width / CPU arch / complie options, etc.).

---

The results on CUDA 10.x

```console
$ python3 -c 'import time; import cupy as cp; x = cp.zeros((1, 1)); time.sleep(120)' &
[1] 5404
$ python3 -c 'import time; import cupy as cp; x = cp.zeros((1, 1)); time.sleep(120)' &
[2] 5456
$ python3 -c 'import time; import cupy as cp; x = cp.zeros((1, 1)); time.sleep(120)' &
[3] 5481
$ python3 -c 'import time; import cupy as cp; x = cp.zeros((1, 1)); time.sleep(120)' &
[4] 5504
$ python3 -c 'import time; import cupy as cp; x = cp.zeros((1, 1)); time.sleep(120)' &
[5] 5529

$ go run go-nvml/examples/compute-processes
Found 5 processes on device 0
        [ 0] ProcessInfo: {Pid:5404 UsedGpuMemory:173015040 GpuInstanceId:4294967295 ComputeInstanceId:4294967295}
        [ 1] ProcessInfo: {Pid:5456 UsedGpuMemory:173015040 GpuInstanceId:4294967295 ComputeInstanceId:4294967295}
        [ 2] ProcessInfo: {Pid:5481 UsedGpuMemory:173015040 GpuInstanceId:4294967295 ComputeInstanceId:4294967295}
        [ 3] ProcessInfo: {Pid:5504 UsedGpuMemory:173015040 GpuInstanceId:4294967295 ComputeInstanceId:4294967295}
        [ 4] ProcessInfo: {Pid:5529 UsedGpuMemory:173015040 GpuInstanceId:4294967295 ComputeInstanceId:4294967295}
Found 0 processes on device 1
Found 0 processes on device 2
```

Fixes #21
Closes #22