### PR TITLE
Fix a bug with handling non-null-terminated strings as input

### DIFF
--- a/gen/nvml/device.go
+++ b/gen/nvml/device.go
@@ -38,21 +38,21 @@ func DeviceGetHandleByIndex(Index int) (Device, Return) {
 // nvml.DeviceGetHandleBySerial()
 func DeviceGetHandleBySerial(Serial string) (Device, Return) {
 	var Device Device
-	ret := nvmlDeviceGetHandleBySerial(Serial, &Device)
+	ret := nvmlDeviceGetHandleBySerial(Serial + string(rune(0)), &Device)
 	return Device, ret
 }
 
 // nvml.DeviceGetHandleByUUID()
 func DeviceGetHandleByUUID(Uuid string) (Device, Return) {
 	var Device Device
-	ret := nvmlDeviceGetHandleByUUID(Uuid, &Device)
+	ret := nvmlDeviceGetHandleByUUID(Uuid + string(rune(0)), &Device)
 	return Device, ret
 }
 
 // nvml.DeviceGetHandleByPciBusId()
 func DeviceGetHandleByPciBusId(PciBusId string) (Device, Return) {
 	var Device Device
-	ret := nvmlDeviceGetHandleByPciBusId(PciBusId, &Device)
+	ret := nvmlDeviceGetHandleByPciBusId(PciBusId + string(rune(0)), &Device)
 	return Device, ret
 }
 

--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -38,21 +38,21 @@ func DeviceGetHandleByIndex(Index int) (Device, Return) {
 // nvml.DeviceGetHandleBySerial()
 func DeviceGetHandleBySerial(Serial string) (Device, Return) {
 	var Device Device
-	ret := nvmlDeviceGetHandleBySerial(Serial, &Device)
+	ret := nvmlDeviceGetHandleBySerial(Serial + string(rune(0)), &Device)
 	return Device, ret
 }
 
 // nvml.DeviceGetHandleByUUID()
 func DeviceGetHandleByUUID(Uuid string) (Device, Return) {
 	var Device Device
-	ret := nvmlDeviceGetHandleByUUID(Uuid, &Device)
+	ret := nvmlDeviceGetHandleByUUID(Uuid + string(rune(0)), &Device)
 	return Device, ret
 }
 
 // nvml.DeviceGetHandleByPciBusId()
 func DeviceGetHandleByPciBusId(PciBusId string) (Device, Return) {
 	var Device Device
-	ret := nvmlDeviceGetHandleByPciBusId(PciBusId, &Device)
+	ret := nvmlDeviceGetHandleByPciBusId(PciBusId + string(rune(0)), &Device)
 	return Device, ret
 }
 


### PR DESCRIPTION
Without this fix, the following code would produce an error:

    uuid := "GPU-3eb87630-93d5-b2b6-b8ff-9b359caf4ee2"

    device, ret = nvml.DeviceGetHandleByUUID(uuid)
    if ret != nvml.SUCCESS {
        fmt.Printf("uuid nvml.DeviceGetHandleByUUID(%v): %v\n", uuid, nvml.ErrorString(ret))
        os.Exit(1)
    }

Even if the UUID pointed to by the hard-coded string was valid. This is due to
the fact that the generated c-for-go code assumes that all go-string inputs are
actually backed by a valid null-terminated C-string under the hood. This is
true when we pull the string from go-nvml, e.g. via `device.GetUUID()`, but not
necessarily when we hard code the string ourselves (or store it to a file and
then try and use it to retrieve a device handle later).

The fix is to ensure that all go-string inputs are actually terminated with a
NULL before passing the to the generatd c-for-go code. This is only done in 3
places and they have each been updated appropriately as part of this commit.

Signed-off-by: Kevin Klues <kklues@nvidia.com>