### PR TITLE
Fix the bug that some functions do not populate the Version field, resulting in failure of the call.

### DIFF
--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -2808,6 +2808,7 @@ func (l *library) DeviceGetRunningProcessDetailList(device Device) (ProcessDetai
 
 func (device nvmlDevice) GetRunningProcessDetailList() (ProcessDetailList, Return) {
 	var plist ProcessDetailList
+	plist.Version = STRUCT_VERSION(plist, 1)
 	ret := nvmlDeviceGetRunningProcessDetailList(device, &plist)
 	return plist, ret
 }
@@ -3052,6 +3053,7 @@ func (l *library) DeviceGetSramEccErrorStatus(device Device) (EccSramErrorStatus
 
 func (device nvmlDevice) GetSramEccErrorStatus() (EccSramErrorStatus, Return) {
 	var status EccSramErrorStatus
+	status.Version = STRUCT_VERSION(status, 1)
 	ret := nvmlDeviceGetSramEccErrorStatus(device, &status)
 	return status, ret
 }

--- a/pkg/nvml/nvml.go
+++ b/pkg/nvml/nvml.go
@@ -3100,6 +3100,7 @@ func nvmlDeviceSetPowerManagementLimit_v2(nvmlDevice nvmlDevice, PowerValue *Pow
 // nvmlDeviceGetSramEccErrorStatus function as declared in nvml/nvml.h
 func nvmlDeviceGetSramEccErrorStatus(nvmlDevice nvmlDevice, Status *EccSramErrorStatus) Return {
 	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
+	Status.Version = C.nvmlEccSramErrorStatus_v1
 	cStatus, _ := (*C.nvmlEccSramErrorStatus_t)(unsafe.Pointer(Status)), cgoAllocsUnknown
 	__ret := C.nvmlDeviceGetSramEccErrorStatus(cnvmlDevice, cStatus)
 	__v := (Return)(__ret)

--- a/pkg/nvml/nvml.go
+++ b/pkg/nvml/nvml.go
@@ -1224,7 +1224,6 @@ func nvmlDeviceGetMPSComputeRunningProcesses_v3(nvmlDevice nvmlDevice, InfoCount
 // nvmlDeviceGetRunningProcessDetailList function as declared in nvml/nvml.h
 func nvmlDeviceGetRunningProcessDetailList(nvmlDevice nvmlDevice, Plist *ProcessDetailList) Return {
 	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
-	Plist.Version = C.nvmlProcessDetailList_v1
 	cPlist, _ := (*C.nvmlProcessDetailList_t)(unsafe.Pointer(Plist)), cgoAllocsUnknown
 	__ret := C.nvmlDeviceGetRunningProcessDetailList(cnvmlDevice, cPlist)
 	__v := (Return)(__ret)
@@ -3100,7 +3099,6 @@ func nvmlDeviceSetPowerManagementLimit_v2(nvmlDevice nvmlDevice, PowerValue *Pow
 // nvmlDeviceGetSramEccErrorStatus function as declared in nvml/nvml.h
 func nvmlDeviceGetSramEccErrorStatus(nvmlDevice nvmlDevice, Status *EccSramErrorStatus) Return {
 	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
-	Status.Version = C.nvmlEccSramErrorStatus_v1
 	cStatus, _ := (*C.nvmlEccSramErrorStatus_t)(unsafe.Pointer(Status)), cgoAllocsUnknown
 	__ret := C.nvmlDeviceGetSramEccErrorStatus(cnvmlDevice, cStatus)
 	__v := (Return)(__ret)

--- a/pkg/nvml/nvml.go
+++ b/pkg/nvml/nvml.go
@@ -1224,6 +1224,7 @@ func nvmlDeviceGetMPSComputeRunningProcesses_v3(nvmlDevice nvmlDevice, InfoCount
 // nvmlDeviceGetRunningProcessDetailList function as declared in nvml/nvml.h
 func nvmlDeviceGetRunningProcessDetailList(nvmlDevice nvmlDevice, Plist *ProcessDetailList) Return {
 	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
+	Plist.Version = C.nvmlProcessDetailList_v1
 	cPlist, _ := (*C.nvmlProcessDetailList_t)(unsafe.Pointer(Plist)), cgoAllocsUnknown
 	__ret := C.nvmlDeviceGetRunningProcessDetailList(cnvmlDevice, cPlist)
 	__v := (Return)(__ret)


### PR DESCRIPTION
Fix the bug that the Version field of ProcessDetailList is not assigned a value(must be nvmlProcessDetailList_v1) when calling the underlying nvmlDeviceGetRunningProcessDetailList function.

If the value is not populated (default is 0), the function will return nvmlReturn_t=25(Argument version mismatch)