### PR TITLE
Allow path to libnvidia-ml.so.1 to be specified

### DIFF
--- a/gen/nvml/api.go
+++ b/gen/nvml/api.go
@@ -33,5 +33,5 @@ type dynamicLibrary interface {
 
 // Interface represents the interace for the NVML library.
 type Interface interface {
-	Library() Library
+	GetLibrary() Library
 }

--- a/gen/nvml/init.go
+++ b/gen/nvml/init.go
@@ -14,10 +14,6 @@
 
 package nvml
 
-import (
-	"fmt"
-)
-
 import "C"
 
 // nvml.Init()
@@ -45,7 +41,7 @@ func Shutdown() Return {
 
 	err := libnvml.close()
 	if err != nil {
-		panic(fmt.Sprintf("error closing %s: %v", nvmlLibraryName, err))
+		panic(err)
 	}
 
 	return ret

--- a/gen/nvml/lib.go
+++ b/gen/nvml/lib.go
@@ -27,33 +27,38 @@ import (
 import "C"
 
 const (
-	nvmlLibraryName      = "libnvidia-ml.so.1"
-	nvmlLibraryLoadFlags = dl.RTLD_LAZY | dl.RTLD_GLOBAL
+	defaultNvmlLibraryName      = "libnvidia-ml.so.1"
+	defaultNvmlLibraryLoadFlags = dl.RTLD_LAZY | dl.RTLD_GLOBAL
 )
 
 var errLibraryNotLoaded = errors.New("library not loaded")
+var errLibraryAlreadyLoaded = errors.New("library already loaded")
 
 // library represents an nvml library.
 // This includes a reference to the underlying DynamicLibrary
 type library struct {
 	sync.Mutex
-	dl dynamicLibrary
+	path  string
+	flags int
+	dl    dynamicLibrary
 }
 
 // libnvml is a global instance of the nvml library.
-var libnvml library
+var libnvml = library{
+	path:  defaultNvmlLibraryName,
+	flags: defaultNvmlLibraryLoadFlags,
+}
 
 var _ Interface = (*library)(nil)
 
-// Default returns a reference to the global library instance.
-// This is returned as an interface so as to not directly expose the underlying instance type.
-func Default() Interface {
-	return &libnvml
+// GetLibrary returns a the library as a Library interface.
+func (l *library) GetLibrary() Library {
+	return l
 }
 
-// Library returns a representation of the underlying library.
-func (l *library) Library() Library {
-	return l
+// GetLibrary returns a representation of the underlying library that implements the Library interface.
+func GetLibrary() Library {
+	return libnvml.GetLibrary()
 }
 
 // Lookup checks whether the specified library symbol exists in the library.
@@ -66,8 +71,8 @@ func (l *library) Lookup(name string) error {
 }
 
 // newDynamicLibrary is a function variable that can be overridden for testing.
-var newDynamicLibrary = func(name string, flags int) dynamicLibrary {
-	return dl.New(name, flags)
+var newDynamicLibrary = func(path string, flags int) dynamicLibrary {
+	return dl.New(path, flags)
 }
 
 // load initializes the library and updates the versioned symbols.
@@ -79,10 +84,10 @@ func (l *library) load() error {
 		return nil
 	}
 
-	dl := newDynamicLibrary(nvmlLibraryName, nvmlLibraryLoadFlags)
+	dl := newDynamicLibrary(l.path, l.flags)
 	err := dl.Open()
 	if err != nil {
-		return err
+		return fmt.Errorf("error opening %s: %w", l.path, err)
 	}
 
 	l.dl = dl
@@ -91,7 +96,9 @@ func (l *library) load() error {
 	return nil
 }
 
-// close the associated dynamic library if required.
+// close the underlying library and ensure that the global pointer to the
+// library is set to nil to ensure that subsequent calls to open will reinitialize it.
+// Multiple calls to an already closed nvml library will return without error.
 func (l *library) close() error {
 	l.Lock()
 	defer l.Unlock()
@@ -102,7 +109,7 @@ func (l *library) close() error {
 
 	err := l.dl.Close()
 	if err != nil {
-		return fmt.Errorf("error closing %s: %w", nvmlLibraryName, err)
+		return fmt.Errorf("error closing %s: %w", l.path, err)
 	}
 
 	l.dl = nil
@@ -130,7 +137,9 @@ var GetBlacklistDeviceInfoByIndex = GetExcludedDeviceInfoByIndex
 var nvmlDeviceGetGpuInstancePossiblePlacements = nvmlDeviceGetGpuInstancePossiblePlacements_v1
 var nvmlVgpuInstanceGetLicenseInfo = nvmlVgpuInstanceGetLicenseInfo_v1
 
+// BlacklistDeviceInfo was replaced by ExcludedDeviceInfo
 type BlacklistDeviceInfo = ExcludedDeviceInfo
+
 type ProcessInfo_v1Slice []ProcessInfo_v1
 type ProcessInfo_v2Slice []ProcessInfo_v2
 
@@ -162,7 +171,10 @@ func (pis ProcessInfo_v2Slice) ToProcessInfoSlice() []ProcessInfo {
 	return newInfos
 }
 
-// updateVersionedSymbols ensures that the global nvml* symbols are updated to their correct counterparts.
+// updateVersionedSymbols checks for versioned symbols in the loaded dynamic library.
+// If newer versioned symbols exist, these replace the default `v1` symbols initialized above.
+// When new versioned symbols are added, these would have to be initialized above and have
+// corresponding checks and subsequent assignments added below.
 func (l *library) updateVersionedSymbols() {
 	err := l.Lookup("nvmlInit_v2")
 	if err == nil {
@@ -254,4 +266,37 @@ func (l *library) updateVersionedSymbols() {
 	if err == nil {
 		nvmlVgpuInstanceGetLicenseInfo = nvmlVgpuInstanceGetLicenseInfo_v2
 	}
+}
+
+// LibraryOption represents a functional option to configure the underlying NVML library
+type LibraryOption func(*library)
+
+// WithLibraryPath provides an option to set the library name to be used by the NVML library.
+func WithLibraryPath(path string) LibraryOption {
+	return func(l *library) {
+		l.path = path
+	}
+}
+
+// SetLibraryOptions applies the specified options to the NVML library.
+// If this is called when a library is already loaded, and error is raised.
+func SetLibraryOptions(opts ...LibraryOption) error {
+	libnvml.Lock()
+	defer libnvml.Unlock()
+	if libnvml.dl != nil {
+		return errLibraryAlreadyLoaded
+	}
+
+	for _, opt := range opts {
+		opt(&libnvml)
+	}
+
+	if libnvml.path == "" {
+		libnvml.path = defaultNvmlLibraryName
+	}
+	if libnvml.flags == 0 {
+		libnvml.flags = defaultNvmlLibraryLoadFlags
+	}
+
+	return nil
 }

--- a/gen/nvml/lib_test.go
+++ b/gen/nvml/lib_test.go
@@ -119,11 +119,11 @@ func TestLookupFromDefault(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			defer setNewDynamicLibraryDuringTest(tc.library)()
 			defer resetLibrary()
-			l := Default()
+			l := GetLibrary()
 			if !tc.skipLoadLibrary {
 				require.ErrorIs(t, libnvml.load(), tc.expectedLoadError)
 			}
-			require.ErrorIs(t, l.Library().Lookup("symbol"), tc.expectedLookupErrror)
+			require.ErrorIs(t, l.Lookup("symbol"), tc.expectedLookupErrror)
 			require.ErrorIs(t, libnvml.close(), tc.expectedCloseError)
 			if tc.expectedCloseError == nil {
 				require.Nil(t, libnvml.dl)
@@ -146,5 +146,8 @@ func setNewDynamicLibraryDuringTest(dl dynamicLibrary) func() {
 }
 
 func resetLibrary() {
-	libnvml = library{}
+	libnvml = library{
+		path:  defaultNvmlLibraryName,
+		flags: defaultNvmlLibraryLoadFlags,
+	}
 }

--- a/gen/nvml/nvml_test.go
+++ b/gen/nvml/nvml_test.go
@@ -21,9 +21,9 @@ import (
 )
 
 func requireLibNvidiaML(t *testing.T) {
-	lib := dl.New(nvmlLibraryName, nvmlLibraryLoadFlags)
+	lib := dl.New(defaultNvmlLibraryName, defaultNvmlLibraryLoadFlags)
 	if err := lib.Open(); err != nil {
-		t.Skipf("This test requires %v", nvmlLibraryName)
+		t.Skipf("This test requires %v", defaultNvmlLibraryName)
 	}
 	lib.Close()
 }

--- a/pkg/nvml/api.go
+++ b/pkg/nvml/api.go
@@ -33,5 +33,5 @@ type dynamicLibrary interface {
 
 // Interface represents the interace for the NVML library.
 type Interface interface {
-	Library() Library
+	GetLibrary() Library
 }

--- a/pkg/nvml/init.go
+++ b/pkg/nvml/init.go
@@ -14,10 +14,6 @@
 
 package nvml
 
-import (
-	"fmt"
-)
-
 import "C"
 
 // nvml.Init()
@@ -45,7 +41,7 @@ func Shutdown() Return {
 
 	err := libnvml.close()
 	if err != nil {
-		panic(fmt.Sprintf("error closing %s: %v", nvmlLibraryName, err))
+		panic(err)
 	}
 
 	return ret

--- a/pkg/nvml/lib.go
+++ b/pkg/nvml/lib.go
@@ -27,33 +27,38 @@ import (
 import "C"
 
 const (
-	nvmlLibraryName      = "libnvidia-ml.so.1"
-	nvmlLibraryLoadFlags = dl.RTLD_LAZY | dl.RTLD_GLOBAL
+	defaultNvmlLibraryName      = "libnvidia-ml.so.1"
+	defaultNvmlLibraryLoadFlags = dl.RTLD_LAZY | dl.RTLD_GLOBAL
 )
 
 var errLibraryNotLoaded = errors.New("library not loaded")
+var errLibraryAlreadyLoaded = errors.New("library already loaded")
 
 // library represents an nvml library.
 // This includes a reference to the underlying DynamicLibrary
 type library struct {
 	sync.Mutex
-	dl dynamicLibrary
+	path  string
+	flags int
+	dl    dynamicLibrary
 }
 
 // libnvml is a global instance of the nvml library.
-var libnvml library
+var libnvml = library{
+	path:  defaultNvmlLibraryName,
+	flags: defaultNvmlLibraryLoadFlags,
+}
 
 var _ Interface = (*library)(nil)
 
-// Default returns a reference to the global library instance.
-// This is returned as an interface so as to not directly expose the underlying instance type.
-func Default() Interface {
-	return &libnvml
+// GetLibrary returns a the library as a Library interface.
+func (l *library) GetLibrary() Library {
+	return l
 }
 
-// Library returns a representation of the underlying library.
-func (l *library) Library() Library {
-	return l
+// GetLibrary returns a representation of the underlying library that implements the Library interface.
+func GetLibrary() Library {
+	return libnvml.GetLibrary()
 }
 
 // Lookup checks whether the specified library symbol exists in the library.
@@ -66,8 +71,8 @@ func (l *library) Lookup(name string) error {
 }
 
 // newDynamicLibrary is a function variable that can be overridden for testing.
-var newDynamicLibrary = func(name string, flags int) dynamicLibrary {
-	return dl.New(name, flags)
+var newDynamicLibrary = func(path string, flags int) dynamicLibrary {
+	return dl.New(path, flags)
 }
 
 // load initializes the library and updates the versioned symbols.
@@ -79,10 +84,10 @@ func (l *library) load() error {
 		return nil
 	}
 
-	dl := newDynamicLibrary(nvmlLibraryName, nvmlLibraryLoadFlags)
+	dl := newDynamicLibrary(l.path, l.flags)
 	err := dl.Open()
 	if err != nil {
-		return err
+		return fmt.Errorf("error opening %s: %w", l.path, err)
 	}
 
 	l.dl = dl
@@ -91,7 +96,9 @@ func (l *library) load() error {
 	return nil
 }
 
-// close the associated dynamic library if required.
+// close the underlying library and ensure that the global pointer to the
+// library is set to nil to ensure that subsequent calls to open will reinitialize it.
+// Multiple calls to an already closed nvml library will return without error.
 func (l *library) close() error {
 	l.Lock()
 	defer l.Unlock()
@@ -102,7 +109,7 @@ func (l *library) close() error {
 
 	err := l.dl.Close()
 	if err != nil {
-		return fmt.Errorf("error closing %s: %w", nvmlLibraryName, err)
+		return fmt.Errorf("error closing %s: %w", l.path, err)
 	}
 
 	l.dl = nil
@@ -130,7 +137,9 @@ var GetBlacklistDeviceInfoByIndex = GetExcludedDeviceInfoByIndex
 var nvmlDeviceGetGpuInstancePossiblePlacements = nvmlDeviceGetGpuInstancePossiblePlacements_v1
 var nvmlVgpuInstanceGetLicenseInfo = nvmlVgpuInstanceGetLicenseInfo_v1
 
+// BlacklistDeviceInfo was replaced by ExcludedDeviceInfo
 type BlacklistDeviceInfo = ExcludedDeviceInfo
+
 type ProcessInfo_v1Slice []ProcessInfo_v1
 type ProcessInfo_v2Slice []ProcessInfo_v2
 
@@ -162,7 +171,10 @@ func (pis ProcessInfo_v2Slice) ToProcessInfoSlice() []ProcessInfo {
 	return newInfos
 }
 
-// updateVersionedSymbols ensures that the global nvml* symbols are updated to their correct counterparts.
+// updateVersionedSymbols checks for versioned symbols in the loaded dynamic library.
+// If newer versioned symbols exist, these replace the default `v1` symbols initialized above.
+// When new versioned symbols are added, these would have to be initialized above and have
+// corresponding checks and subsequent assignments added below.
 func (l *library) updateVersionedSymbols() {
 	err := l.Lookup("nvmlInit_v2")
 	if err == nil {
@@ -254,4 +266,37 @@ func (l *library) updateVersionedSymbols() {
 	if err == nil {
 		nvmlVgpuInstanceGetLicenseInfo = nvmlVgpuInstanceGetLicenseInfo_v2
 	}
+}
+
+// LibraryOption represents a functional option to configure the underlying NVML library
+type LibraryOption func(*library)
+
+// WithLibraryPath provides an option to set the library name to be used by the NVML library.
+func WithLibraryPath(path string) LibraryOption {
+	return func(l *library) {
+		l.path = path
+	}
+}
+
+// SetLibraryOptions applies the specified options to the NVML library.
+// If this is called when a library is already loaded, and error is raised.
+func SetLibraryOptions(opts ...LibraryOption) error {
+	libnvml.Lock()
+	defer libnvml.Unlock()
+	if libnvml.dl != nil {
+		return errLibraryAlreadyLoaded
+	}
+
+	for _, opt := range opts {
+		opt(&libnvml)
+	}
+
+	if libnvml.path == "" {
+		libnvml.path = defaultNvmlLibraryName
+	}
+	if libnvml.flags == 0 {
+		libnvml.flags = defaultNvmlLibraryLoadFlags
+	}
+
+	return nil
 }

--- a/pkg/nvml/lib_test.go
+++ b/pkg/nvml/lib_test.go
@@ -119,11 +119,11 @@ func TestLookupFromDefault(t *testing.T) {
 		t.Run(tc.description, func(t *testing.T) {
 			defer setNewDynamicLibraryDuringTest(tc.library)()
 			defer resetLibrary()
-			l := Default()
+			l := GetLibrary()
 			if !tc.skipLoadLibrary {
 				require.ErrorIs(t, libnvml.load(), tc.expectedLoadError)
 			}
-			require.ErrorIs(t, l.Library().Lookup("symbol"), tc.expectedLookupErrror)
+			require.ErrorIs(t, l.Lookup("symbol"), tc.expectedLookupErrror)
 			require.ErrorIs(t, libnvml.close(), tc.expectedCloseError)
 			if tc.expectedCloseError == nil {
 				require.Nil(t, libnvml.dl)
@@ -146,5 +146,8 @@ func setNewDynamicLibraryDuringTest(dl dynamicLibrary) func() {
 }
 
 func resetLibrary() {
-	libnvml = library{}
+	libnvml = library{
+		path:  defaultNvmlLibraryName,
+		flags: defaultNvmlLibraryLoadFlags,
+	}
 }

--- a/pkg/nvml/nvml_test.go
+++ b/pkg/nvml/nvml_test.go
@@ -21,9 +21,9 @@ import (
 )
 
 func requireLibNvidiaML(t *testing.T) {
-	lib := dl.New(nvmlLibraryName, nvmlLibraryLoadFlags)
+	lib := dl.New(defaultNvmlLibraryName, defaultNvmlLibraryLoadFlags)
 	if err := lib.Open(); err != nil {
-		t.Skipf("This test requires %v", nvmlLibraryName)
+		t.Skipf("This test requires %v", defaultNvmlLibraryName)
 	}
 	lib.Close()
 }


### PR DESCRIPTION
These changes add a basic API for allowing the path to `libnvidia-ml.so.1` to be set.

This can be used in environments where the path to the library can be determined programatically but not reliably added to the `LD_LIBRARY_PATH` before program startup, for example.

This builds on the changes from #86