### PR TITLE
Fix unset version in structs

### DIFF
--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -2808,6 +2808,7 @@ func (l *library) DeviceGetRunningProcessDetailList(device Device) (ProcessDetai
 
 func (device nvmlDevice) GetRunningProcessDetailList() (ProcessDetailList, Return) {
 	var plist ProcessDetailList
+	plist.Version = STRUCT_VERSION(plist, 1)
 	ret := nvmlDeviceGetRunningProcessDetailList(device, &plist)
 	return plist, ret
 }
@@ -2923,6 +2924,7 @@ func (l *library) DeviceGetPciInfoExt(device Device) (PciInfoExt, Return) {
 
 func (device nvmlDevice) GetPciInfoExt() (PciInfoExt, Return) {
 	var pciInfo PciInfoExt
+	pciInfo.Version = STRUCT_VERSION(pciInfo, 1)
 	ret := nvmlDeviceGetPciInfoExt(device, &pciInfo)
 	return pciInfo, ret
 }
@@ -2969,6 +2971,7 @@ func (l *library) DeviceGetVgpuHeterogeneousMode(device Device) (VgpuHeterogeneo
 
 func (device nvmlDevice) GetVgpuHeterogeneousMode() (VgpuHeterogeneousMode, Return) {
 	var heterogeneousMode VgpuHeterogeneousMode
+	heterogeneousMode.Version = STRUCT_VERSION(heterogeneousMode, 1)
 	ret := nvmlDeviceGetVgpuHeterogeneousMode(device, &heterogeneousMode)
 	return heterogeneousMode, ret
 }
@@ -2994,6 +2997,7 @@ func (device nvmlDevice) GetVgpuTypeSupportedPlacements(vgpuTypeId VgpuTypeId) (
 
 func (vgpuTypeId nvmlVgpuTypeId) GetSupportedPlacements(device Device) (VgpuPlacementList, Return) {
 	var placementList VgpuPlacementList
+	placementList.Version = STRUCT_VERSION(placementList, 1)
 	ret := nvmlDeviceGetVgpuTypeSupportedPlacements(nvmlDeviceHandle(device), vgpuTypeId, &placementList)
 	return placementList, ret
 }
@@ -3009,6 +3013,7 @@ func (device nvmlDevice) GetVgpuTypeCreatablePlacements(vgpuTypeId VgpuTypeId) (
 
 func (vgpuTypeId nvmlVgpuTypeId) GetCreatablePlacements(device Device) (VgpuPlacementList, Return) {
 	var placementList VgpuPlacementList
+	placementList.Version = STRUCT_VERSION(placementList, 1)
 	ret := nvmlDeviceGetVgpuTypeCreatablePlacements(nvmlDeviceHandle(device), vgpuTypeId, &placementList)
 	return placementList, ret
 }
@@ -3041,6 +3046,7 @@ func (l *library) DeviceGetVgpuProcessesUtilizationInfo(device Device) (VgpuProc
 
 func (device nvmlDevice) GetVgpuProcessesUtilizationInfo() (VgpuProcessesUtilizationInfo, Return) {
 	var vgpuProcUtilInfo VgpuProcessesUtilizationInfo
+	vgpuProcUtilInfo.Version = STRUCT_VERSION(vgpuProcUtilInfo, 1)
 	ret := nvmlDeviceGetVgpuProcessesUtilizationInfo(device, &vgpuProcUtilInfo)
 	return vgpuProcUtilInfo, ret
 }
@@ -3052,6 +3058,7 @@ func (l *library) DeviceGetSramEccErrorStatus(device Device) (EccSramErrorStatus
 
 func (device nvmlDevice) GetSramEccErrorStatus() (EccSramErrorStatus, Return) {
 	var status EccSramErrorStatus
+	status.Version = STRUCT_VERSION(status, 1)
 	ret := nvmlDeviceGetSramEccErrorStatus(device, &status)
 	return status, ret
 }

--- a/pkg/nvml/gpm.go
+++ b/pkg/nvml/gpm.go
@@ -122,7 +122,7 @@ func (device nvmlDevice) GpmQueryDeviceSupportV() GpmSupportV {
 
 func (gpmSupportV GpmSupportV) V1() (GpmSupport, Return) {
 	var gpmSupport GpmSupport
-	gpmSupport.Version = 1
+	gpmSupport.Version = STRUCT_VERSION(gpmSupport, 1)
 	ret := nvmlGpmQueryDeviceSupport(gpmSupportV.device, &gpmSupport)
 	return gpmSupport, ret
 }
@@ -133,7 +133,7 @@ func (l *library) GpmQueryDeviceSupport(device Device) (GpmSupport, Return) {
 
 func (device nvmlDevice) GpmQueryDeviceSupport() (GpmSupport, Return) {
 	var gpmSupport GpmSupport
-	gpmSupport.Version = GPM_SUPPORT_VERSION
+	gpmSupport.Version = STRUCT_VERSION(gpmSupport, GPM_SUPPORT_VERSION)
 	ret := nvmlGpmQueryDeviceSupport(device, &gpmSupport)
 	return gpmSupport, ret
 }

--- a/pkg/nvml/system.go
+++ b/pkg/nvml/system.go
@@ -121,6 +121,7 @@ func SystemGetNvlinkBwMode() (uint32, Return) {
 // nvml.SystemGetConfComputeKeyRotationThresholdInfo()
 func (l *library) SystemGetConfComputeKeyRotationThresholdInfo() (ConfComputeGetKeyRotationThresholdInfo, Return) {
 	var keyRotationThresholdInfo ConfComputeGetKeyRotationThresholdInfo
+	keyRotationThresholdInfo.Version = STRUCT_VERSION(keyRotationThresholdInfo, 1)
 	ret := nvmlSystemGetConfComputeKeyRotationThresholdInfo(&keyRotationThresholdInfo)
 	return keyRotationThresholdInfo, ret
 }
@@ -128,6 +129,7 @@ func (l *library) SystemGetConfComputeKeyRotationThresholdInfo() (ConfComputeGet
 // nvml.SystemGetConfComputeSettings()
 func (l *library) SystemGetConfComputeSettings() (SystemConfComputeSettings, Return) {
 	var settings SystemConfComputeSettings
+	settings.Version = STRUCT_VERSION(settings, 1)
 	ret := nvmlSystemGetConfComputeSettings(&settings)
 	return settings, ret
 }


### PR DESCRIPTION
This change ensures that the Version field is set in structs that require them.

This addresses the following calls:
* DeviceGetRunningProcessDetailList
* DeviceGetPciInfoExt
* DeviceGetVgpuHeterogeneousMode
* DeviceGetSupportedPlacements
* DeviceGetCreatablePlacements
* DeviceGetVgpuProcessesUtilizationInfo
* DeviceGetSramEccErrorStatus
* SystemGetConfComputeKeyRotationThresholdInfo
* SystemGetConfComputeSettings

This replaces replace #130

fixes #138 