### PR TITLE
Return ERROR_UNKNOWN instead of panicing

### DIFF
--- a/pkg/nvml/init.go
+++ b/pkg/nvml/init.go
@@ -41,7 +41,7 @@ func Shutdown() Return {
 
 	err := libnvml.close()
 	if err != nil {
-		panic(err)
+		return ERROR_UNKNOWN
 	}
 
 	return ret


### PR DESCRIPTION
This change removes the panic from the shutdown code. Instead an ERROR_UNKNOWN is returned. This does cause the source of the error to be lost, but this can be addressed in a follow-up.

This replaces #70 