### PR TITLE
Fix device buffer size

### DIFF
--- a/gen/nvml/device.go
+++ b/gen/nvml/device.go
@@ -58,8 +58,8 @@ func DeviceGetHandleByPciBusId(PciBusId string) (Device, Return) {
 
 // nvml.DeviceGetName()
 func DeviceGetName(Device Device) (string, Return) {
-	Name := make([]byte, DEVICE_NAME_BUFFER_SIZE)
-	ret := nvmlDeviceGetName(Device, &Name[0], DEVICE_NAME_BUFFER_SIZE)
+	Name := make([]byte, NVML_DEVICE_NAME_V2_BUFFER_SIZE)
+	ret := nvmlDeviceGetName(Device, &Name[0], NVML_DEVICE_NAME_V2_BUFFER_SIZE)
 	return string(Name[:clen(Name)]), ret
 }
 

--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -58,8 +58,8 @@ func DeviceGetHandleByPciBusId(PciBusId string) (Device, Return) {
 
 // nvml.DeviceGetName()
 func DeviceGetName(Device Device) (string, Return) {
-	Name := make([]byte, DEVICE_NAME_BUFFER_SIZE)
-	ret := nvmlDeviceGetName(Device, &Name[0], DEVICE_NAME_BUFFER_SIZE)
+	Name := make([]byte, NVML_DEVICE_NAME_V2_BUFFER_SIZE)
+	ret := nvmlDeviceGetName(Device, &Name[0], NVML_DEVICE_NAME_V2_BUFFER_SIZE)
 	return string(Name[:clen(Name)]), ret
 }
 


### PR DESCRIPTION
This change uses `NVML_DEVICE_NAME_V2_BUFFER_SIZE` for device names instead of `NVML_DEVICE_NAME_BUFFER_SIZE` to prevent errors when calling `GetName` on MIG devices.