### PR TITLE
migrate to golangci-lint v2

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -42,7 +42,7 @@ jobs:
       with:
         go-version: ${{ env.GOLANG_VERSION }}
     - name: Lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v7
       with:
         version: latest
         args: -v --timeout 5m

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,19 +1,34 @@
+version: "2"
 linters:
-  enable:
-    - goimports
   disable:
     - asciicheck
     - contextcheck
+    - errcheck
     - forcetypeassert
     - gocritic
     - godot
-    - gofmt
     - misspell
-    - stylecheck
-
-run:
-  deadline: 10m
-
-linters-settings:
-  goimports:
-    local-prefixes: github.com/NVIDIA/go-nvml
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/NVIDIA/go-nvml
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -2191,7 +2191,7 @@ func (device nvmlDevice) GetGpuInstances(info *GpuInstanceProfileInfo) ([]GpuIns
 	if info == nil {
 		return nil, ERROR_INVALID_ARGUMENT
 	}
-	var count uint32 = info.InstanceCount
+	var count = info.InstanceCount
 	gpuInstances := make([]nvmlGpuInstance, count)
 	ret := nvmlDeviceGetGpuInstances(device, info.Id, &gpuInstances[0], &count)
 	return convertSlice[nvmlGpuInstance, GpuInstance](gpuInstances[:count]), ret
@@ -2302,7 +2302,7 @@ func (gpuInstance nvmlGpuInstance) GetComputeInstances(info *ComputeInstanceProf
 	if info == nil {
 		return nil, ERROR_INVALID_ARGUMENT
 	}
-	var count uint32 = info.InstanceCount
+	var count = info.InstanceCount
 	computeInstances := make([]nvmlComputeInstance, count)
 	ret := nvmlGpuInstanceGetComputeInstances(gpuInstance, info.Id, &computeInstances[0], &count)
 	return convertSlice[nvmlComputeInstance, ComputeInstance](computeInstances[:count]), ret

--- a/pkg/nvml/gpm.go
+++ b/pkg/nvml/gpm.go
@@ -30,9 +30,8 @@ func (g *GpmMetricsGetType) convert() *nvmlGpmMetricsGetType {
 		Sample1:    g.Sample1.(nvmlGpmSample),
 		Sample2:    g.Sample2.(nvmlGpmSample),
 	}
-	for i := range g.Metrics {
-		out.Metrics[i] = g.Metrics[i]
-	}
+	copy(out.Metrics[:], g.Metrics[:])
+
 	return out
 }
 
@@ -43,9 +42,8 @@ func (g *nvmlGpmMetricsGetType) convert() *GpmMetricsGetType {
 		Sample1:    g.Sample1,
 		Sample2:    g.Sample2,
 	}
-	for i := range g.Metrics {
-		out.Metrics[i] = g.Metrics[i]
-	}
+	copy(out.Metrics[:], g.Metrics[:])
+
 	return out
 }
 

--- a/pkg/nvml/mock/dgxa100/dgxa100.go
+++ b/pkg/nvml/mock/dgxa100/dgxa100.go
@@ -20,9 +20,10 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/google/uuid"
+
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/NVIDIA/go-nvml/pkg/nvml/mock"
-	"github.com/google/uuid"
 )
 
 type Server struct {
@@ -108,7 +109,7 @@ func NewDevice(index int) *Device {
 		},
 		GpuInstances:       make(map[*GpuInstance]struct{}),
 		GpuInstanceCounter: 0,
-		MemoryInfo:         nvml.Memory{42949672960, 0, 0},
+		MemoryInfo:         nvml.Memory{Total: 42949672960, Free: 0, Used: 0},
 	}
 	device.setMockFuncs()
 	return device


### PR DESCRIPTION
The following lint issues have been fixed

```
                      ^
pkg/nvml/mock/dgxa100/dgxa100.go:22:1: File is not properly formatted (goimports)

^
pkg/nvml/mock/dgxa100/dgxa100.go:111:23: composites: github.com/NVIDIA/go-nvml/pkg/nvml.Memory struct literal uses unkeyed fields (govet)
                MemoryInfo:         nvml.Memory{42949672960, 0, 0},
                                    ^
gen/nvml/generateapi.go:106:2: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
        fmt.Fprintf(writer, header)
        ^
gen/nvml/generateapi.go:115:4: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
                        fmt.Fprintf(writer, comment)
                        ^
gen/nvml/generateapi.go:130:3: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
                fmt.Fprintf(writer, comment)
                ^
gen/nvml/generateapi.go:273:15: ST1005: error strings should not end with punctuation or newlines (staticcheck)
                return nil, fmt.Errorf("walking %s: %w\n", sourceDir, err)
                            ^
pkg/nvml/device.go:2194:12: QF1011: could omit type uint32 from declaration; it will be inferred from the right-hand side (staticcheck)
        var count uint32 = info.InstanceCount
                  ^
pkg/nvml/device.go:2305:12: QF1011: could omit type uint32 from declaration; it will be inferred from the right-hand side (staticcheck)
        var count uint32 = info.InstanceCount
                  ^
pkg/nvml/gpm.go:33:2: S1001: should copy arrays using assignment instead of using a loop (staticcheck)
        for i := range g.Metrics {
        ^
pkg/nvml/gpm.go:46:2: S1001: should copy arrays using assignment instead of using a loop (staticcheck)
        for i := range g.Metrics {
        ^
                   ^

```