### PR TITLE
Add -z,lazy to LDFLAGS

### DIFF
--- a/gen/nvml/nvml.yml
+++ b/gen/nvml/nvml.yml
@@ -32,7 +32,7 @@ GENERATOR:
     limitations under the License.
   Includes: ["nvml.h"]
   FlagGroups:
-    - {name: "LDFLAGS", traits: ["linux"], flags: ["-Wl,--export-dynamic","-Wl,--unresolved-symbols=ignore-in-object-files"]}
+    - {name: "LDFLAGS", traits: ["linux"], flags: ["-Wl,--export-dynamic","-Wl,--unresolved-symbols=ignore-in-object-files","-Wl,-z,lazy"]}
     - {name: "LDFLAGS", traits: ["darwin"], flags: ["-Wl,-undefined,dynamic_lookup"]}
     - {name: "CFLAGS", flags: ["-DNVML_NO_UNVERSIONED_FUNC_DEFS=1"]}
 PARSER:

--- a/pkg/nvml/const.go
+++ b/pkg/nvml/const.go
@@ -18,7 +18,7 @@
 package nvml
 
 /*
-#cgo linux LDFLAGS: -Wl,--export-dynamic -Wl,--unresolved-symbols=ignore-in-object-files
+#cgo linux LDFLAGS: -Wl,--export-dynamic -Wl,--unresolved-symbols=ignore-in-object-files -Wl,-z,lazy
 #cgo darwin LDFLAGS: -Wl,-undefined,dynamic_lookup
 #cgo CFLAGS: -DNVML_NO_UNVERSIONED_FUNC_DEFS=1
 #include "nvml.h"

--- a/pkg/nvml/nvml.go
+++ b/pkg/nvml/nvml.go
@@ -18,7 +18,7 @@
 package nvml
 
 /*
-#cgo linux LDFLAGS: -Wl,--export-dynamic -Wl,--unresolved-symbols=ignore-in-object-files
+#cgo linux LDFLAGS: -Wl,--export-dynamic -Wl,--unresolved-symbols=ignore-in-object-files -Wl,-z,lazy
 #cgo darwin LDFLAGS: -Wl,-undefined,dynamic_lookup
 #cgo CFLAGS: -DNVML_NO_UNVERSIONED_FUNC_DEFS=1
 #include "nvml.h"


### PR DESCRIPTION
This fixes undefined symbol errors on platforms where -z,lazy may not be the default.