### PR TITLE
[CI] re-enable the check stage

### DIFF
--- a/.github/workflows/golang.yml
+++ b/.github/workflows/golang.yml
@@ -26,8 +26,6 @@ on:
 
 jobs:
   check:
-    # TODO: We disable checks for the time being since we need to address the linter errors.
-    if: false
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ EXAMPLE_TARGETS := $(patsubst %,example-%, $(EXAMPLES))
 CMDS := $(patsubst ./cmd/%/,%,$(sort $(dir $(wildcard ./cmd/*/))))
 CMD_TARGETS := $(patsubst %,cmd-%, $(CMDS))
 
-CHECK_TARGETS := golangci-lint
+CHECK_TARGETS := validate-modules golangci-lint
 
 MAKE_TARGETS := binary build all fmt generate test coverage check examples update-nvml-h
 
@@ -71,6 +71,13 @@ test: build
 coverage: test
 	cat $(COVERAGE_FILE) | grep -v "_mock.go" > $(COVERAGE_FILE).no-mocks
 	go tool cover -func=$(COVERAGE_FILE).no-mocks
+
+validate-modules:
+	@echo "- Verifying that the dependencies have expected content..."
+	go mod verify
+	@echo "- Checking for any unused/missing packages in go.mod..."
+	go mod tidy
+	git diff --exit-code HEAD -- go.mod go.sum
 
 # Generate an image for containerized builds
 # Note: This image is local only

--- a/gen/nvml/generateapi.go
+++ b/gen/nvml/generateapi.go
@@ -103,7 +103,7 @@ func main() {
 		fmt.Printf("Error: %v", err)
 		return
 	}
-	fmt.Fprintf(writer, header)
+	fmt.Fprint(writer, header)
 
 	for i, p := range GeneratableInterfaces {
 		if p.PackageMethodsAliasedFrom != "" {
@@ -112,7 +112,7 @@ func main() {
 				fmt.Printf("Error: %v", err)
 				return
 			}
-			fmt.Fprintf(writer, comment)
+			fmt.Fprint(writer, comment)
 
 			output, err := generatePackageMethods(*sourceDir, p)
 			if err != nil {
@@ -127,17 +127,17 @@ func main() {
 			fmt.Printf("Error: %v", err)
 			return
 		}
-		fmt.Fprintf(writer, comment)
+		fmt.Fprint(writer, comment)
 
 		output, err := generateInterface(*sourceDir, p)
 		if err != nil {
 			fmt.Printf("Error: %v", err)
 			return
 		}
-		fmt.Fprintf(writer, output)
+		fmt.Fprint(writer, output)
 
 		if i < (len(GeneratableInterfaces) - 1) {
-			fmt.Fprintf(writer, "\n")
+			fmt.Fprint(writer, "\n")
 		}
 	}
 }
@@ -270,7 +270,7 @@ func getGoFiles(sourceDir string) (map[string][]byte, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("walking %s: %w\n", sourceDir, err)
+		return nil, fmt.Errorf("walking %s: %w", sourceDir, err)
 	}
 
 	return gofiles, nil

--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -68,16 +68,6 @@ type GpuInstanceInfo struct {
 	Placement GpuInstancePlacement
 }
 
-func (g GpuInstanceInfo) convert() nvmlGpuInstanceInfo {
-	out := nvmlGpuInstanceInfo{
-		Device:    g.Device.(nvmlDevice),
-		Id:        g.Id,
-		ProfileId: g.ProfileId,
-		Placement: g.Placement,
-	}
-	return out
-}
-
 func (g nvmlGpuInstanceInfo) convert() GpuInstanceInfo {
 	out := GpuInstanceInfo{
 		Device:    g.Device,
@@ -95,17 +85,6 @@ type ComputeInstanceInfo struct {
 	Id          uint32
 	ProfileId   uint32
 	Placement   ComputeInstancePlacement
-}
-
-func (c ComputeInstanceInfo) convert() nvmlComputeInstanceInfo {
-	out := nvmlComputeInstanceInfo{
-		Device:      c.Device.(nvmlDevice),
-		GpuInstance: c.GpuInstance.(nvmlGpuInstance),
-		Id:          c.Id,
-		ProfileId:   c.ProfileId,
-		Placement:   c.Placement,
-	}
-	return out
 }
 
 func (c nvmlComputeInstanceInfo) convert() ComputeInstanceInfo {

--- a/pkg/nvml/event_set.go
+++ b/pkg/nvml/event_set.go
@@ -23,17 +23,6 @@ type EventData struct {
 	ComputeInstanceId uint32
 }
 
-func (e EventData) convert() nvmlEventData {
-	out := nvmlEventData{
-		Device:            e.Device.(nvmlDevice),
-		EventType:         e.EventType,
-		EventData:         e.EventData,
-		GpuInstanceId:     e.GpuInstanceId,
-		ComputeInstanceId: e.ComputeInstanceId,
-	}
-	return out
-}
-
 func (e nvmlEventData) convert() EventData {
 	out := EventData{
 		Device:            e.Device,


### PR DESCRIPTION
The following lint errors have been fixed as part of this PR changeset 
```
pkg/nvml/device.go:71:26: func GpuInstanceInfo.convert is unused (unused)
func (g GpuInstanceInfo) convert() nvmlGpuInstanceInfo {
                         ^
pkg/nvml/device.go:100:30: func ComputeInstanceInfo.convert is unused (unused)
func (c ComputeInstanceInfo) convert() nvmlComputeInstanceInfo {
                             ^
pkg/nvml/event_set.go:26:20: func EventData.convert is unused (unused)
func (e EventData) convert() nvmlEventData {

gen/nvml/generateapi.go:130:3: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
  		fmt.Fprintf(writer, comment)
  		^
gen/nvml/generateapi.go:137:3: SA1006: printf-style function with dynamic format string and no further arguments should use print-style function instead (staticcheck)
  		fmt.Fprintf(writer, output)
  	
```

     