### PR TITLE
Add script to generate a raw cgo-level interface for go-nvml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,9 +151,14 @@ bindings: .create-bindings .strip-autogen-comment .strip-nvml-h-linenumber
 		go fmt types_gen.go; \
 	cd -> /dev/null
 	rm -rf $(PKG_BINDINGS_DIR)/nvml.yml $(PKG_BINDINGS_DIR)/cgo_helpers.go $(PKG_BINDINGS_DIR)/types.go $(PKG_BINDINGS_DIR)/_obj
-	go run $(GEN_BINDINGS_DIR)/generateapi.go \
+	go run -tags generateapi \
+		$(GEN_BINDINGS_DIR)/generateapi.go \
 		--sourceDir $(PKG_BINDINGS_DIR) \
 		--output $(PKG_BINDINGS_DIR)/zz_generated.api.go
+	go run -tags generatecgoapi \
+		$(GEN_BINDINGS_DIR)/generatecgoapi.go \
+		--sourceDir $(PKG_BINDINGS_DIR) \
+		--output $(PKG_BINDINGS_DIR)/zz_generated.cgoapi.go
 	make fmt
 
 .strip-autogen-comment: SED_SEARCH_STRING := // WARNING: This file has automatically been generated on

--- a/gen/nvml/generateapi.go
+++ b/gen/nvml/generateapi.go
@@ -14,6 +14,7 @@
 # limitations under the License.
 **/
 
+//go:build generateapi
 package main
 
 import (

--- a/gen/nvml/generatecgoapi.go
+++ b/gen/nvml/generatecgoapi.go
@@ -1,3 +1,20 @@
+/**
+# Copyright 2025 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+//go:build generatecgoapi
 package main
 
 import (

--- a/gen/nvml/generatecgoapi.go
+++ b/gen/nvml/generatecgoapi.go
@@ -1,0 +1,696 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/template"
+)
+
+// Constants for type checking
+const (
+	nvmlPrefix    = "nvml"
+	pointerPrefix = "*"
+	arrayPrefix   = "[]"
+)
+
+// Template definitions
+const fileTemplate = `
+/**
+# Copyright 2025 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+// Generated Code; DO NOT EDIT.
+
+package nvml
+
+// CgoAPI is a global variable providing direct calls to the cgo API rather than the standard wrappers
+var CgoAPI = cgoapi{}
+
+type cgoapi struct{}
+
+{{range $i, $method := .Methods}}
+{{- if $i }}
+
+{{- end }}
+{{$method}}
+{{end}}`
+
+const methodTemplate = `
+{{- $params := "" -}}
+{{- range $i, $param := .Params -}}
+{{- if $i -}}
+{{- $params = printf "%s, %s %s" $params .Name .Type -}}
+{{- else -}}
+{{- $params = printf "%s %s" .Name .Type -}}
+{{- end -}}
+{{- end -}}
+
+{{- $returns := "" -}}
+{{- range $i, $ret := .Returns -}}
+{{- if $i -}}
+{{- $returns = printf "%s, %s" $returns .Type -}}
+{{- else -}}
+{{- $returns = printf "%s" .Type -}}
+{{- end -}}
+{{- end -}}
+
+{{- $callParams := "" -}}
+{{- range $i, $param := .CallParams -}}
+{{- if $i -}}
+{{- $callParams = printf "%s, %s" $callParams . -}}
+{{- else -}}
+{{- $callParams = printf "%s" . -}}
+{{- end -}}
+{{- end -}}
+
+func (cgoapi) {{.Name}}({{$params}}) {{if .Returns}}({{$returns}}){{end}} {
+{{- range .Conversions}}
+	{{.}}
+{{- end}}
+	ret := {{.CallName}}({{$callParams}})
+{{- range .Assignments}}
+	{{.}}
+{{- end}}
+	return ret
+}`
+
+// Dynamic type caches - populated during generation
+var interfaceTypes = make(map[string]bool)
+var structTypesWithEmbeddedNvml = make(map[string]string)
+
+// Template data structures
+type FileTemplateData struct {
+	Methods []string
+}
+
+type MethodTemplateData struct {
+	Name         string
+	Params       []ParamData
+	Returns      []ReturnData
+	Conversions  []string
+	CallName     string
+	CallParams   []string
+	Assignments  []string
+}
+
+type ParamData struct {
+	Name string
+	Type string
+}
+
+type ReturnData struct {
+	Type string
+}
+
+
+
+// ParameterInfo holds processed parameter information
+type ParameterInfo struct {
+	name            string
+	convertedType   string
+	convertedName   string
+	needsConversion bool
+	isPointer       bool
+	baseType        string
+}
+
+func main() {
+	// Parse command line flags
+	sourceDir := flag.String("sourceDir", "", "Path to the source directory for all go files")
+	output := flag.String("output", "", "Path to the output file (default: stdout)")
+	flag.Parse()
+
+	if *sourceDir == "" {
+		flag.Usage()
+		return
+	}
+
+	// Discover interface types and struct types with embedded nvml* types
+	if err := discoverTypes(*sourceDir); err != nil {
+		fmt.Printf("Error discovering types: %v", err)
+		return
+	}
+
+	// Set up output writer
+	writer, closer, err := getWriter(*output)
+	if err != nil {
+		fmt.Printf("Error: %v", err)
+		return
+	}
+	defer closer()
+
+	// Generate the cgoapi file content
+	fileContent, err := generateCgoAPIFile(*sourceDir)
+	if err != nil {
+		fmt.Printf("Error: %v", err)
+		return
+	}
+	fmt.Fprint(writer, fileContent)
+}
+
+// getWriter returns an appropriate writer for the output file
+func getWriter(outputFile string) (io.Writer, func() error, error) {
+	if outputFile == "" {
+		return os.Stdout, func() error { return nil }, nil
+	}
+	file, err := os.Create(outputFile)
+	if err != nil {
+		return nil, nil, err
+	}
+	return file, file.Close, nil
+}
+
+// generateCgoAPIFile generates the full cgoapi.go file content using templates
+func generateCgoAPIFile(sourceDir string) (string, error) {
+	// Parse the main file template
+	tmpl, err := template.New("file").Parse(fileTemplate)
+	if err != nil {
+		return "", fmt.Errorf("parsing file template: %w", err)
+	}
+
+	// Collect methods
+	methods, err := collectCgoApiMethods(sourceDir)
+	if err != nil {
+		return "", err
+	}
+
+	// Prepare file data
+	fileData := FileTemplateData{
+		Methods: methods,
+	}
+
+	// Execute template
+	var sb strings.Builder
+	if err := tmpl.Execute(&sb, fileData); err != nil {
+		return "", fmt.Errorf("executing file template: %w", err)
+	}
+
+	return sb.String(), nil
+}
+
+
+
+// collectCgoApiMethods collects and returns all cgoapi methods, sorted alphabetically
+func collectCgoApiMethods(sourceDir string) ([]string, error) {
+	// Extract all functions from nvml.go
+	funcs, err := extractFunctionsFromNvmlFile(sourceDir)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a map for quick function lookup
+	funcMap := make(map[string]*ast.FuncDecl)
+	for _, f := range funcs {
+		funcMap[f.Name.Name] = f
+	}
+
+	var methods []string
+
+	// Generate methods for all functions from nvml.go
+	for _, function := range funcs {
+		methodName := removeNvmlPrefix(function.Name.Name)
+		if methodName == function.Name.Name {
+			continue // Skip functions that don't start with "nvml"
+		}
+		methodCode, err := generateMethodData(methodName, function, function.Name.Name)
+		if err != nil {
+			return nil, err
+		}
+		methods = append(methods, methodCode)
+	}
+
+	// Generate methods for unversioned functions from lib.go
+	unversionedFuncs, err := extractUnversionedNvmlFunctionsFromLibFile(sourceDir)
+	if err != nil {
+		return nil, err
+	}
+	for _, pair := range unversionedFuncs {
+		nvmlFunc := pair[0]
+		aliasedFunc := pair[1]
+		methodName := removeNvmlPrefix(nvmlFunc)
+		targetFunc := funcMap[aliasedFunc]
+		if targetFunc == nil {
+			continue // Skip if the aliased function doesn't exist
+		}
+		methodCode, err := generateMethodData(methodName, targetFunc, nvmlFunc)
+		if err != nil {
+			return nil, err
+		}
+		methods = append(methods, methodCode)
+	}
+
+	// Sort methods alphabetically
+	sort.Strings(methods)
+	return methods, nil
+}
+
+// generateMethodData generates method code for a given function declaration
+func generateMethodData(methodName string, decl *ast.FuncDecl, callName string) (string, error) {
+	// Parse the method template
+	tmpl, err := template.New("method").Parse(methodTemplate)
+	if err != nil {
+		return "", fmt.Errorf("parsing method template: %w", err)
+	}
+
+	// Process parameters
+	params := processParameters(decl.Type.Params.List)
+	paramData := make([]ParamData, len(params))
+	for i, param := range params {
+		paramData[i] = ParamData{
+			Name: param.name,
+			Type: param.convertedType,
+		}
+	}
+
+	// Process return types
+	var returnData []ReturnData
+	if decl.Type.Results != nil {
+		for _, result := range decl.Type.Results.List {
+			returnData = append(returnData, ReturnData{
+				Type: formatFieldList(result),
+			})
+		}
+	}
+
+	// Generate conversions
+	var conversions []string
+	for _, param := range params {
+		if param.needsConversion && param.isPointer {
+			conversions = append(conversions, fmt.Sprintf("var nvml%s %s", strings.Title(param.name), param.baseType))
+		}
+	}
+
+	// Generate call parameters
+	callParams := make([]string, len(params))
+	for i, param := range params {
+		callParams[i] = param.convertedName
+	}
+
+	// Generate assignments
+	var assignments []string
+	for _, param := range params {
+		if !param.needsConversion || !param.isPointer {
+			continue
+		}
+
+		// Skip assignment for structs with embedded nvml* types
+		if isStructWithEmbeddedNvmlType(convertTypeName(param.baseType)) {
+			continue
+		}
+
+		// Only convert if the target type (without nvml prefix) is an interface
+		if strings.HasPrefix(param.baseType, nvmlPrefix) {
+			targetType := convertTypeName(param.baseType)
+			if isInterfaceType(targetType) {
+				assignment := generateAssignmentStatement(param, targetType)
+				assignments = append(assignments, assignment)
+			}
+		}
+	}
+
+	methodData := MethodTemplateData{
+		Name:        methodName,
+		Params:      paramData,
+		Returns:     returnData,
+		Conversions: conversions,
+		CallName:    callName,
+		CallParams:  callParams,
+		Assignments: assignments,
+	}
+
+	// Generate the method code using template
+	var sb strings.Builder
+	if err := tmpl.Execute(&sb, methodData); err != nil {
+		return "", fmt.Errorf("executing method template: %w", err)
+	}
+
+	return sb.String(), nil
+}
+
+
+
+// processParameters processes all parameters and returns their conversion info
+func processParameters(params []*ast.Field) []ParameterInfo {
+	var results []ParameterInfo
+
+	for _, param := range params {
+		paramType := getTypeString(param.Type)
+		info := ParameterInfo{
+			convertedType: paramType,
+			isPointer:     isPointerType(paramType),
+		}
+
+		if len(param.Names) > 0 {
+			paramName := param.Names[0].Name
+			info.name = convertParamName(paramName)
+			info.convertedName = info.name
+			info.baseType = paramType
+
+			// Apply type-specific conversion logic
+			if info.isPointer {
+				info.baseType = paramType[len(pointerPrefix):] // Remove * prefix
+				info = processPointerParameter(info)
+			} else if shouldConvertType(paramType) {
+				info = processNonPointerParameter(info)
+			}
+		}
+
+		results = append(results, info)
+	}
+
+	return results
+}
+
+// processPointerParameter handles pointer parameter conversion logic
+func processPointerParameter(info ParameterInfo) ParameterInfo {
+	// Check if this is a pointer to a struct that embeds an nvml* type
+	if isStructWithEmbeddedNvmlType(convertTypeName(info.baseType)) {
+		embeddedType := getEmbeddedNvmlType(convertTypeName(info.baseType))
+		info.convertedType = "*" + convertTypeName(info.baseType)
+		info.convertedName = fmt.Sprintf("&%s.%s", info.name, embeddedType)
+		info.needsConversion = false // No conversion needed - pass embedded field reference
+	} else {
+		// Regular pointer to nvml* type - create local variable for conversion
+		info.convertedType = "*" + convertTypeName(info.baseType)
+		info.convertedName = "&nvml" + strings.Title(info.name)
+		info.needsConversion = true
+	}
+
+	return info
+}
+
+// processNonPointerParameter handles non-pointer parameter conversion logic
+func processNonPointerParameter(info ParameterInfo) ParameterInfo {
+	targetType := convertTypeName(info.baseType)
+	if isInterfaceType(targetType) {
+		// Convert to interface type using Handle() method
+		info.convertedType = targetType
+		info.convertedName = fmt.Sprintf("%sHandle(%s)", info.baseType, info.name)
+		info.needsConversion = true
+	} else {
+		// Pass the nvml* type directly - no conversion needed
+		info.convertedType = info.baseType
+		info.convertedName = info.name
+		info.needsConversion = false
+	}
+
+	return info
+}
+
+
+
+// generateAssignmentStatement generates a single assignment statement
+func generateAssignmentStatement(param ParameterInfo, targetType string) string {
+	// Check if it's a struct type that has a convert() method
+	if strings.HasSuffix(targetType, "Info") || strings.HasSuffix(targetType, "Stats") || strings.HasSuffix(targetType, "Settings") {
+		return fmt.Sprintf("\t*%s = nvml%s.convert()", param.name, strings.Title(param.name))
+	} else {
+		// Use type conversion for other interface types
+		return fmt.Sprintf("\t*%s = %s(nvml%s)", param.name, targetType, strings.Title(param.name))
+	}
+}
+
+// discoverTypes discovers interface types and struct types with embedded nvml* types
+func discoverTypes(sourceDir string) error {
+	// Parse all Go files in the source directory
+	files, err := filepath.Glob(filepath.Join(sourceDir, "*.go"))
+	if err != nil {
+		return fmt.Errorf("finding Go files: %w", err)
+	}
+
+	for _, file := range files {
+		if err := parseFileForTypes(file); err != nil {
+			return fmt.Errorf("parsing %s: %w", file, err)
+		}
+	}
+
+	return nil
+}
+
+// parseFileForTypes parses a single file to discover interface and struct types
+func parseFileForTypes(filePath string) error {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return err
+	}
+
+	fset := token.NewFileSet()
+	node, err := parser.ParseFile(fset, filePath, content, parser.ParseComments)
+	if err != nil {
+		return err
+	}
+
+	// Look for interface and struct type declarations
+	for _, decl := range node.Decls {
+		if genDecl, ok := decl.(*ast.GenDecl); ok && genDecl.Tok == token.TYPE {
+			for _, spec := range genDecl.Specs {
+				if typeSpec, ok := spec.(*ast.TypeSpec); ok {
+					analyzeTypeDeclaration(typeSpec)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// analyzeTypeDeclaration analyzes a type declaration to determine if it's an interface or struct with embedded nvml* type
+func analyzeTypeDeclaration(typeSpec *ast.TypeSpec) {
+	typeName := typeSpec.Name.Name
+
+	switch t := typeSpec.Type.(type) {
+	case *ast.InterfaceType:
+		// This is an interface type
+		interfaceTypes[typeName] = true
+	case *ast.StructType:
+		// Check if this struct embeds an nvml* type
+		for _, field := range t.Fields.List {
+			if len(field.Names) == 0 && field.Type != nil {
+				// This is an embedded field
+				if embeddedType := getTypeString(field.Type); strings.HasPrefix(embeddedType, nvmlPrefix) {
+					structTypesWithEmbeddedNvml[typeName] = embeddedType
+					break
+				}
+			}
+		}
+	}
+}
+
+// extractFunctionsFromNvmlFile parses nvml.go and returns all function declarations
+func extractFunctionsFromNvmlFile(sourceDir string) ([]*ast.FuncDecl, error) {
+	nvmlFilePath := filepath.Join(sourceDir, "nvml.go")
+	content, err := os.ReadFile(nvmlFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", nvmlFilePath, err)
+	}
+	fset := token.NewFileSet()
+	node, err := parser.ParseFile(fset, nvmlFilePath, content, parser.ParseComments)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", nvmlFilePath, err)
+	}
+	var functions []*ast.FuncDecl
+	for _, decl := range node.Decls {
+		if funcDecl, ok := decl.(*ast.FuncDecl); ok {
+			functions = append(functions, funcDecl)
+		}
+	}
+	return functions, nil
+}
+
+// removeNvmlPrefix removes the nvml prefix and capitalizes the first letter
+func removeNvmlPrefix(name string) string {
+	if strings.HasPrefix(name, nvmlPrefix) {
+		name = name[len(nvmlPrefix):]
+	}
+	if len(name) > 0 {
+		return strings.ToUpper(name[:1]) + name[1:]
+	}
+	return name
+}
+
+// extractUnversionedNvmlFunctionsFromLibFile extracts nvml* function aliases from the marked block in lib.go
+func extractUnversionedNvmlFunctionsFromLibFile(sourceDir string) ([][2]string, error) {
+	libFilePath := filepath.Join(sourceDir, "lib.go")
+	content, err := os.ReadFile(libFilePath)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", libFilePath, err)
+	}
+	lines := strings.Split(string(content), "\n")
+	var results [][2]string
+	inBlock := false
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "// BEGIN_UNVERSIONED_FUNCTIONS" {
+			inBlock = true
+			continue
+		}
+		if line == "// END_UNVERSIONED_FUNCTIONS" {
+			inBlock = false
+			continue
+		}
+		if !inBlock {
+			continue
+		}
+		if strings.HasPrefix(line, "var nvml") && strings.Contains(line, "=") {
+			parts := strings.SplitN(line, "=", 2)
+			if len(parts) == 2 {
+				nvmlFunc := strings.TrimSpace(parts[0][4:])
+				aliasedFunc := strings.TrimSpace(parts[1])
+				results = append(results, [2]string{nvmlFunc, aliasedFunc})
+			}
+		}
+	}
+	return results, nil
+}
+
+// getTypeString returns the string representation of a type
+func getTypeString(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.StarExpr:
+		return "*" + getTypeString(t.X)
+	case *ast.ArrayType:
+		return "[]" + getTypeString(t.Elt)
+	case *ast.SelectorExpr:
+		if x, ok := t.X.(*ast.Ident); ok {
+			return x.Name + "." + t.Sel.Name
+		}
+		return t.Sel.Name
+	default:
+		return "interface{}"
+	}
+}
+
+// shouldConvertType checks if a type should be converted (non-exported nvml* type that's not a pointer)
+func shouldConvertType(typeName string) bool {
+	// Check if it's a non-exported type (starts with lowercase)
+	if len(typeName) == 0 || typeName[0] < 'a' || typeName[0] > 'z' {
+		return false
+	}
+
+	// Check if it starts with "nvml"
+	if !strings.HasPrefix(typeName, nvmlPrefix) {
+		return false
+	}
+
+	// Check if it's not an array
+	if strings.HasPrefix(typeName, arrayPrefix) {
+		return false
+	}
+
+	return true
+}
+
+// isInterfaceType checks if a type (without nvml prefix) is an interface type
+func isInterfaceType(typeName string) bool {
+	return interfaceTypes[typeName]
+}
+
+// isStructWithEmbeddedNvmlType checks if a type is a struct that embeds an nvml* type
+func isStructWithEmbeddedNvmlType(typeName string) bool {
+	return structTypesWithEmbeddedNvml[typeName] != ""
+}
+
+// getEmbeddedNvmlType returns the embedded nvml* type for a struct type
+func getEmbeddedNvmlType(typeName string) string {
+	return structTypesWithEmbeddedNvml[typeName]
+}
+
+// isPointerType checks if a type is a pointer to an nvml* type that should be converted
+func isPointerType(typeName string) bool {
+	if !strings.HasPrefix(typeName, pointerPrefix) {
+		return false
+	}
+
+	// Extract the base type (remove the * prefix)
+	baseType := typeName[len(pointerPrefix):]
+
+	// Check if it's a non-exported type (starts with lowercase)
+	if len(baseType) == 0 || baseType[0] < 'a' || baseType[0] > 'z' {
+		return false
+	}
+
+	// Check if it starts with "nvml"
+	if !strings.HasPrefix(baseType, nvmlPrefix) {
+		return false
+	}
+
+	return true
+}
+
+// convertTypeName removes the "nvml" prefix and capitalizes the first letter
+func convertTypeName(typeName string) string {
+	if strings.HasPrefix(typeName, nvmlPrefix) {
+		typeName = typeName[len(nvmlPrefix):]
+	}
+	if len(typeName) > 0 {
+		return strings.ToUpper(typeName[:1]) + typeName[1:]
+	}
+	return typeName
+}
+
+// convertParamName removes the "nvml" prefix and converts to lowercase
+func convertParamName(paramName string) string {
+	if strings.HasPrefix(paramName, nvmlPrefix) {
+		return strings.ToLower(paramName[len(nvmlPrefix):])
+	}
+	return strings.ToLower(paramName)
+}
+
+// formatFieldList returns a string for a parameter or result field
+func formatFieldList(field *ast.Field) string {
+	var builder strings.Builder
+	if len(field.Names) > 0 {
+		for i, name := range field.Names {
+			if i > 0 {
+				builder.WriteString(", ")
+			}
+			builder.WriteString(name.Name)
+		}
+		builder.WriteString(" ")
+	}
+	switch t := field.Type.(type) {
+	case *ast.Ident:
+		builder.WriteString(t.Name)
+	case *ast.StarExpr:
+		builder.WriteString(pointerPrefix)
+		if ident, ok := t.X.(*ast.Ident); ok {
+			builder.WriteString(ident.Name)
+		}
+	case *ast.ArrayType:
+		builder.WriteString(arrayPrefix)
+		if ident, ok := t.Elt.(*ast.Ident); ok {
+			builder.WriteString(ident.Name)
+		}
+	case *ast.SelectorExpr:
+		if x, ok := t.X.(*ast.Ident); ok {
+			builder.WriteString(x.Name)
+			builder.WriteString(".")
+		}
+		builder.WriteString(t.Sel.Name)
+	default:
+		builder.WriteString("interface{}")
+	}
+	return builder.String()
+}

--- a/pkg/nvml/cgoapi_test.go
+++ b/pkg/nvml/cgoapi_test.go
@@ -1,0 +1,539 @@
+/**
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package nvml
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestCgoAPIDeviceHandleConversion verifies that we can convert an nvmlDevice to a Device interface and use it via CgoAPI.
+func TestCgoAPIDeviceHandleConversion(t *testing.T) {
+	requireLibNvidiaML(t)
+
+	// Initialize NVML
+	ret := Init()
+	require.Equal(t, SUCCESS, ret, "Init should succeed")
+	defer Shutdown()
+
+	// Test that we can call CgoAPI methods with Device interface
+	// The CgoAPI should automatically convert nvmlDevice to Device interface
+
+	var count uint32
+	ret = CgoAPI.DeviceGetCount(&count)
+	require.Equal(t, SUCCESS, ret, "DeviceGetCount should succeed")
+
+	// Test getting a device handle by index
+	var device Device
+	ret = CgoAPI.DeviceGetHandleByIndex(0, &device)
+	if ret == SUCCESS {
+		// If we got a device, test calling methods on it
+		var name [DEVICE_NAME_BUFFER_SIZE]byte
+		ret = CgoAPI.DeviceGetName(device, &name[0], DEVICE_NAME_BUFFER_SIZE)
+		require.Equal(t, SUCCESS, ret, "DeviceGetName should succeed")
+
+		// Test getting device memory info
+		var memory Memory
+		ret = CgoAPI.DeviceGetMemoryInfo(device, &memory)
+		require.Equal(t, SUCCESS, ret, "DeviceGetMemoryInfo should succeed")
+
+		// Test getting compute mode
+		var mode ComputeMode
+		ret = CgoAPI.DeviceGetComputeMode(device, &mode)
+		require.Equal(t, SUCCESS, ret, "DeviceGetComputeMode should succeed")
+	} else {
+		t.Logf("No devices available for testing, skipping device-specific tests")
+	}
+}
+
+// TestCgoAPIDeviceMethods exercises various device-related CgoAPI methods.
+func TestCgoAPIDeviceMethods(t *testing.T) {
+	requireLibNvidiaML(t)
+
+	// Initialize NVML
+	ret := Init()
+	require.Equal(t, SUCCESS, ret, "Init should succeed")
+	defer Shutdown()
+
+	// Test system-level device count
+	var count uint32
+	ret = CgoAPI.DeviceGetCount(&count)
+	require.Equal(t, SUCCESS, ret, "DeviceGetCount should succeed")
+	t.Logf("Device count: %d", count)
+
+	if count == 0 {
+		t.Skip("No devices available for testing")
+	}
+
+	// Test getting device handle by index
+	var device Device
+	ret = CgoAPI.DeviceGetHandleByIndex(0, &device)
+	require.Equal(t, SUCCESS, ret, "DeviceGetHandleByIndex should succeed")
+
+	// Test various device information methods
+	var name [DEVICE_NAME_BUFFER_SIZE]byte
+	ret = CgoAPI.DeviceGetName(device, &name[0], DEVICE_NAME_BUFFER_SIZE)
+	require.Equal(t, SUCCESS, ret, "DeviceGetName should succeed")
+	t.Logf("Device name: %s", string(name[:]))
+
+	var uuid [DEVICE_UUID_BUFFER_SIZE]byte
+	ret = CgoAPI.DeviceGetUUID(device, &uuid[0], DEVICE_UUID_BUFFER_SIZE)
+	require.Equal(t, SUCCESS, ret, "DeviceGetUUID should succeed")
+	t.Logf("Device UUID: %s", string(uuid[:]))
+
+	var brand BrandType
+	ret = CgoAPI.DeviceGetBrand(device, &brand)
+	require.Equal(t, SUCCESS, ret, "DeviceGetBrand should succeed")
+	t.Logf("Device brand: %v", brand)
+
+	var busType BusType
+	ret = CgoAPI.DeviceGetBusType(device, &busType)
+	require.Equal(t, SUCCESS, ret, "DeviceGetBusType should succeed")
+	t.Logf("Device bus type: %v", busType)
+}
+
+// TestCgoAPIDeviceMemoryInfo tests device memory information methods via CgoAPI.
+func TestCgoAPIDeviceMemoryInfo(t *testing.T) {
+	requireLibNvidiaML(t)
+
+	// Initialize NVML
+	ret := Init()
+	require.Equal(t, SUCCESS, ret, "Init should succeed")
+	defer Shutdown()
+
+	var count uint32
+	ret = CgoAPI.DeviceGetCount(&count)
+	require.Equal(t, SUCCESS, ret, "DeviceGetCount should succeed")
+
+	if count == 0 {
+		t.Skip("No devices available for testing")
+	}
+
+	var device Device
+	ret = CgoAPI.DeviceGetHandleByIndex(0, &device)
+	require.Equal(t, SUCCESS, ret, "DeviceGetHandleByIndex should succeed")
+
+	// Test memory info
+	var memInfo Memory
+	ret = CgoAPI.DeviceGetMemoryInfo(device, &memInfo)
+	require.Equal(t, SUCCESS, ret, "DeviceGetMemoryInfo should succeed")
+	t.Logf("Memory info: Total=%d, Used=%d, Free=%d",
+		memInfo.Total, memInfo.Used, memInfo.Free)
+
+	// Test BAR1 memory info
+	var bar1Info BAR1Memory
+	ret = CgoAPI.DeviceGetBAR1MemoryInfo(device, &bar1Info)
+	require.Equal(t, SUCCESS, ret, "DeviceGetBAR1MemoryInfo should succeed")
+	t.Logf("BAR1 memory: Total=%d, Used=%d, Free=%d",
+		bar1Info.Bar1Total, bar1Info.Bar1Used, bar1Info.Bar1Free)
+}
+
+// TestCgoAPIDeviceUtilization tests device utilization methods via CgoAPI.
+func TestCgoAPIDeviceUtilization(t *testing.T) {
+	requireLibNvidiaML(t)
+
+	// Initialize NVML
+	ret := Init()
+	require.Equal(t, SUCCESS, ret, "Init should succeed")
+	defer Shutdown()
+
+	var count uint32
+	ret = CgoAPI.DeviceGetCount(&count)
+	require.Equal(t, SUCCESS, ret, "DeviceGetCount should succeed")
+
+	if count == 0 {
+		t.Skip("No devices available for testing")
+	}
+
+	var device Device
+	ret = CgoAPI.DeviceGetHandleByIndex(0, &device)
+	require.Equal(t, SUCCESS, ret, "DeviceGetHandleByIndex should succeed")
+
+	// Test GPU utilization
+	var utilization Utilization
+	ret = CgoAPI.DeviceGetUtilizationRates(device, &utilization)
+	require.Equal(t, SUCCESS, ret, "DeviceGetUtilizationRates should succeed")
+	t.Logf("GPU utilization: %d%%, sampling period: %dμs", utilization.Gpu, utilization.Memory)
+
+	// Test encoder utilization
+	var encoderUtil uint32
+	var encoderSamplingPeriodUs uint32
+	ret = CgoAPI.DeviceGetEncoderUtilization(device, &encoderUtil, &encoderSamplingPeriodUs)
+	require.Equal(t, SUCCESS, ret, "DeviceGetEncoderUtilization should succeed")
+	t.Logf("Encoder utilization: %d%%, sampling period: %dμs", encoderUtil, encoderSamplingPeriodUs)
+
+	// Test decoder utilization
+	var decoderUtil uint32
+	var decoderSamplingPeriodUs uint32
+	ret = CgoAPI.DeviceGetDecoderUtilization(device, &decoderUtil, &decoderSamplingPeriodUs)
+	require.Equal(t, SUCCESS, ret, "DeviceGetDecoderUtilization should succeed")
+	t.Logf("Decoder utilization: %d%%, sampling period: %dμs", decoderUtil, decoderSamplingPeriodUs)
+}
+
+// TestCgoAPIDeviceTemperature tests device temperature methods via CgoAPI.
+func TestCgoAPIDeviceTemperature(t *testing.T) {
+	requireLibNvidiaML(t)
+
+	// Initialize NVML
+	ret := Init()
+	require.Equal(t, SUCCESS, ret, "Init should succeed")
+	defer Shutdown()
+
+	var count uint32
+	ret = CgoAPI.DeviceGetCount(&count)
+	require.Equal(t, SUCCESS, ret, "DeviceGetCount should succeed")
+
+	if count == 0 {
+		t.Skip("No devices available for testing")
+	}
+
+	var device Device
+	ret = CgoAPI.DeviceGetHandleByIndex(0, &device)
+	require.Equal(t, SUCCESS, ret, "DeviceGetHandleByIndex should succeed")
+
+	// Test GPU temperature
+	var temp uint32
+	ret = CgoAPI.DeviceGetTemperature(device, TEMPERATURE_GPU, &temp)
+	require.Equal(t, SUCCESS, ret, "DeviceGetTemperature should succeed")
+	t.Logf("GPU temperature: %d°C", temp)
+
+	// Test memory temperature (using GPU temperature as fallback since TEMPERATURE_MEMORY doesn't exist)
+	var memTemp uint32
+	ret = CgoAPI.DeviceGetTemperature(device, TEMPERATURE_GPU, &memTemp)
+	require.Equal(t, SUCCESS, ret, "DeviceGetTemperature should succeed")
+	t.Logf("GPU temperature: %d°C", memTemp)
+}
+
+// TestCgoAPIDevicePower tests device power methods via CgoAPI.
+func TestCgoAPIDevicePower(t *testing.T) {
+	requireLibNvidiaML(t)
+
+	// Initialize NVML
+	ret := Init()
+	require.Equal(t, SUCCESS, ret, "Init should succeed")
+	defer Shutdown()
+
+	var count uint32
+	ret = CgoAPI.DeviceGetCount(&count)
+	require.Equal(t, SUCCESS, ret, "DeviceGetCount should succeed")
+
+	if count == 0 {
+		t.Skip("No devices available for testing")
+	}
+
+	var device Device
+	ret = CgoAPI.DeviceGetHandleByIndex(0, &device)
+	require.Equal(t, SUCCESS, ret, "DeviceGetHandleByIndex should succeed")
+
+	// Test power management mode
+	var mode EnableState
+	ret = CgoAPI.DeviceGetPowerManagementMode(device, &mode)
+	require.Equal(t, SUCCESS, ret, "DeviceGetPowerManagementMode should succeed")
+	t.Logf("Power management mode: %v", mode)
+
+	// Test power usage
+	var power uint32
+	ret = CgoAPI.DeviceGetPowerUsage(device, &power)
+	require.Equal(t, SUCCESS, ret, "DeviceGetPowerUsage should succeed")
+	t.Logf("Power usage: %d mW", power)
+
+	// Test power limit
+	var limit uint32
+	ret = CgoAPI.DeviceGetEnforcedPowerLimit(device, &limit)
+	require.Equal(t, SUCCESS, ret, "DeviceGetEnforcedPowerLimit should succeed")
+	t.Logf("Enforced power limit: %d mW", limit)
+}
+
+// TestCgoAPISystemMethods tests system-level CgoAPI methods.
+func TestCgoAPISystemMethods(t *testing.T) {
+	requireLibNvidiaML(t)
+
+	// Initialize NVML
+	ret := Init()
+	require.Equal(t, SUCCESS, ret, "Init should succeed")
+	defer Shutdown()
+
+	// Test driver version
+	var driverVersion [SYSTEM_DRIVER_VERSION_BUFFER_SIZE]byte
+	ret = CgoAPI.SystemGetDriverVersion(&driverVersion[0], SYSTEM_DRIVER_VERSION_BUFFER_SIZE)
+	require.Equal(t, SUCCESS, ret, "SystemGetDriverVersion should succeed")
+	t.Logf("Driver version: %s", string(driverVersion[:]))
+
+	// Test NVML version
+	var nvmlVersion [SYSTEM_NVML_VERSION_BUFFER_SIZE]byte
+	ret = CgoAPI.SystemGetNVMLVersion(&nvmlVersion[0], SYSTEM_NVML_VERSION_BUFFER_SIZE)
+	require.Equal(t, SUCCESS, ret, "SystemGetNVMLVersion should succeed")
+	t.Logf("NVML version: %s", string(nvmlVersion[:]))
+
+	// Test CUDA driver version
+	var cudaVersion int32
+	ret = CgoAPI.SystemGetCudaDriverVersion(&cudaVersion)
+	require.Equal(t, SUCCESS, ret, "SystemGetCudaDriverVersion should succeed")
+	t.Logf("CUDA driver version: %d", cudaVersion)
+}
+
+// TestCgoAPIDeviceTopology tests device topology methods via CgoAPI.
+func TestCgoAPIDeviceTopology(t *testing.T) {
+	requireLibNvidiaML(t)
+
+	// Initialize NVML
+	ret := Init()
+	require.Equal(t, SUCCESS, ret, "Init should succeed")
+	defer Shutdown()
+
+	var count uint32
+	ret = CgoAPI.DeviceGetCount(&count)
+	require.Equal(t, SUCCESS, ret, "DeviceGetCount should succeed")
+
+	if count < 2 {
+		t.Skip("Need at least 2 devices for topology tests")
+	}
+
+	var device1, device2 Device
+	ret = CgoAPI.DeviceGetHandleByIndex(0, &device1)
+	require.Equal(t, SUCCESS, ret, "DeviceGetHandleByIndex(0) should succeed")
+
+	ret = CgoAPI.DeviceGetHandleByIndex(1, &device2)
+	require.Equal(t, SUCCESS, ret, "DeviceGetHandleByIndex(1) should succeed")
+
+	// Test topology common ancestor
+	var pathInfo GpuTopologyLevel
+	ret = CgoAPI.DeviceGetTopologyCommonAncestor(device1, device2, &pathInfo)
+	require.Equal(t, SUCCESS, ret, "DeviceGetTopologyCommonAncestor should succeed")
+	t.Logf("Topology common ancestor: %v", pathInfo)
+
+	// Test P2P status
+	var p2pStatus GpuP2PStatus
+	ret = CgoAPI.DeviceGetP2PStatus(device1, device2, P2P_CAPS_INDEX_READ, &p2pStatus)
+	require.Equal(t, SUCCESS, ret, "DeviceGetP2PStatus should succeed")
+	t.Logf("P2P read status: %v", p2pStatus)
+
+	// Test if devices are on same board
+	var onSameBoard int32
+	ret = CgoAPI.DeviceOnSameBoard(device1, device2, &onSameBoard)
+	require.Equal(t, SUCCESS, ret, "DeviceOnSameBoard should succeed")
+	t.Logf("Devices on same board: %v", onSameBoard == 1)
+}
+
+// TestCgoAPIDeviceClockInfo tests device clock information methods via CgoAPI.
+func TestCgoAPIDeviceClockInfo(t *testing.T) {
+	requireLibNvidiaML(t)
+
+	// Initialize NVML
+	ret := Init()
+	require.Equal(t, SUCCESS, ret, "Init should succeed")
+	defer Shutdown()
+
+	var count uint32
+	ret = CgoAPI.DeviceGetCount(&count)
+	require.Equal(t, SUCCESS, ret, "DeviceGetCount should succeed")
+
+	if count == 0 {
+		t.Skip("No devices available for testing")
+	}
+
+	var device Device
+	ret = CgoAPI.DeviceGetHandleByIndex(0, &device)
+	require.Equal(t, SUCCESS, ret, "DeviceGetHandleByIndex should succeed")
+
+	// Test current clock frequencies
+	var clockFreqs DeviceCurrentClockFreqs
+	clockFreqs.Version = STRUCT_VERSION(clockFreqs, 1)
+	ret = CgoAPI.DeviceGetCurrentClockFreqs(device, &clockFreqs)
+	require.Equal(t, SUCCESS, ret, "DeviceGetCurrentClockFreqs should succeed")
+	t.Logf("Current clock freqs: Version=%d, Str=%s",
+		clockFreqs.Version, string(convertSlice[int8, uint8](clockFreqs.Str[:])))
+
+	// Test applications clock
+	var appClock uint32
+	ret = CgoAPI.DeviceGetApplicationsClock(device, CLOCK_SM, &appClock)
+	require.Equal(t, SUCCESS, ret, "DeviceGetApplicationsClock should succeed")
+	t.Logf("Applications SM clock: %d MHz", appClock)
+}
+
+// TestCgoAPI_DeviceHandleInterface verifies that a Device handle obtained via CgoAPI
+// can be used to call Device interface methods directly.
+func TestCgoAPI_DeviceHandleInterface(t *testing.T) {
+	requireLibNvidiaML(t)
+
+	// Initialize NVML
+	ret := Init()
+	require.Equal(t, SUCCESS, ret, "Init should succeed")
+	defer Shutdown()
+
+	var count uint32
+	ret = CgoAPI.DeviceGetCount(&count)
+	require.Equal(t, SUCCESS, ret, "DeviceGetCount should succeed")
+	if count == 0 {
+		t.Skip("No devices available for testing")
+	}
+
+	var device Device
+	ret = CgoAPI.DeviceGetHandleByIndex(0, &device)
+	require.Equal(t, SUCCESS, ret, "DeviceGetHandleByIndex should succeed")
+
+	// Now call Device interface methods directly
+	name, ret := device.GetName()
+	require.Equal(t, SUCCESS, ret, "Device.GetName should succeed")
+	t.Logf("Device.GetName: %s", name)
+
+	uuid, ret := device.GetUUID()
+	require.Equal(t, SUCCESS, ret, "Device.GetUUID should succeed")
+	t.Logf("Device.GetUUID: %s", uuid)
+
+	brand, ret := device.GetBrand()
+	require.Equal(t, SUCCESS, ret, "Device.GetBrand should succeed")
+	t.Logf("Device.GetBrand: %v", brand)
+
+	busType, ret := device.GetBusType()
+	require.Equal(t, SUCCESS, ret, "Device.GetBusType should succeed")
+	t.Logf("Device.GetBusType: %v", busType)
+}
+
+// requireConfComputeSupport checks if confidential compute is supported and skips the test if not.
+func requireConfComputeSupport(t *testing.T, device Device) {
+	var attestationReport ConfComputeGpuAttestationReport
+	// Initialize nonce to all zeros
+	for i := range attestationReport.Nonce {
+		attestationReport.Nonce[i] = 0
+	}
+
+	ret := CgoAPI.DeviceGetConfComputeGpuAttestationReport(device, &attestationReport)
+	if ret != SUCCESS {
+		t.Skipf("Confidential compute not supported on this system (returned: %v)", ret)
+	}
+}
+
+// TestCgoAPIDeviceConfComputeAttestation tests confidential compute GPU attestation report methods via CgoAPI.
+func TestCgoAPIDeviceConfComputeAttestation(t *testing.T) {
+	requireLibNvidiaML(t)
+
+	// Initialize NVML
+	ret := Init()
+	require.Equal(t, SUCCESS, ret, "Init should succeed")
+	defer Shutdown()
+
+	var count uint32
+	ret = CgoAPI.DeviceGetCount(&count)
+	require.Equal(t, SUCCESS, ret, "DeviceGetCount should succeed")
+
+	if count == 0 {
+		t.Skip("No devices available for testing")
+	}
+
+	var device Device
+	ret = CgoAPI.DeviceGetHandleByIndex(0, &device)
+	require.Equal(t, SUCCESS, ret, "DeviceGetHandleByIndex should succeed")
+
+	// Check if confidential compute is supported
+	requireConfComputeSupport(t, device)
+
+	// Test with zero nonce
+	var attestationReport ConfComputeGpuAttestationReport
+	// Initialize nonce to all zeros
+	for i := range attestationReport.Nonce {
+		attestationReport.Nonce[i] = 0
+	}
+
+	ret = CgoAPI.DeviceGetConfComputeGpuAttestationReport(device, &attestationReport)
+	require.Equal(t, SUCCESS, ret, "DeviceGetConfComputeGpuAttestationReport should succeed")
+	t.Logf("Attestation report: IsCecPresent=%d, AttestationSize=%d, CecSize=%d",
+		attestationReport.IsCecAttestationReportPresent,
+		attestationReport.AttestationReportSize,
+		attestationReport.CecAttestationReportSize)
+
+	// Test with pattern nonce
+	var attestationReport2 ConfComputeGpuAttestationReport
+	attestationReport2.Nonce = createPatternNonce(1, 1) // Creates [1, 2, 3, ..., 32]
+
+	ret = CgoAPI.DeviceGetConfComputeGpuAttestationReport(device, &attestationReport2)
+	require.Equal(t, SUCCESS, ret, "DeviceGetConfComputeGpuAttestationReport with pattern nonce should succeed")
+	t.Logf("Attestation report with pattern nonce: IsCecPresent=%d, AttestationSize=%d, CecSize=%d",
+		attestationReport2.IsCecAttestationReportPresent,
+		attestationReport2.AttestationReportSize,
+		attestationReport2.CecAttestationReportSize)
+
+	// Test with all-ones nonce
+	var attestationReport3 ConfComputeGpuAttestationReport
+	// Set nonce to all ones
+	for i := range attestationReport3.Nonce {
+		attestationReport3.Nonce[i] = 0xFF
+	}
+
+	ret = CgoAPI.DeviceGetConfComputeGpuAttestationReport(device, &attestationReport3)
+	require.Equal(t, SUCCESS, ret, "DeviceGetConfComputeGpuAttestationReport with all-ones nonce should succeed")
+	t.Logf("Attestation report with all-ones nonce: IsCecPresent=%d, AttestationSize=%d, CecSize=%d",
+		attestationReport3.IsCecAttestationReportPresent,
+		attestationReport3.AttestationReportSize,
+		attestationReport3.CecAttestationReportSize)
+
+	// Test nonce field access and modification using helper function
+	testNonce := createNonceFromString("test-nonce-32-bytes-long-string")
+
+	var attestationReport4 ConfComputeGpuAttestationReport
+	attestationReport4.Nonce = testNonce
+
+	// Verify nonce was set correctly
+	for i := 0; i < 32; i++ {
+		require.Equal(t, testNonce[i], attestationReport4.Nonce[i], "Nonce field should be set correctly")
+	}
+
+	ret = CgoAPI.DeviceGetConfComputeGpuAttestationReport(device, &attestationReport4)
+	require.Equal(t, SUCCESS, ret, "DeviceGetConfComputeGpuAttestationReport with string nonce should succeed")
+	t.Logf("Attestation report with string nonce: IsCecPresent=%d, AttestationSize=%d, CecSize=%d",
+		attestationReport4.IsCecAttestationReportPresent,
+		attestationReport4.AttestationReportSize,
+		attestationReport4.CecAttestationReportSize)
+
+	// Test with pseudo-random nonce
+	var attestationReport5 ConfComputeGpuAttestationReport
+	attestationReport5.Nonce = createRandomNonce(42) // Use seed 42 for reproducible results
+
+	ret = CgoAPI.DeviceGetConfComputeGpuAttestationReport(device, &attestationReport5)
+	require.Equal(t, SUCCESS, ret, "DeviceGetConfComputeGpuAttestationReport with random nonce should succeed")
+	t.Logf("Attestation report with random nonce: IsCecPresent=%d, AttestationSize=%d, CecSize=%d",
+		attestationReport5.IsCecAttestationReportPresent,
+		attestationReport5.AttestationReportSize,
+		attestationReport5.CecAttestationReportSize)
+}
+
+// createNonceFromString creates a 32-byte nonce from a string, padding with zeros if needed.
+func createNonceFromString(s string) [32]uint8 {
+	var nonce [32]uint8
+	copy(nonce[:], []byte(s))
+	return nonce
+}
+
+// createPatternNonce creates a 32-byte nonce with a repeating pattern.
+func createPatternNonce(start, step uint8) [32]uint8 {
+	var nonce [32]uint8
+	for i := range nonce {
+		nonce[i] = start + uint8(i)*step
+	}
+	return nonce
+}
+
+// createRandomNonce creates a 32-byte nonce with pseudo-random values.
+func createRandomNonce(seed int64) [32]uint8 {
+	var nonce [32]uint8
+	// Simple pseudo-random generation for testing
+	for i := range nonce {
+		nonce[i] = uint8((seed + int64(i)*7) % 256)
+	}
+	return nonce
+}

--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -15,47 +15,8 @@
 package nvml
 
 import (
-	"fmt"
-	"reflect"
 	"unsafe"
 )
-
-// nvmlDeviceHandle attempts to convert a device d to an nvmlDevice.
-// This is required for functions such as GetTopologyCommonAncestor which
-// accept Device arguments that need to be passed to internal nvml* functions
-// as nvmlDevice parameters.
-func nvmlDeviceHandle(d Device) nvmlDevice {
-	var helper func(val reflect.Value) nvmlDevice
-	helper = func(val reflect.Value) nvmlDevice {
-		if val.Kind() == reflect.Interface {
-			val = val.Elem()
-		}
-
-		if val.Kind() == reflect.Ptr {
-			val = val.Elem()
-		}
-
-		if val.Type() == reflect.TypeOf(nvmlDevice{}) {
-			return val.Interface().(nvmlDevice)
-		}
-
-		if val.Kind() != reflect.Struct {
-			panic(fmt.Errorf("unable to convert non-struct type %v to nvmlDevice", val.Kind()))
-		}
-
-		for i := 0; i < val.Type().NumField(); i++ {
-			if !val.Type().Field(i).Anonymous {
-				continue
-			}
-			if !val.Field(i).Type().Implements(reflect.TypeOf((*Device)(nil)).Elem()) {
-				continue
-			}
-			return helper(val.Field(i))
-		}
-		panic(fmt.Errorf("unable to convert %T to nvmlDevice", d))
-	}
-	return helper(reflect.ValueOf(d))
-}
 
 // EccBitType
 type EccBitType = MemoryErrorType

--- a/pkg/nvml/lib.go
+++ b/pkg/nvml/lib.go
@@ -144,7 +144,7 @@ func (l *library) close() (rerr error) {
 	return nil
 }
 
-// Default all versioned APIs to v1 (to infer the types)
+// BEGIN_UNVERSIONED_FUNCTIONS
 var nvmlInit = nvmlInit_v1
 var nvmlDeviceGetPciInfo = nvmlDeviceGetPciInfo_v1
 var nvmlDeviceGetCount = nvmlDeviceGetCount_v1
@@ -156,14 +156,21 @@ var nvmlDeviceGetGridLicensableFeatures = nvmlDeviceGetGridLicensableFeatures_v1
 var nvmlEventSetWait = nvmlEventSetWait_v1
 var nvmlDeviceGetAttributes = nvmlDeviceGetAttributes_v1
 var nvmlComputeInstanceGetInfo = nvmlComputeInstanceGetInfo_v1
+var nvmlDeviceGetComputeRunningProcesses = nvmlDeviceGetComputeRunningProcesses_v3
 var deviceGetComputeRunningProcesses = deviceGetComputeRunningProcesses_v1
+var nvmlDeviceGetGraphicsRunningProcesses = nvmlDeviceGetGraphicsRunningProcesses_v3
 var deviceGetGraphicsRunningProcesses = deviceGetGraphicsRunningProcesses_v1
+var nvmlDeviceGetMPSComputeRunningProcesses = nvmlDeviceGetMPSComputeRunningProcesses_v3
 var deviceGetMPSComputeRunningProcesses = deviceGetMPSComputeRunningProcesses_v1
+var nvmlGetBlacklistDeviceCount = nvmlGetExcludedDeviceCount
 var GetBlacklistDeviceCount = GetExcludedDeviceCount
+var nvmlGetBlacklistDeviceInfoByIndex = nvmlGetExcludedDeviceInfoByIndex
 var GetBlacklistDeviceInfoByIndex = GetExcludedDeviceInfoByIndex
 var nvmlDeviceGetGpuInstancePossiblePlacements = nvmlDeviceGetGpuInstancePossiblePlacements_v1
 var nvmlVgpuInstanceGetLicenseInfo = nvmlVgpuInstanceGetLicenseInfo_v1
 var nvmlDeviceGetDriverModel = nvmlDeviceGetDriverModel_v1
+
+// END_UNVERSIONED_FUNCTIONS
 
 // BlacklistDeviceInfo was replaced by ExcludedDeviceInfo
 type BlacklistDeviceInfo = ExcludedDeviceInfo

--- a/pkg/nvml/zz_generated.api.go
+++ b/pkg/nvml/zz_generated.api.go
@@ -18,6 +18,11 @@
 
 package nvml
 
+import (
+	"fmt"
+	"reflect"
+)
+
 // The variables below represent package level methods from the library type.
 var (
 	ComputeInstanceDestroy                           = libnvml.ComputeInstanceDestroy
@@ -1127,4 +1132,244 @@ type VgpuTypeId interface {
 	GetNumDisplayHeads() (int, Return)
 	GetResolution(int) (uint32, uint32, Return)
 	GetSupportedPlacements(Device) (VgpuPlacementList, Return)
+}
+
+// nvmlDeviceHandle attempts to convert a Device to an nvmlDevice.
+func nvmlDeviceHandle(device Device) nvmlDevice {
+	var helper func(val reflect.Value) nvmlDevice
+	helper = func(val reflect.Value) nvmlDevice {
+		if val.Kind() == reflect.Interface {
+			val = val.Elem()
+		}
+		if val.Kind() == reflect.Ptr {
+			val = val.Elem()
+		}
+		if val.Type() == reflect.TypeOf((*nvmlDevice)(nil)).Elem() {
+			return val.Interface().(nvmlDevice)
+		}
+		if val.Kind() != reflect.Struct {
+			panic(fmt.Errorf("unable to convert non-struct type %v to nvmlDevice", val.Kind()))
+		}
+		for i := 0; i < val.Type().NumField(); i++ {
+			if !val.Type().Field(i).Anonymous {
+				continue
+			}
+			if !val.Field(i).Type().Implements(reflect.TypeOf((*Device)(nil)).Elem()) {
+				continue
+			}
+			return helper(val.Field(i))
+		}
+		panic(fmt.Errorf("unable to convert %T to nvmlDevice", device))
+	}
+	return helper(reflect.ValueOf(device))
+}
+
+// nvmlGpuInstanceHandle attempts to convert a GpuInstance to an nvmlGpuInstance.
+func nvmlGpuInstanceHandle(gpuInstance GpuInstance) nvmlGpuInstance {
+	var helper func(val reflect.Value) nvmlGpuInstance
+	helper = func(val reflect.Value) nvmlGpuInstance {
+		if val.Kind() == reflect.Interface {
+			val = val.Elem()
+		}
+		if val.Kind() == reflect.Ptr {
+			val = val.Elem()
+		}
+		if val.Type() == reflect.TypeOf((*nvmlGpuInstance)(nil)).Elem() {
+			return val.Interface().(nvmlGpuInstance)
+		}
+		if val.Kind() != reflect.Struct {
+			panic(fmt.Errorf("unable to convert non-struct type %v to nvmlGpuInstance", val.Kind()))
+		}
+		for i := 0; i < val.Type().NumField(); i++ {
+			if !val.Type().Field(i).Anonymous {
+				continue
+			}
+			if !val.Field(i).Type().Implements(reflect.TypeOf((*GpuInstance)(nil)).Elem()) {
+				continue
+			}
+			return helper(val.Field(i))
+		}
+		panic(fmt.Errorf("unable to convert %T to nvmlGpuInstance", gpuInstance))
+	}
+	return helper(reflect.ValueOf(gpuInstance))
+}
+
+// nvmlComputeInstanceHandle attempts to convert a ComputeInstance to an nvmlComputeInstance.
+func nvmlComputeInstanceHandle(computeInstance ComputeInstance) nvmlComputeInstance {
+	var helper func(val reflect.Value) nvmlComputeInstance
+	helper = func(val reflect.Value) nvmlComputeInstance {
+		if val.Kind() == reflect.Interface {
+			val = val.Elem()
+		}
+		if val.Kind() == reflect.Ptr {
+			val = val.Elem()
+		}
+		if val.Type() == reflect.TypeOf((*nvmlComputeInstance)(nil)).Elem() {
+			return val.Interface().(nvmlComputeInstance)
+		}
+		if val.Kind() != reflect.Struct {
+			panic(fmt.Errorf("unable to convert non-struct type %v to nvmlComputeInstance", val.Kind()))
+		}
+		for i := 0; i < val.Type().NumField(); i++ {
+			if !val.Type().Field(i).Anonymous {
+				continue
+			}
+			if !val.Field(i).Type().Implements(reflect.TypeOf((*ComputeInstance)(nil)).Elem()) {
+				continue
+			}
+			return helper(val.Field(i))
+		}
+		panic(fmt.Errorf("unable to convert %T to nvmlComputeInstance", computeInstance))
+	}
+	return helper(reflect.ValueOf(computeInstance))
+}
+
+// nvmlEventSetHandle attempts to convert a EventSet to an nvmlEventSet.
+func nvmlEventSetHandle(eventSet EventSet) nvmlEventSet {
+	var helper func(val reflect.Value) nvmlEventSet
+	helper = func(val reflect.Value) nvmlEventSet {
+		if val.Kind() == reflect.Interface {
+			val = val.Elem()
+		}
+		if val.Kind() == reflect.Ptr {
+			val = val.Elem()
+		}
+		if val.Type() == reflect.TypeOf((*nvmlEventSet)(nil)).Elem() {
+			return val.Interface().(nvmlEventSet)
+		}
+		if val.Kind() != reflect.Struct {
+			panic(fmt.Errorf("unable to convert non-struct type %v to nvmlEventSet", val.Kind()))
+		}
+		for i := 0; i < val.Type().NumField(); i++ {
+			if !val.Type().Field(i).Anonymous {
+				continue
+			}
+			if !val.Field(i).Type().Implements(reflect.TypeOf((*EventSet)(nil)).Elem()) {
+				continue
+			}
+			return helper(val.Field(i))
+		}
+		panic(fmt.Errorf("unable to convert %T to nvmlEventSet", eventSet))
+	}
+	return helper(reflect.ValueOf(eventSet))
+}
+
+// nvmlGpmSampleHandle attempts to convert a GpmSample to an nvmlGpmSample.
+func nvmlGpmSampleHandle(gpmSample GpmSample) nvmlGpmSample {
+	var helper func(val reflect.Value) nvmlGpmSample
+	helper = func(val reflect.Value) nvmlGpmSample {
+		if val.Kind() == reflect.Interface {
+			val = val.Elem()
+		}
+		if val.Kind() == reflect.Ptr {
+			val = val.Elem()
+		}
+		if val.Type() == reflect.TypeOf((*nvmlGpmSample)(nil)).Elem() {
+			return val.Interface().(nvmlGpmSample)
+		}
+		if val.Kind() != reflect.Struct {
+			panic(fmt.Errorf("unable to convert non-struct type %v to nvmlGpmSample", val.Kind()))
+		}
+		for i := 0; i < val.Type().NumField(); i++ {
+			if !val.Type().Field(i).Anonymous {
+				continue
+			}
+			if !val.Field(i).Type().Implements(reflect.TypeOf((*GpmSample)(nil)).Elem()) {
+				continue
+			}
+			return helper(val.Field(i))
+		}
+		panic(fmt.Errorf("unable to convert %T to nvmlGpmSample", gpmSample))
+	}
+	return helper(reflect.ValueOf(gpmSample))
+}
+
+// nvmlUnitHandle attempts to convert a Unit to an nvmlUnit.
+func nvmlUnitHandle(unit Unit) nvmlUnit {
+	var helper func(val reflect.Value) nvmlUnit
+	helper = func(val reflect.Value) nvmlUnit {
+		if val.Kind() == reflect.Interface {
+			val = val.Elem()
+		}
+		if val.Kind() == reflect.Ptr {
+			val = val.Elem()
+		}
+		if val.Type() == reflect.TypeOf((*nvmlUnit)(nil)).Elem() {
+			return val.Interface().(nvmlUnit)
+		}
+		if val.Kind() != reflect.Struct {
+			panic(fmt.Errorf("unable to convert non-struct type %v to nvmlUnit", val.Kind()))
+		}
+		for i := 0; i < val.Type().NumField(); i++ {
+			if !val.Type().Field(i).Anonymous {
+				continue
+			}
+			if !val.Field(i).Type().Implements(reflect.TypeOf((*Unit)(nil)).Elem()) {
+				continue
+			}
+			return helper(val.Field(i))
+		}
+		panic(fmt.Errorf("unable to convert %T to nvmlUnit", unit))
+	}
+	return helper(reflect.ValueOf(unit))
+}
+
+// nvmlVgpuInstanceHandle attempts to convert a VgpuInstance to an nvmlVgpuInstance.
+func nvmlVgpuInstanceHandle(vgpuInstance VgpuInstance) nvmlVgpuInstance {
+	var helper func(val reflect.Value) nvmlVgpuInstance
+	helper = func(val reflect.Value) nvmlVgpuInstance {
+		if val.Kind() == reflect.Interface {
+			val = val.Elem()
+		}
+		if val.Kind() == reflect.Ptr {
+			val = val.Elem()
+		}
+		if val.Type() == reflect.TypeOf((*nvmlVgpuInstance)(nil)).Elem() {
+			return val.Interface().(nvmlVgpuInstance)
+		}
+		if val.Kind() != reflect.Struct {
+			panic(fmt.Errorf("unable to convert non-struct type %v to nvmlVgpuInstance", val.Kind()))
+		}
+		for i := 0; i < val.Type().NumField(); i++ {
+			if !val.Type().Field(i).Anonymous {
+				continue
+			}
+			if !val.Field(i).Type().Implements(reflect.TypeOf((*VgpuInstance)(nil)).Elem()) {
+				continue
+			}
+			return helper(val.Field(i))
+		}
+		panic(fmt.Errorf("unable to convert %T to nvmlVgpuInstance", vgpuInstance))
+	}
+	return helper(reflect.ValueOf(vgpuInstance))
+}
+
+// nvmlVgpuTypeIdHandle attempts to convert a VgpuTypeId to an nvmlVgpuTypeId.
+func nvmlVgpuTypeIdHandle(vgpuTypeId VgpuTypeId) nvmlVgpuTypeId {
+	var helper func(val reflect.Value) nvmlVgpuTypeId
+	helper = func(val reflect.Value) nvmlVgpuTypeId {
+		if val.Kind() == reflect.Interface {
+			val = val.Elem()
+		}
+		if val.Kind() == reflect.Ptr {
+			val = val.Elem()
+		}
+		if val.Type() == reflect.TypeOf((*nvmlVgpuTypeId)(nil)).Elem() {
+			return val.Interface().(nvmlVgpuTypeId)
+		}
+		if val.Kind() != reflect.Struct {
+			panic(fmt.Errorf("unable to convert non-struct type %v to nvmlVgpuTypeId", val.Kind()))
+		}
+		for i := 0; i < val.Type().NumField(); i++ {
+			if !val.Type().Field(i).Anonymous {
+				continue
+			}
+			if !val.Field(i).Type().Implements(reflect.TypeOf((*VgpuTypeId)(nil)).Elem()) {
+				continue
+			}
+			return helper(val.Field(i))
+		}
+		panic(fmt.Errorf("unable to convert %T to nvmlVgpuTypeId", vgpuTypeId))
+	}
+	return helper(reflect.ValueOf(vgpuTypeId))
 }

--- a/pkg/nvml/zz_generated.cgoapi.go
+++ b/pkg/nvml/zz_generated.cgoapi.go
@@ -1,0 +1,2120 @@
+/**
+# Copyright 2025 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+// Generated Code; DO NOT EDIT.
+
+package nvml
+
+// CgoAPI is a global variable providing direct calls to the cgo API rather than the standard wrappers
+var CgoAPI = cgoapi{}
+
+type cgoapi struct{}
+
+func (cgoapi) ComputeInstanceDestroy(computeinstance ComputeInstance) Return {
+	ret := nvmlComputeInstanceDestroy(nvmlComputeInstanceHandle(computeinstance))
+	return ret
+}
+
+func (cgoapi) ComputeInstanceGetInfo(computeinstance ComputeInstance, info *ComputeInstanceInfo) Return {
+	var nvmlInfo nvmlComputeInstanceInfo
+	ret := nvmlComputeInstanceGetInfo(nvmlComputeInstanceHandle(computeinstance), &nvmlInfo)
+	return ret
+}
+
+func (cgoapi) ComputeInstanceGetInfo_v1(computeinstance ComputeInstance, info *ComputeInstanceInfo) Return {
+	var nvmlInfo nvmlComputeInstanceInfo
+	ret := nvmlComputeInstanceGetInfo_v1(nvmlComputeInstanceHandle(computeinstance), &nvmlInfo)
+	return ret
+}
+
+func (cgoapi) ComputeInstanceGetInfo_v2(computeinstance ComputeInstance, info *ComputeInstanceInfo) Return {
+	var nvmlInfo nvmlComputeInstanceInfo
+	ret := nvmlComputeInstanceGetInfo_v2(nvmlComputeInstanceHandle(computeinstance), &nvmlInfo)
+	return ret
+}
+
+func (cgoapi) DeviceClearAccountingPids(device Device) Return {
+	ret := nvmlDeviceClearAccountingPids(nvmlDeviceHandle(device))
+	return ret
+}
+
+func (cgoapi) DeviceClearCpuAffinity(device Device) Return {
+	ret := nvmlDeviceClearCpuAffinity(nvmlDeviceHandle(device))
+	return ret
+}
+
+func (cgoapi) DeviceClearEccErrorCounts(device Device, countertype EccCounterType) Return {
+	ret := nvmlDeviceClearEccErrorCounts(nvmlDeviceHandle(device), countertype)
+	return ret
+}
+
+func (cgoapi) DeviceClearFieldValues(device Device, valuescount int32, values *FieldValue) Return {
+	ret := nvmlDeviceClearFieldValues(nvmlDeviceHandle(device), valuescount, values)
+	return ret
+}
+
+func (cgoapi) DeviceCreateGpuInstance(device Device, profileid uint32, gpuinstance *GpuInstance) Return {
+	var nvmlGpuinstance nvmlGpuInstance
+	ret := nvmlDeviceCreateGpuInstance(nvmlDeviceHandle(device), profileid, &nvmlGpuinstance)
+	*gpuinstance = GpuInstance(nvmlGpuinstance)
+	return ret
+}
+
+func (cgoapi) DeviceCreateGpuInstanceWithPlacement(device Device, profileid uint32, placement *GpuInstancePlacement, gpuinstance *GpuInstance) Return {
+	var nvmlGpuinstance nvmlGpuInstance
+	ret := nvmlDeviceCreateGpuInstanceWithPlacement(nvmlDeviceHandle(device), profileid, placement, &nvmlGpuinstance)
+	*gpuinstance = GpuInstance(nvmlGpuinstance)
+	return ret
+}
+
+func (cgoapi) DeviceDiscoverGpus(pciinfo *PciInfo) Return {
+	ret := nvmlDeviceDiscoverGpus(pciinfo)
+	return ret
+}
+
+func (cgoapi) DeviceFreezeNvLinkUtilizationCounter(device Device, link uint32, counter uint32, freeze EnableState) Return {
+	ret := nvmlDeviceFreezeNvLinkUtilizationCounter(nvmlDeviceHandle(device), link, counter, freeze)
+	return ret
+}
+
+func (cgoapi) DeviceGetAPIRestriction(device Device, apitype RestrictedAPI, isrestricted *EnableState) Return {
+	ret := nvmlDeviceGetAPIRestriction(nvmlDeviceHandle(device), apitype, isrestricted)
+	return ret
+}
+
+func (cgoapi) DeviceGetAccountingBufferSize(device Device, buffersize *uint32) Return {
+	ret := nvmlDeviceGetAccountingBufferSize(nvmlDeviceHandle(device), buffersize)
+	return ret
+}
+
+func (cgoapi) DeviceGetAccountingMode(device Device, mode *EnableState) Return {
+	ret := nvmlDeviceGetAccountingMode(nvmlDeviceHandle(device), mode)
+	return ret
+}
+
+func (cgoapi) DeviceGetAccountingPids(device Device, count *uint32, pids *uint32) Return {
+	ret := nvmlDeviceGetAccountingPids(nvmlDeviceHandle(device), count, pids)
+	return ret
+}
+
+func (cgoapi) DeviceGetAccountingStats(device Device, pid uint32, stats *AccountingStats) Return {
+	ret := nvmlDeviceGetAccountingStats(nvmlDeviceHandle(device), pid, stats)
+	return ret
+}
+
+func (cgoapi) DeviceGetActiveVgpus(device Device, vgpucount *uint32, vgpuinstances *VgpuInstance) Return {
+	var nvmlVgpuinstances nvmlVgpuInstance
+	ret := nvmlDeviceGetActiveVgpus(nvmlDeviceHandle(device), vgpucount, &nvmlVgpuinstances)
+	*vgpuinstances = VgpuInstance(nvmlVgpuinstances)
+	return ret
+}
+
+func (cgoapi) DeviceGetAdaptiveClockInfoStatus(device Device, adaptiveclockstatus *uint32) Return {
+	ret := nvmlDeviceGetAdaptiveClockInfoStatus(nvmlDeviceHandle(device), adaptiveclockstatus)
+	return ret
+}
+
+func (cgoapi) DeviceGetApplicationsClock(device Device, clocktype ClockType, clockmhz *uint32) Return {
+	ret := nvmlDeviceGetApplicationsClock(nvmlDeviceHandle(device), clocktype, clockmhz)
+	return ret
+}
+
+func (cgoapi) DeviceGetArchitecture(device Device, arch *DeviceArchitecture) Return {
+	ret := nvmlDeviceGetArchitecture(nvmlDeviceHandle(device), arch)
+	return ret
+}
+
+func (cgoapi) DeviceGetAttributes(device Device, attributes *DeviceAttributes) Return {
+	ret := nvmlDeviceGetAttributes(nvmlDeviceHandle(device), attributes)
+	return ret
+}
+
+func (cgoapi) DeviceGetAttributes_v1(device Device, attributes *DeviceAttributes) Return {
+	ret := nvmlDeviceGetAttributes_v1(nvmlDeviceHandle(device), attributes)
+	return ret
+}
+
+func (cgoapi) DeviceGetAttributes_v2(device Device, attributes *DeviceAttributes) Return {
+	ret := nvmlDeviceGetAttributes_v2(nvmlDeviceHandle(device), attributes)
+	return ret
+}
+
+func (cgoapi) DeviceGetAutoBoostedClocksEnabled(device Device, isenabled *EnableState, defaultisenabled *EnableState) Return {
+	ret := nvmlDeviceGetAutoBoostedClocksEnabled(nvmlDeviceHandle(device), isenabled, defaultisenabled)
+	return ret
+}
+
+func (cgoapi) DeviceGetBAR1MemoryInfo(device Device, bar1memory *BAR1Memory) Return {
+	ret := nvmlDeviceGetBAR1MemoryInfo(nvmlDeviceHandle(device), bar1memory)
+	return ret
+}
+
+func (cgoapi) DeviceGetBoardId(device Device, boardid *uint32) Return {
+	ret := nvmlDeviceGetBoardId(nvmlDeviceHandle(device), boardid)
+	return ret
+}
+
+func (cgoapi) DeviceGetBoardPartNumber(device Device, partnumber *byte, length uint32) Return {
+	ret := nvmlDeviceGetBoardPartNumber(nvmlDeviceHandle(device), partnumber, length)
+	return ret
+}
+
+func (cgoapi) DeviceGetBrand(device Device, _type *BrandType) Return {
+	ret := nvmlDeviceGetBrand(nvmlDeviceHandle(device), _type)
+	return ret
+}
+
+func (cgoapi) DeviceGetBridgeChipInfo(device Device, bridgehierarchy *BridgeChipHierarchy) Return {
+	ret := nvmlDeviceGetBridgeChipInfo(nvmlDeviceHandle(device), bridgehierarchy)
+	return ret
+}
+
+func (cgoapi) DeviceGetBusType(device Device, _type *BusType) Return {
+	ret := nvmlDeviceGetBusType(nvmlDeviceHandle(device), _type)
+	return ret
+}
+
+func (cgoapi) DeviceGetC2cModeInfoV(device Device, c2cmodeinfo *C2cModeInfo_v1) Return {
+	ret := nvmlDeviceGetC2cModeInfoV(nvmlDeviceHandle(device), c2cmodeinfo)
+	return ret
+}
+
+func (cgoapi) DeviceGetCapabilities(device Device, caps *DeviceCapabilities) Return {
+	ret := nvmlDeviceGetCapabilities(nvmlDeviceHandle(device), caps)
+	return ret
+}
+
+func (cgoapi) DeviceGetClkMonStatus(device Device, status *ClkMonStatus) Return {
+	ret := nvmlDeviceGetClkMonStatus(nvmlDeviceHandle(device), status)
+	return ret
+}
+
+func (cgoapi) DeviceGetClock(device Device, clocktype ClockType, clockid ClockId, clockmhz *uint32) Return {
+	ret := nvmlDeviceGetClock(nvmlDeviceHandle(device), clocktype, clockid, clockmhz)
+	return ret
+}
+
+func (cgoapi) DeviceGetClockInfo(device Device, _type ClockType, clock *uint32) Return {
+	ret := nvmlDeviceGetClockInfo(nvmlDeviceHandle(device), _type, clock)
+	return ret
+}
+
+func (cgoapi) DeviceGetClockOffsets(device Device, info *ClockOffset) Return {
+	ret := nvmlDeviceGetClockOffsets(nvmlDeviceHandle(device), info)
+	return ret
+}
+
+func (cgoapi) DeviceGetComputeInstanceId(device Device, id *uint32) Return {
+	ret := nvmlDeviceGetComputeInstanceId(nvmlDeviceHandle(device), id)
+	return ret
+}
+
+func (cgoapi) DeviceGetComputeMode(device Device, mode *ComputeMode) Return {
+	ret := nvmlDeviceGetComputeMode(nvmlDeviceHandle(device), mode)
+	return ret
+}
+
+func (cgoapi) DeviceGetComputeRunningProcesses(device Device, infocount *uint32, infos *ProcessInfo) Return {
+	ret := nvmlDeviceGetComputeRunningProcesses(nvmlDeviceHandle(device), infocount, infos)
+	return ret
+}
+
+func (cgoapi) DeviceGetComputeRunningProcesses_v1(device Device, infocount *uint32, infos *ProcessInfo_v1) Return {
+	ret := nvmlDeviceGetComputeRunningProcesses_v1(nvmlDeviceHandle(device), infocount, infos)
+	return ret
+}
+
+func (cgoapi) DeviceGetComputeRunningProcesses_v2(device Device, infocount *uint32, infos *ProcessInfo_v2) Return {
+	ret := nvmlDeviceGetComputeRunningProcesses_v2(nvmlDeviceHandle(device), infocount, infos)
+	return ret
+}
+
+func (cgoapi) DeviceGetComputeRunningProcesses_v3(device Device, infocount *uint32, infos *ProcessInfo) Return {
+	ret := nvmlDeviceGetComputeRunningProcesses_v3(nvmlDeviceHandle(device), infocount, infos)
+	return ret
+}
+
+func (cgoapi) DeviceGetConfComputeGpuAttestationReport(device Device, gpuatstreport *ConfComputeGpuAttestationReport) Return {
+	ret := nvmlDeviceGetConfComputeGpuAttestationReport(nvmlDeviceHandle(device), gpuatstreport)
+	return ret
+}
+
+func (cgoapi) DeviceGetConfComputeGpuCertificate(device Device, gpucert *ConfComputeGpuCertificate) Return {
+	ret := nvmlDeviceGetConfComputeGpuCertificate(nvmlDeviceHandle(device), gpucert)
+	return ret
+}
+
+func (cgoapi) DeviceGetConfComputeMemSizeInfo(device Device, meminfo *ConfComputeMemSizeInfo) Return {
+	ret := nvmlDeviceGetConfComputeMemSizeInfo(nvmlDeviceHandle(device), meminfo)
+	return ret
+}
+
+func (cgoapi) DeviceGetConfComputeProtectedMemoryUsage(device Device, memory *Memory) Return {
+	ret := nvmlDeviceGetConfComputeProtectedMemoryUsage(nvmlDeviceHandle(device), memory)
+	return ret
+}
+
+func (cgoapi) DeviceGetCoolerInfo(device Device, coolerinfo *CoolerInfo) Return {
+	ret := nvmlDeviceGetCoolerInfo(nvmlDeviceHandle(device), coolerinfo)
+	return ret
+}
+
+func (cgoapi) DeviceGetCount(devicecount *uint32) Return {
+	ret := nvmlDeviceGetCount(devicecount)
+	return ret
+}
+
+func (cgoapi) DeviceGetCount_v1(devicecount *uint32) Return {
+	ret := nvmlDeviceGetCount_v1(devicecount)
+	return ret
+}
+
+func (cgoapi) DeviceGetCount_v2(devicecount *uint32) Return {
+	ret := nvmlDeviceGetCount_v2(devicecount)
+	return ret
+}
+
+func (cgoapi) DeviceGetCpuAffinity(device Device, cpusetsize uint32, cpuset *uint) Return {
+	ret := nvmlDeviceGetCpuAffinity(nvmlDeviceHandle(device), cpusetsize, cpuset)
+	return ret
+}
+
+func (cgoapi) DeviceGetCpuAffinityWithinScope(device Device, cpusetsize uint32, cpuset *uint, scope AffinityScope) Return {
+	ret := nvmlDeviceGetCpuAffinityWithinScope(nvmlDeviceHandle(device), cpusetsize, cpuset, scope)
+	return ret
+}
+
+func (cgoapi) DeviceGetCreatableVgpus(device Device, vgpucount *uint32, vgputypeids *VgpuTypeId) Return {
+	var nvmlVgputypeids nvmlVgpuTypeId
+	ret := nvmlDeviceGetCreatableVgpus(nvmlDeviceHandle(device), vgpucount, &nvmlVgputypeids)
+	*vgputypeids = VgpuTypeId(nvmlVgputypeids)
+	return ret
+}
+
+func (cgoapi) DeviceGetCudaComputeCapability(device Device, major *int32, minor *int32) Return {
+	ret := nvmlDeviceGetCudaComputeCapability(nvmlDeviceHandle(device), major, minor)
+	return ret
+}
+
+func (cgoapi) DeviceGetCurrPcieLinkGeneration(device Device, currlinkgen *uint32) Return {
+	ret := nvmlDeviceGetCurrPcieLinkGeneration(nvmlDeviceHandle(device), currlinkgen)
+	return ret
+}
+
+func (cgoapi) DeviceGetCurrPcieLinkWidth(device Device, currlinkwidth *uint32) Return {
+	ret := nvmlDeviceGetCurrPcieLinkWidth(nvmlDeviceHandle(device), currlinkwidth)
+	return ret
+}
+
+func (cgoapi) DeviceGetCurrentClockFreqs(device Device, currentclockfreqs *DeviceCurrentClockFreqs) Return {
+	ret := nvmlDeviceGetCurrentClockFreqs(nvmlDeviceHandle(device), currentclockfreqs)
+	return ret
+}
+
+func (cgoapi) DeviceGetCurrentClocksEventReasons(device Device, clockseventreasons *uint64) Return {
+	ret := nvmlDeviceGetCurrentClocksEventReasons(nvmlDeviceHandle(device), clockseventreasons)
+	return ret
+}
+
+func (cgoapi) DeviceGetCurrentClocksThrottleReasons(device Device, clocksthrottlereasons *uint64) Return {
+	ret := nvmlDeviceGetCurrentClocksThrottleReasons(nvmlDeviceHandle(device), clocksthrottlereasons)
+	return ret
+}
+
+func (cgoapi) DeviceGetDecoderUtilization(device Device, utilization *uint32, samplingperiodus *uint32) Return {
+	ret := nvmlDeviceGetDecoderUtilization(nvmlDeviceHandle(device), utilization, samplingperiodus)
+	return ret
+}
+
+func (cgoapi) DeviceGetDefaultApplicationsClock(device Device, clocktype ClockType, clockmhz *uint32) Return {
+	ret := nvmlDeviceGetDefaultApplicationsClock(nvmlDeviceHandle(device), clocktype, clockmhz)
+	return ret
+}
+
+func (cgoapi) DeviceGetDefaultEccMode(device Device, defaultmode *EnableState) Return {
+	ret := nvmlDeviceGetDefaultEccMode(nvmlDeviceHandle(device), defaultmode)
+	return ret
+}
+
+func (cgoapi) DeviceGetDetailedEccErrors(device Device, errortype MemoryErrorType, countertype EccCounterType, ecccounts *EccErrorCounts) Return {
+	ret := nvmlDeviceGetDetailedEccErrors(nvmlDeviceHandle(device), errortype, countertype, ecccounts)
+	return ret
+}
+
+func (cgoapi) DeviceGetDeviceHandleFromMigDeviceHandle(migdevice Device, device *Device) Return {
+	var nvmlDevice nvmlDevice
+	ret := nvmlDeviceGetDeviceHandleFromMigDeviceHandle(nvmlDeviceHandle(migdevice), &nvmlDevice)
+	*device = Device(nvmlDevice)
+	return ret
+}
+
+func (cgoapi) DeviceGetDisplayActive(device Device, isactive *EnableState) Return {
+	ret := nvmlDeviceGetDisplayActive(nvmlDeviceHandle(device), isactive)
+	return ret
+}
+
+func (cgoapi) DeviceGetDisplayMode(device Device, display *EnableState) Return {
+	ret := nvmlDeviceGetDisplayMode(nvmlDeviceHandle(device), display)
+	return ret
+}
+
+func (cgoapi) DeviceGetDramEncryptionMode(device Device, current *DramEncryptionInfo, pending *DramEncryptionInfo) Return {
+	ret := nvmlDeviceGetDramEncryptionMode(nvmlDeviceHandle(device), current, pending)
+	return ret
+}
+
+func (cgoapi) DeviceGetDriverModel(device Device, current *DriverModel, pending *DriverModel) Return {
+	ret := nvmlDeviceGetDriverModel(nvmlDeviceHandle(device), current, pending)
+	return ret
+}
+
+func (cgoapi) DeviceGetDriverModel_v1(device Device, current *DriverModel, pending *DriverModel) Return {
+	ret := nvmlDeviceGetDriverModel_v1(nvmlDeviceHandle(device), current, pending)
+	return ret
+}
+
+func (cgoapi) DeviceGetDriverModel_v2(device Device, current *DriverModel, pending *DriverModel) Return {
+	ret := nvmlDeviceGetDriverModel_v2(nvmlDeviceHandle(device), current, pending)
+	return ret
+}
+
+func (cgoapi) DeviceGetDynamicPstatesInfo(device Device, pdynamicpstatesinfo *GpuDynamicPstatesInfo) Return {
+	ret := nvmlDeviceGetDynamicPstatesInfo(nvmlDeviceHandle(device), pdynamicpstatesinfo)
+	return ret
+}
+
+func (cgoapi) DeviceGetEccMode(device Device, current *EnableState, pending *EnableState) Return {
+	ret := nvmlDeviceGetEccMode(nvmlDeviceHandle(device), current, pending)
+	return ret
+}
+
+func (cgoapi) DeviceGetEncoderCapacity(device Device, encoderquerytype EncoderType, encodercapacity *uint32) Return {
+	ret := nvmlDeviceGetEncoderCapacity(nvmlDeviceHandle(device), encoderquerytype, encodercapacity)
+	return ret
+}
+
+func (cgoapi) DeviceGetEncoderSessions(device Device, sessioncount *uint32, sessioninfos *EncoderSessionInfo) Return {
+	ret := nvmlDeviceGetEncoderSessions(nvmlDeviceHandle(device), sessioncount, sessioninfos)
+	return ret
+}
+
+func (cgoapi) DeviceGetEncoderStats(device Device, sessioncount *uint32, averagefps *uint32, averagelatency *uint32) Return {
+	ret := nvmlDeviceGetEncoderStats(nvmlDeviceHandle(device), sessioncount, averagefps, averagelatency)
+	return ret
+}
+
+func (cgoapi) DeviceGetEncoderUtilization(device Device, utilization *uint32, samplingperiodus *uint32) Return {
+	ret := nvmlDeviceGetEncoderUtilization(nvmlDeviceHandle(device), utilization, samplingperiodus)
+	return ret
+}
+
+func (cgoapi) DeviceGetEnforcedPowerLimit(device Device, limit *uint32) Return {
+	ret := nvmlDeviceGetEnforcedPowerLimit(nvmlDeviceHandle(device), limit)
+	return ret
+}
+
+func (cgoapi) DeviceGetFBCSessions(device Device, sessioncount *uint32, sessioninfo *FBCSessionInfo) Return {
+	ret := nvmlDeviceGetFBCSessions(nvmlDeviceHandle(device), sessioncount, sessioninfo)
+	return ret
+}
+
+func (cgoapi) DeviceGetFBCStats(device Device, fbcstats *FBCStats) Return {
+	ret := nvmlDeviceGetFBCStats(nvmlDeviceHandle(device), fbcstats)
+	return ret
+}
+
+func (cgoapi) DeviceGetFanControlPolicy_v2(device Device, fan uint32, policy *FanControlPolicy) Return {
+	ret := nvmlDeviceGetFanControlPolicy_v2(nvmlDeviceHandle(device), fan, policy)
+	return ret
+}
+
+func (cgoapi) DeviceGetFanSpeed(device Device, speed *uint32) Return {
+	ret := nvmlDeviceGetFanSpeed(nvmlDeviceHandle(device), speed)
+	return ret
+}
+
+func (cgoapi) DeviceGetFanSpeedRPM(device Device, fanspeed *FanSpeedInfo) Return {
+	ret := nvmlDeviceGetFanSpeedRPM(nvmlDeviceHandle(device), fanspeed)
+	return ret
+}
+
+func (cgoapi) DeviceGetFanSpeed_v2(device Device, fan uint32, speed *uint32) Return {
+	ret := nvmlDeviceGetFanSpeed_v2(nvmlDeviceHandle(device), fan, speed)
+	return ret
+}
+
+func (cgoapi) DeviceGetFieldValues(device Device, valuescount int32, values *FieldValue) Return {
+	ret := nvmlDeviceGetFieldValues(nvmlDeviceHandle(device), valuescount, values)
+	return ret
+}
+
+func (cgoapi) DeviceGetGpcClkMinMaxVfOffset(device Device, minoffset *int32, maxoffset *int32) Return {
+	ret := nvmlDeviceGetGpcClkMinMaxVfOffset(nvmlDeviceHandle(device), minoffset, maxoffset)
+	return ret
+}
+
+func (cgoapi) DeviceGetGpcClkVfOffset(device Device, offset *int32) Return {
+	ret := nvmlDeviceGetGpcClkVfOffset(nvmlDeviceHandle(device), offset)
+	return ret
+}
+
+func (cgoapi) DeviceGetGpuFabricInfo(device Device, gpufabricinfo *GpuFabricInfo) Return {
+	ret := nvmlDeviceGetGpuFabricInfo(nvmlDeviceHandle(device), gpufabricinfo)
+	return ret
+}
+
+func (cgoapi) DeviceGetGpuFabricInfoV(device Device, gpufabricinfo *GpuFabricInfoV) Return {
+	ret := nvmlDeviceGetGpuFabricInfoV(nvmlDeviceHandle(device), gpufabricinfo)
+	return ret
+}
+
+func (cgoapi) DeviceGetGpuInstanceById(device Device, id uint32, gpuinstance *GpuInstance) Return {
+	var nvmlGpuinstance nvmlGpuInstance
+	ret := nvmlDeviceGetGpuInstanceById(nvmlDeviceHandle(device), id, &nvmlGpuinstance)
+	*gpuinstance = GpuInstance(nvmlGpuinstance)
+	return ret
+}
+
+func (cgoapi) DeviceGetGpuInstanceId(device Device, id *uint32) Return {
+	ret := nvmlDeviceGetGpuInstanceId(nvmlDeviceHandle(device), id)
+	return ret
+}
+
+func (cgoapi) DeviceGetGpuInstancePossiblePlacements(device Device, profileid uint32, placements *GpuInstancePlacement, count *uint32) Return {
+	ret := nvmlDeviceGetGpuInstancePossiblePlacements(nvmlDeviceHandle(device), profileid, placements, count)
+	return ret
+}
+
+func (cgoapi) DeviceGetGpuInstancePossiblePlacements_v1(device Device, profileid uint32, placements *GpuInstancePlacement, count *uint32) Return {
+	ret := nvmlDeviceGetGpuInstancePossiblePlacements_v1(nvmlDeviceHandle(device), profileid, placements, count)
+	return ret
+}
+
+func (cgoapi) DeviceGetGpuInstancePossiblePlacements_v2(device Device, profileid uint32, placements *GpuInstancePlacement, count *uint32) Return {
+	ret := nvmlDeviceGetGpuInstancePossiblePlacements_v2(nvmlDeviceHandle(device), profileid, placements, count)
+	return ret
+}
+
+func (cgoapi) DeviceGetGpuInstanceProfileInfo(device Device, profile uint32, info *GpuInstanceProfileInfo) Return {
+	ret := nvmlDeviceGetGpuInstanceProfileInfo(nvmlDeviceHandle(device), profile, info)
+	return ret
+}
+
+func (cgoapi) DeviceGetGpuInstanceProfileInfoV(device Device, profile uint32, info *GpuInstanceProfileInfo_v2) Return {
+	ret := nvmlDeviceGetGpuInstanceProfileInfoV(nvmlDeviceHandle(device), profile, info)
+	return ret
+}
+
+func (cgoapi) DeviceGetGpuInstanceRemainingCapacity(device Device, profileid uint32, count *uint32) Return {
+	ret := nvmlDeviceGetGpuInstanceRemainingCapacity(nvmlDeviceHandle(device), profileid, count)
+	return ret
+}
+
+func (cgoapi) DeviceGetGpuInstances(device Device, profileid uint32, gpuinstances *GpuInstance, count *uint32) Return {
+	var nvmlGpuinstances nvmlGpuInstance
+	ret := nvmlDeviceGetGpuInstances(nvmlDeviceHandle(device), profileid, &nvmlGpuinstances, count)
+	*gpuinstances = GpuInstance(nvmlGpuinstances)
+	return ret
+}
+
+func (cgoapi) DeviceGetGpuMaxPcieLinkGeneration(device Device, maxlinkgendevice *uint32) Return {
+	ret := nvmlDeviceGetGpuMaxPcieLinkGeneration(nvmlDeviceHandle(device), maxlinkgendevice)
+	return ret
+}
+
+func (cgoapi) DeviceGetGpuOperationMode(device Device, current *GpuOperationMode, pending *GpuOperationMode) Return {
+	ret := nvmlDeviceGetGpuOperationMode(nvmlDeviceHandle(device), current, pending)
+	return ret
+}
+
+func (cgoapi) DeviceGetGraphicsRunningProcesses(device Device, infocount *uint32, infos *ProcessInfo) Return {
+	ret := nvmlDeviceGetGraphicsRunningProcesses(nvmlDeviceHandle(device), infocount, infos)
+	return ret
+}
+
+func (cgoapi) DeviceGetGraphicsRunningProcesses_v1(device Device, infocount *uint32, infos *ProcessInfo_v1) Return {
+	ret := nvmlDeviceGetGraphicsRunningProcesses_v1(nvmlDeviceHandle(device), infocount, infos)
+	return ret
+}
+
+func (cgoapi) DeviceGetGraphicsRunningProcesses_v2(device Device, infocount *uint32, infos *ProcessInfo_v2) Return {
+	ret := nvmlDeviceGetGraphicsRunningProcesses_v2(nvmlDeviceHandle(device), infocount, infos)
+	return ret
+}
+
+func (cgoapi) DeviceGetGraphicsRunningProcesses_v3(device Device, infocount *uint32, infos *ProcessInfo) Return {
+	ret := nvmlDeviceGetGraphicsRunningProcesses_v3(nvmlDeviceHandle(device), infocount, infos)
+	return ret
+}
+
+func (cgoapi) DeviceGetGridLicensableFeatures(device Device, pgridlicensablefeatures *GridLicensableFeatures) Return {
+	ret := nvmlDeviceGetGridLicensableFeatures(nvmlDeviceHandle(device), pgridlicensablefeatures)
+	return ret
+}
+
+func (cgoapi) DeviceGetGridLicensableFeatures_v1(device Device, pgridlicensablefeatures *GridLicensableFeatures) Return {
+	ret := nvmlDeviceGetGridLicensableFeatures_v1(nvmlDeviceHandle(device), pgridlicensablefeatures)
+	return ret
+}
+
+func (cgoapi) DeviceGetGridLicensableFeatures_v2(device Device, pgridlicensablefeatures *GridLicensableFeatures) Return {
+	ret := nvmlDeviceGetGridLicensableFeatures_v2(nvmlDeviceHandle(device), pgridlicensablefeatures)
+	return ret
+}
+
+func (cgoapi) DeviceGetGridLicensableFeatures_v3(device Device, pgridlicensablefeatures *GridLicensableFeatures) Return {
+	ret := nvmlDeviceGetGridLicensableFeatures_v3(nvmlDeviceHandle(device), pgridlicensablefeatures)
+	return ret
+}
+
+func (cgoapi) DeviceGetGridLicensableFeatures_v4(device Device, pgridlicensablefeatures *GridLicensableFeatures) Return {
+	ret := nvmlDeviceGetGridLicensableFeatures_v4(nvmlDeviceHandle(device), pgridlicensablefeatures)
+	return ret
+}
+
+func (cgoapi) DeviceGetGspFirmwareMode(device Device, isenabled *uint32, defaultmode *uint32) Return {
+	ret := nvmlDeviceGetGspFirmwareMode(nvmlDeviceHandle(device), isenabled, defaultmode)
+	return ret
+}
+
+func (cgoapi) DeviceGetGspFirmwareVersion(device Device, version *byte) Return {
+	ret := nvmlDeviceGetGspFirmwareVersion(nvmlDeviceHandle(device), version)
+	return ret
+}
+
+func (cgoapi) DeviceGetHandleByIndex(index uint32, device *Device) Return {
+	var nvmlDevice nvmlDevice
+	ret := nvmlDeviceGetHandleByIndex(index, &nvmlDevice)
+	*device = Device(nvmlDevice)
+	return ret
+}
+
+func (cgoapi) DeviceGetHandleByIndex_v1(index uint32, device *Device) Return {
+	var nvmlDevice nvmlDevice
+	ret := nvmlDeviceGetHandleByIndex_v1(index, &nvmlDevice)
+	*device = Device(nvmlDevice)
+	return ret
+}
+
+func (cgoapi) DeviceGetHandleByIndex_v2(index uint32, device *Device) Return {
+	var nvmlDevice nvmlDevice
+	ret := nvmlDeviceGetHandleByIndex_v2(index, &nvmlDevice)
+	*device = Device(nvmlDevice)
+	return ret
+}
+
+func (cgoapi) DeviceGetHandleByPciBusId(pcibusid string, device *Device) Return {
+	var nvmlDevice nvmlDevice
+	ret := nvmlDeviceGetHandleByPciBusId(pcibusid, &nvmlDevice)
+	*device = Device(nvmlDevice)
+	return ret
+}
+
+func (cgoapi) DeviceGetHandleByPciBusId_v1(pcibusid string, device *Device) Return {
+	var nvmlDevice nvmlDevice
+	ret := nvmlDeviceGetHandleByPciBusId_v1(pcibusid, &nvmlDevice)
+	*device = Device(nvmlDevice)
+	return ret
+}
+
+func (cgoapi) DeviceGetHandleByPciBusId_v2(pcibusid string, device *Device) Return {
+	var nvmlDevice nvmlDevice
+	ret := nvmlDeviceGetHandleByPciBusId_v2(pcibusid, &nvmlDevice)
+	*device = Device(nvmlDevice)
+	return ret
+}
+
+func (cgoapi) DeviceGetHandleBySerial(serial string, device *Device) Return {
+	var nvmlDevice nvmlDevice
+	ret := nvmlDeviceGetHandleBySerial(serial, &nvmlDevice)
+	*device = Device(nvmlDevice)
+	return ret
+}
+
+func (cgoapi) DeviceGetHandleByUUID(uuid string, device *Device) Return {
+	var nvmlDevice nvmlDevice
+	ret := nvmlDeviceGetHandleByUUID(uuid, &nvmlDevice)
+	*device = Device(nvmlDevice)
+	return ret
+}
+
+func (cgoapi) DeviceGetHandleByUUIDV(uuid *UUID, device *Device) Return {
+	var nvmlDevice nvmlDevice
+	ret := nvmlDeviceGetHandleByUUIDV(uuid, &nvmlDevice)
+	*device = Device(nvmlDevice)
+	return ret
+}
+
+func (cgoapi) DeviceGetHostVgpuMode(device Device, phostvgpumode *HostVgpuMode) Return {
+	ret := nvmlDeviceGetHostVgpuMode(nvmlDeviceHandle(device), phostvgpumode)
+	return ret
+}
+
+func (cgoapi) DeviceGetIndex(device Device, index *uint32) Return {
+	ret := nvmlDeviceGetIndex(nvmlDeviceHandle(device), index)
+	return ret
+}
+
+func (cgoapi) DeviceGetInforomConfigurationChecksum(device Device, checksum *uint32) Return {
+	ret := nvmlDeviceGetInforomConfigurationChecksum(nvmlDeviceHandle(device), checksum)
+	return ret
+}
+
+func (cgoapi) DeviceGetInforomImageVersion(device Device, version *byte, length uint32) Return {
+	ret := nvmlDeviceGetInforomImageVersion(nvmlDeviceHandle(device), version, length)
+	return ret
+}
+
+func (cgoapi) DeviceGetInforomVersion(device Device, object InforomObject, version *byte, length uint32) Return {
+	ret := nvmlDeviceGetInforomVersion(nvmlDeviceHandle(device), object, version, length)
+	return ret
+}
+
+func (cgoapi) DeviceGetIrqNum(device Device, irqnum *uint32) Return {
+	ret := nvmlDeviceGetIrqNum(nvmlDeviceHandle(device), irqnum)
+	return ret
+}
+
+func (cgoapi) DeviceGetJpgUtilization(device Device, utilization *uint32, samplingperiodus *uint32) Return {
+	ret := nvmlDeviceGetJpgUtilization(nvmlDeviceHandle(device), utilization, samplingperiodus)
+	return ret
+}
+
+func (cgoapi) DeviceGetLastBBXFlushTime(device Device, timestamp *uint64, durationus *uint) Return {
+	ret := nvmlDeviceGetLastBBXFlushTime(nvmlDeviceHandle(device), timestamp, durationus)
+	return ret
+}
+
+func (cgoapi) DeviceGetMPSComputeRunningProcesses(device Device, infocount *uint32, infos *ProcessInfo) Return {
+	ret := nvmlDeviceGetMPSComputeRunningProcesses(nvmlDeviceHandle(device), infocount, infos)
+	return ret
+}
+
+func (cgoapi) DeviceGetMPSComputeRunningProcesses_v1(device Device, infocount *uint32, infos *ProcessInfo_v1) Return {
+	ret := nvmlDeviceGetMPSComputeRunningProcesses_v1(nvmlDeviceHandle(device), infocount, infos)
+	return ret
+}
+
+func (cgoapi) DeviceGetMPSComputeRunningProcesses_v2(device Device, infocount *uint32, infos *ProcessInfo_v2) Return {
+	ret := nvmlDeviceGetMPSComputeRunningProcesses_v2(nvmlDeviceHandle(device), infocount, infos)
+	return ret
+}
+
+func (cgoapi) DeviceGetMPSComputeRunningProcesses_v3(device Device, infocount *uint32, infos *ProcessInfo) Return {
+	ret := nvmlDeviceGetMPSComputeRunningProcesses_v3(nvmlDeviceHandle(device), infocount, infos)
+	return ret
+}
+
+func (cgoapi) DeviceGetMarginTemperature(device Device, margintempinfo *MarginTemperature) Return {
+	ret := nvmlDeviceGetMarginTemperature(nvmlDeviceHandle(device), margintempinfo)
+	return ret
+}
+
+func (cgoapi) DeviceGetMaxClockInfo(device Device, _type ClockType, clock *uint32) Return {
+	ret := nvmlDeviceGetMaxClockInfo(nvmlDeviceHandle(device), _type, clock)
+	return ret
+}
+
+func (cgoapi) DeviceGetMaxCustomerBoostClock(device Device, clocktype ClockType, clockmhz *uint32) Return {
+	ret := nvmlDeviceGetMaxCustomerBoostClock(nvmlDeviceHandle(device), clocktype, clockmhz)
+	return ret
+}
+
+func (cgoapi) DeviceGetMaxMigDeviceCount(device Device, count *uint32) Return {
+	ret := nvmlDeviceGetMaxMigDeviceCount(nvmlDeviceHandle(device), count)
+	return ret
+}
+
+func (cgoapi) DeviceGetMaxPcieLinkGeneration(device Device, maxlinkgen *uint32) Return {
+	ret := nvmlDeviceGetMaxPcieLinkGeneration(nvmlDeviceHandle(device), maxlinkgen)
+	return ret
+}
+
+func (cgoapi) DeviceGetMaxPcieLinkWidth(device Device, maxlinkwidth *uint32) Return {
+	ret := nvmlDeviceGetMaxPcieLinkWidth(nvmlDeviceHandle(device), maxlinkwidth)
+	return ret
+}
+
+func (cgoapi) DeviceGetMemClkMinMaxVfOffset(device Device, minoffset *int32, maxoffset *int32) Return {
+	ret := nvmlDeviceGetMemClkMinMaxVfOffset(nvmlDeviceHandle(device), minoffset, maxoffset)
+	return ret
+}
+
+func (cgoapi) DeviceGetMemClkVfOffset(device Device, offset *int32) Return {
+	ret := nvmlDeviceGetMemClkVfOffset(nvmlDeviceHandle(device), offset)
+	return ret
+}
+
+func (cgoapi) DeviceGetMemoryAffinity(device Device, nodesetsize uint32, nodeset *uint, scope AffinityScope) Return {
+	ret := nvmlDeviceGetMemoryAffinity(nvmlDeviceHandle(device), nodesetsize, nodeset, scope)
+	return ret
+}
+
+func (cgoapi) DeviceGetMemoryBusWidth(device Device, buswidth *uint32) Return {
+	ret := nvmlDeviceGetMemoryBusWidth(nvmlDeviceHandle(device), buswidth)
+	return ret
+}
+
+func (cgoapi) DeviceGetMemoryErrorCounter(device Device, errortype MemoryErrorType, countertype EccCounterType, locationtype MemoryLocation, count *uint64) Return {
+	ret := nvmlDeviceGetMemoryErrorCounter(nvmlDeviceHandle(device), errortype, countertype, locationtype, count)
+	return ret
+}
+
+func (cgoapi) DeviceGetMemoryInfo(device Device, memory *Memory) Return {
+	ret := nvmlDeviceGetMemoryInfo(nvmlDeviceHandle(device), memory)
+	return ret
+}
+
+func (cgoapi) DeviceGetMemoryInfo_v2(device Device, memory *Memory_v2) Return {
+	ret := nvmlDeviceGetMemoryInfo_v2(nvmlDeviceHandle(device), memory)
+	return ret
+}
+
+func (cgoapi) DeviceGetMigDeviceHandleByIndex(device Device, index uint32, migdevice *Device) Return {
+	var nvmlMigdevice nvmlDevice
+	ret := nvmlDeviceGetMigDeviceHandleByIndex(nvmlDeviceHandle(device), index, &nvmlMigdevice)
+	*migdevice = Device(nvmlMigdevice)
+	return ret
+}
+
+func (cgoapi) DeviceGetMigMode(device Device, currentmode *uint32, pendingmode *uint32) Return {
+	ret := nvmlDeviceGetMigMode(nvmlDeviceHandle(device), currentmode, pendingmode)
+	return ret
+}
+
+func (cgoapi) DeviceGetMinMaxClockOfPState(device Device, _type ClockType, pstate Pstates, minclockmhz *uint32, maxclockmhz *uint32) Return {
+	ret := nvmlDeviceGetMinMaxClockOfPState(nvmlDeviceHandle(device), _type, pstate, minclockmhz, maxclockmhz)
+	return ret
+}
+
+func (cgoapi) DeviceGetMinMaxFanSpeed(device Device, minspeed *uint32, maxspeed *uint32) Return {
+	ret := nvmlDeviceGetMinMaxFanSpeed(nvmlDeviceHandle(device), minspeed, maxspeed)
+	return ret
+}
+
+func (cgoapi) DeviceGetMinorNumber(device Device, minornumber *uint32) Return {
+	ret := nvmlDeviceGetMinorNumber(nvmlDeviceHandle(device), minornumber)
+	return ret
+}
+
+func (cgoapi) DeviceGetModuleId(device Device, moduleid *uint32) Return {
+	ret := nvmlDeviceGetModuleId(nvmlDeviceHandle(device), moduleid)
+	return ret
+}
+
+func (cgoapi) DeviceGetMultiGpuBoard(device Device, multigpubool *uint32) Return {
+	ret := nvmlDeviceGetMultiGpuBoard(nvmlDeviceHandle(device), multigpubool)
+	return ret
+}
+
+func (cgoapi) DeviceGetName(device Device, name *byte, length uint32) Return {
+	ret := nvmlDeviceGetName(nvmlDeviceHandle(device), name, length)
+	return ret
+}
+
+func (cgoapi) DeviceGetNumFans(device Device, numfans *uint32) Return {
+	ret := nvmlDeviceGetNumFans(nvmlDeviceHandle(device), numfans)
+	return ret
+}
+
+func (cgoapi) DeviceGetNumGpuCores(device Device, numcores *uint32) Return {
+	ret := nvmlDeviceGetNumGpuCores(nvmlDeviceHandle(device), numcores)
+	return ret
+}
+
+func (cgoapi) DeviceGetNumaNodeId(device Device, node *uint32) Return {
+	ret := nvmlDeviceGetNumaNodeId(nvmlDeviceHandle(device), node)
+	return ret
+}
+
+func (cgoapi) DeviceGetNvLinkCapability(device Device, link uint32, capability NvLinkCapability, capresult *uint32) Return {
+	ret := nvmlDeviceGetNvLinkCapability(nvmlDeviceHandle(device), link, capability, capresult)
+	return ret
+}
+
+func (cgoapi) DeviceGetNvLinkErrorCounter(device Device, link uint32, counter NvLinkErrorCounter, countervalue *uint64) Return {
+	ret := nvmlDeviceGetNvLinkErrorCounter(nvmlDeviceHandle(device), link, counter, countervalue)
+	return ret
+}
+
+func (cgoapi) DeviceGetNvLinkRemoteDeviceType(device Device, link uint32, pnvlinkdevicetype *IntNvLinkDeviceType) Return {
+	ret := nvmlDeviceGetNvLinkRemoteDeviceType(nvmlDeviceHandle(device), link, pnvlinkdevicetype)
+	return ret
+}
+
+func (cgoapi) DeviceGetNvLinkRemotePciInfo(device Device, link uint32, pci *PciInfo) Return {
+	ret := nvmlDeviceGetNvLinkRemotePciInfo(nvmlDeviceHandle(device), link, pci)
+	return ret
+}
+
+func (cgoapi) DeviceGetNvLinkRemotePciInfo_v1(device Device, link uint32, pci *PciInfo) Return {
+	ret := nvmlDeviceGetNvLinkRemotePciInfo_v1(nvmlDeviceHandle(device), link, pci)
+	return ret
+}
+
+func (cgoapi) DeviceGetNvLinkRemotePciInfo_v2(device Device, link uint32, pci *PciInfo) Return {
+	ret := nvmlDeviceGetNvLinkRemotePciInfo_v2(nvmlDeviceHandle(device), link, pci)
+	return ret
+}
+
+func (cgoapi) DeviceGetNvLinkState(device Device, link uint32, isactive *EnableState) Return {
+	ret := nvmlDeviceGetNvLinkState(nvmlDeviceHandle(device), link, isactive)
+	return ret
+}
+
+func (cgoapi) DeviceGetNvLinkUtilizationControl(device Device, link uint32, counter uint32, control *NvLinkUtilizationControl) Return {
+	ret := nvmlDeviceGetNvLinkUtilizationControl(nvmlDeviceHandle(device), link, counter, control)
+	return ret
+}
+
+func (cgoapi) DeviceGetNvLinkUtilizationCounter(device Device, link uint32, counter uint32, rxcounter *uint64, txcounter *uint64) Return {
+	ret := nvmlDeviceGetNvLinkUtilizationCounter(nvmlDeviceHandle(device), link, counter, rxcounter, txcounter)
+	return ret
+}
+
+func (cgoapi) DeviceGetNvLinkVersion(device Device, link uint32, version *uint32) Return {
+	ret := nvmlDeviceGetNvLinkVersion(nvmlDeviceHandle(device), link, version)
+	return ret
+}
+
+func (cgoapi) DeviceGetNvlinkBwMode(device Device, getbwmode *NvlinkGetBwMode) Return {
+	ret := nvmlDeviceGetNvlinkBwMode(nvmlDeviceHandle(device), getbwmode)
+	return ret
+}
+
+func (cgoapi) DeviceGetNvlinkSupportedBwModes(device Device, supportedbwmode *NvlinkSupportedBwModes) Return {
+	ret := nvmlDeviceGetNvlinkSupportedBwModes(nvmlDeviceHandle(device), supportedbwmode)
+	return ret
+}
+
+func (cgoapi) DeviceGetOfaUtilization(device Device, utilization *uint32, samplingperiodus *uint32) Return {
+	ret := nvmlDeviceGetOfaUtilization(nvmlDeviceHandle(device), utilization, samplingperiodus)
+	return ret
+}
+
+func (cgoapi) DeviceGetP2PStatus(device1 Device, device2 Device, p2pindex GpuP2PCapsIndex, p2pstatus *GpuP2PStatus) Return {
+	ret := nvmlDeviceGetP2PStatus(nvmlDeviceHandle(device1), nvmlDeviceHandle(device2), p2pindex, p2pstatus)
+	return ret
+}
+
+func (cgoapi) DeviceGetPciInfo(device Device, pci *PciInfo) Return {
+	ret := nvmlDeviceGetPciInfo(nvmlDeviceHandle(device), pci)
+	return ret
+}
+
+func (cgoapi) DeviceGetPciInfoExt(device Device, pci *PciInfoExt) Return {
+	ret := nvmlDeviceGetPciInfoExt(nvmlDeviceHandle(device), pci)
+	return ret
+}
+
+func (cgoapi) DeviceGetPciInfo_v1(device Device, pci *PciInfo) Return {
+	ret := nvmlDeviceGetPciInfo_v1(nvmlDeviceHandle(device), pci)
+	return ret
+}
+
+func (cgoapi) DeviceGetPciInfo_v2(device Device, pci *PciInfo) Return {
+	ret := nvmlDeviceGetPciInfo_v2(nvmlDeviceHandle(device), pci)
+	return ret
+}
+
+func (cgoapi) DeviceGetPciInfo_v3(device Device, pci *PciInfo) Return {
+	ret := nvmlDeviceGetPciInfo_v3(nvmlDeviceHandle(device), pci)
+	return ret
+}
+
+func (cgoapi) DeviceGetPcieLinkMaxSpeed(device Device, maxspeed *uint32) Return {
+	ret := nvmlDeviceGetPcieLinkMaxSpeed(nvmlDeviceHandle(device), maxspeed)
+	return ret
+}
+
+func (cgoapi) DeviceGetPcieReplayCounter(device Device, value *uint32) Return {
+	ret := nvmlDeviceGetPcieReplayCounter(nvmlDeviceHandle(device), value)
+	return ret
+}
+
+func (cgoapi) DeviceGetPcieSpeed(device Device, pciespeed *uint32) Return {
+	ret := nvmlDeviceGetPcieSpeed(nvmlDeviceHandle(device), pciespeed)
+	return ret
+}
+
+func (cgoapi) DeviceGetPcieThroughput(device Device, counter PcieUtilCounter, value *uint32) Return {
+	ret := nvmlDeviceGetPcieThroughput(nvmlDeviceHandle(device), counter, value)
+	return ret
+}
+
+func (cgoapi) DeviceGetPerformanceModes(device Device, perfmodes *DevicePerfModes) Return {
+	ret := nvmlDeviceGetPerformanceModes(nvmlDeviceHandle(device), perfmodes)
+	return ret
+}
+
+func (cgoapi) DeviceGetPerformanceState(device Device, pstate *Pstates) Return {
+	ret := nvmlDeviceGetPerformanceState(nvmlDeviceHandle(device), pstate)
+	return ret
+}
+
+func (cgoapi) DeviceGetPersistenceMode(device Device, mode *EnableState) Return {
+	ret := nvmlDeviceGetPersistenceMode(nvmlDeviceHandle(device), mode)
+	return ret
+}
+
+func (cgoapi) DeviceGetPgpuMetadataString(device Device, pgpumetadata *byte, buffersize *uint32) Return {
+	ret := nvmlDeviceGetPgpuMetadataString(nvmlDeviceHandle(device), pgpumetadata, buffersize)
+	return ret
+}
+
+func (cgoapi) DeviceGetPlatformInfo(device Device, platforminfo *PlatformInfo) Return {
+	ret := nvmlDeviceGetPlatformInfo(nvmlDeviceHandle(device), platforminfo)
+	return ret
+}
+
+func (cgoapi) DeviceGetPowerManagementDefaultLimit(device Device, defaultlimit *uint32) Return {
+	ret := nvmlDeviceGetPowerManagementDefaultLimit(nvmlDeviceHandle(device), defaultlimit)
+	return ret
+}
+
+func (cgoapi) DeviceGetPowerManagementLimit(device Device, limit *uint32) Return {
+	ret := nvmlDeviceGetPowerManagementLimit(nvmlDeviceHandle(device), limit)
+	return ret
+}
+
+func (cgoapi) DeviceGetPowerManagementLimitConstraints(device Device, minlimit *uint32, maxlimit *uint32) Return {
+	ret := nvmlDeviceGetPowerManagementLimitConstraints(nvmlDeviceHandle(device), minlimit, maxlimit)
+	return ret
+}
+
+func (cgoapi) DeviceGetPowerManagementMode(device Device, mode *EnableState) Return {
+	ret := nvmlDeviceGetPowerManagementMode(nvmlDeviceHandle(device), mode)
+	return ret
+}
+
+func (cgoapi) DeviceGetPowerSource(device Device, powersource *PowerSource) Return {
+	ret := nvmlDeviceGetPowerSource(nvmlDeviceHandle(device), powersource)
+	return ret
+}
+
+func (cgoapi) DeviceGetPowerState(device Device, pstate *Pstates) Return {
+	ret := nvmlDeviceGetPowerState(nvmlDeviceHandle(device), pstate)
+	return ret
+}
+
+func (cgoapi) DeviceGetPowerUsage(device Device, power *uint32) Return {
+	ret := nvmlDeviceGetPowerUsage(nvmlDeviceHandle(device), power)
+	return ret
+}
+
+func (cgoapi) DeviceGetProcessUtilization(device Device, utilization *ProcessUtilizationSample, processsamplescount *uint32, lastseentimestamp uint64) Return {
+	ret := nvmlDeviceGetProcessUtilization(nvmlDeviceHandle(device), utilization, processsamplescount, lastseentimestamp)
+	return ret
+}
+
+func (cgoapi) DeviceGetProcessesUtilizationInfo(device Device, procesesutilinfo *ProcessesUtilizationInfo) Return {
+	ret := nvmlDeviceGetProcessesUtilizationInfo(nvmlDeviceHandle(device), procesesutilinfo)
+	return ret
+}
+
+func (cgoapi) DeviceGetRemappedRows(device Device, corrrows *uint32, uncrows *uint32, ispending *uint32, failureoccurred *uint32) Return {
+	ret := nvmlDeviceGetRemappedRows(nvmlDeviceHandle(device), corrrows, uncrows, ispending, failureoccurred)
+	return ret
+}
+
+func (cgoapi) DeviceGetRetiredPages(device Device, cause PageRetirementCause, pagecount *uint32, addresses *uint64) Return {
+	ret := nvmlDeviceGetRetiredPages(nvmlDeviceHandle(device), cause, pagecount, addresses)
+	return ret
+}
+
+func (cgoapi) DeviceGetRetiredPagesPendingStatus(device Device, ispending *EnableState) Return {
+	ret := nvmlDeviceGetRetiredPagesPendingStatus(nvmlDeviceHandle(device), ispending)
+	return ret
+}
+
+func (cgoapi) DeviceGetRetiredPages_v2(device Device, cause PageRetirementCause, pagecount *uint32, addresses *uint64, timestamps *uint64) Return {
+	ret := nvmlDeviceGetRetiredPages_v2(nvmlDeviceHandle(device), cause, pagecount, addresses, timestamps)
+	return ret
+}
+
+func (cgoapi) DeviceGetRowRemapperHistogram(device Device, values *RowRemapperHistogramValues) Return {
+	ret := nvmlDeviceGetRowRemapperHistogram(nvmlDeviceHandle(device), values)
+	return ret
+}
+
+func (cgoapi) DeviceGetRunningProcessDetailList(device Device, plist *ProcessDetailList) Return {
+	ret := nvmlDeviceGetRunningProcessDetailList(nvmlDeviceHandle(device), plist)
+	return ret
+}
+
+func (cgoapi) DeviceGetSamples(device Device, _type SamplingType, lastseentimestamp uint64, samplevaltype *ValueType, samplecount *uint32, samples *Sample) Return {
+	ret := nvmlDeviceGetSamples(nvmlDeviceHandle(device), _type, lastseentimestamp, samplevaltype, samplecount, samples)
+	return ret
+}
+
+func (cgoapi) DeviceGetSerial(device Device, serial *byte, length uint32) Return {
+	ret := nvmlDeviceGetSerial(nvmlDeviceHandle(device), serial, length)
+	return ret
+}
+
+func (cgoapi) DeviceGetSramEccErrorStatus(device Device, status *EccSramErrorStatus) Return {
+	ret := nvmlDeviceGetSramEccErrorStatus(nvmlDeviceHandle(device), status)
+	return ret
+}
+
+func (cgoapi) DeviceGetSupportedClocksEventReasons(device Device, supportedclockseventreasons *uint64) Return {
+	ret := nvmlDeviceGetSupportedClocksEventReasons(nvmlDeviceHandle(device), supportedclockseventreasons)
+	return ret
+}
+
+func (cgoapi) DeviceGetSupportedClocksThrottleReasons(device Device, supportedclocksthrottlereasons *uint64) Return {
+	ret := nvmlDeviceGetSupportedClocksThrottleReasons(nvmlDeviceHandle(device), supportedclocksthrottlereasons)
+	return ret
+}
+
+func (cgoapi) DeviceGetSupportedEventTypes(device Device, eventtypes *uint64) Return {
+	ret := nvmlDeviceGetSupportedEventTypes(nvmlDeviceHandle(device), eventtypes)
+	return ret
+}
+
+func (cgoapi) DeviceGetSupportedGraphicsClocks(device Device, memoryclockmhz uint32, count *uint32, clocksmhz *uint32) Return {
+	ret := nvmlDeviceGetSupportedGraphicsClocks(nvmlDeviceHandle(device), memoryclockmhz, count, clocksmhz)
+	return ret
+}
+
+func (cgoapi) DeviceGetSupportedMemoryClocks(device Device, count *uint32, clocksmhz *uint32) Return {
+	ret := nvmlDeviceGetSupportedMemoryClocks(nvmlDeviceHandle(device), count, clocksmhz)
+	return ret
+}
+
+func (cgoapi) DeviceGetSupportedPerformanceStates(device Device, pstates *Pstates, size uint32) Return {
+	ret := nvmlDeviceGetSupportedPerformanceStates(nvmlDeviceHandle(device), pstates, size)
+	return ret
+}
+
+func (cgoapi) DeviceGetSupportedVgpus(device Device, vgpucount *uint32, vgputypeids *VgpuTypeId) Return {
+	var nvmlVgputypeids nvmlVgpuTypeId
+	ret := nvmlDeviceGetSupportedVgpus(nvmlDeviceHandle(device), vgpucount, &nvmlVgputypeids)
+	*vgputypeids = VgpuTypeId(nvmlVgputypeids)
+	return ret
+}
+
+func (cgoapi) DeviceGetTargetFanSpeed(device Device, fan uint32, targetspeed *uint32) Return {
+	ret := nvmlDeviceGetTargetFanSpeed(nvmlDeviceHandle(device), fan, targetspeed)
+	return ret
+}
+
+func (cgoapi) DeviceGetTemperature(device Device, sensortype TemperatureSensors, temp *uint32) Return {
+	ret := nvmlDeviceGetTemperature(nvmlDeviceHandle(device), sensortype, temp)
+	return ret
+}
+
+func (cgoapi) DeviceGetTemperatureThreshold(device Device, thresholdtype TemperatureThresholds, temp *uint32) Return {
+	ret := nvmlDeviceGetTemperatureThreshold(nvmlDeviceHandle(device), thresholdtype, temp)
+	return ret
+}
+
+func (cgoapi) DeviceGetTemperatureV(device Device, temperature *Temperature) Return {
+	ret := nvmlDeviceGetTemperatureV(nvmlDeviceHandle(device), temperature)
+	return ret
+}
+
+func (cgoapi) DeviceGetThermalSettings(device Device, sensorindex uint32, pthermalsettings *GpuThermalSettings) Return {
+	ret := nvmlDeviceGetThermalSettings(nvmlDeviceHandle(device), sensorindex, pthermalsettings)
+	return ret
+}
+
+func (cgoapi) DeviceGetTopologyCommonAncestor(device1 Device, device2 Device, pathinfo *GpuTopologyLevel) Return {
+	ret := nvmlDeviceGetTopologyCommonAncestor(nvmlDeviceHandle(device1), nvmlDeviceHandle(device2), pathinfo)
+	return ret
+}
+
+func (cgoapi) DeviceGetTopologyNearestGpus(device Device, level GpuTopologyLevel, count *uint32, devicearray *Device) Return {
+	var nvmlDevicearray nvmlDevice
+	ret := nvmlDeviceGetTopologyNearestGpus(nvmlDeviceHandle(device), level, count, &nvmlDevicearray)
+	*devicearray = Device(nvmlDevicearray)
+	return ret
+}
+
+func (cgoapi) DeviceGetTotalEccErrors(device Device, errortype MemoryErrorType, countertype EccCounterType, ecccounts *uint64) Return {
+	ret := nvmlDeviceGetTotalEccErrors(nvmlDeviceHandle(device), errortype, countertype, ecccounts)
+	return ret
+}
+
+func (cgoapi) DeviceGetTotalEnergyConsumption(device Device, energy *uint64) Return {
+	ret := nvmlDeviceGetTotalEnergyConsumption(nvmlDeviceHandle(device), energy)
+	return ret
+}
+
+func (cgoapi) DeviceGetUUID(device Device, uuid *byte, length uint32) Return {
+	ret := nvmlDeviceGetUUID(nvmlDeviceHandle(device), uuid, length)
+	return ret
+}
+
+func (cgoapi) DeviceGetUtilizationRates(device Device, utilization *Utilization) Return {
+	ret := nvmlDeviceGetUtilizationRates(nvmlDeviceHandle(device), utilization)
+	return ret
+}
+
+func (cgoapi) DeviceGetVbiosVersion(device Device, version *byte, length uint32) Return {
+	ret := nvmlDeviceGetVbiosVersion(nvmlDeviceHandle(device), version, length)
+	return ret
+}
+
+func (cgoapi) DeviceGetVgpuCapabilities(device Device, capability DeviceVgpuCapability, capresult *uint32) Return {
+	ret := nvmlDeviceGetVgpuCapabilities(nvmlDeviceHandle(device), capability, capresult)
+	return ret
+}
+
+func (cgoapi) DeviceGetVgpuHeterogeneousMode(device Device, pheterogeneousmode *VgpuHeterogeneousMode) Return {
+	ret := nvmlDeviceGetVgpuHeterogeneousMode(nvmlDeviceHandle(device), pheterogeneousmode)
+	return ret
+}
+
+func (cgoapi) DeviceGetVgpuInstancesUtilizationInfo(device Device, vgpuutilinfo *VgpuInstancesUtilizationInfo) Return {
+	ret := nvmlDeviceGetVgpuInstancesUtilizationInfo(nvmlDeviceHandle(device), vgpuutilinfo)
+	return ret
+}
+
+func (cgoapi) DeviceGetVgpuMetadata(device Device, pgpumetadata *VgpuPgpuMetadata, buffersize *uint32) Return {
+	ret := nvmlDeviceGetVgpuMetadata(nvmlDeviceHandle(device), &pgpumetadata.nvmlVgpuPgpuMetadata, buffersize)
+	return ret
+}
+
+func (cgoapi) DeviceGetVgpuProcessUtilization(device Device, lastseentimestamp uint64, vgpuprocesssamplescount *uint32, utilizationsamples *VgpuProcessUtilizationSample) Return {
+	ret := nvmlDeviceGetVgpuProcessUtilization(nvmlDeviceHandle(device), lastseentimestamp, vgpuprocesssamplescount, utilizationsamples)
+	return ret
+}
+
+func (cgoapi) DeviceGetVgpuProcessesUtilizationInfo(device Device, vgpuprocutilinfo *VgpuProcessesUtilizationInfo) Return {
+	ret := nvmlDeviceGetVgpuProcessesUtilizationInfo(nvmlDeviceHandle(device), vgpuprocutilinfo)
+	return ret
+}
+
+func (cgoapi) DeviceGetVgpuSchedulerCapabilities(device Device, pcapabilities *VgpuSchedulerCapabilities) Return {
+	ret := nvmlDeviceGetVgpuSchedulerCapabilities(nvmlDeviceHandle(device), pcapabilities)
+	return ret
+}
+
+func (cgoapi) DeviceGetVgpuSchedulerLog(device Device, pschedulerlog *VgpuSchedulerLog) Return {
+	ret := nvmlDeviceGetVgpuSchedulerLog(nvmlDeviceHandle(device), pschedulerlog)
+	return ret
+}
+
+func (cgoapi) DeviceGetVgpuSchedulerState(device Device, pschedulerstate *VgpuSchedulerGetState) Return {
+	ret := nvmlDeviceGetVgpuSchedulerState(nvmlDeviceHandle(device), pschedulerstate)
+	return ret
+}
+
+func (cgoapi) DeviceGetVgpuTypeCreatablePlacements(device Device, vgputypeid VgpuTypeId, pplacementlist *VgpuPlacementList) Return {
+	ret := nvmlDeviceGetVgpuTypeCreatablePlacements(nvmlDeviceHandle(device), nvmlVgpuTypeIdHandle(vgputypeid), pplacementlist)
+	return ret
+}
+
+func (cgoapi) DeviceGetVgpuTypeSupportedPlacements(device Device, vgputypeid VgpuTypeId, pplacementlist *VgpuPlacementList) Return {
+	ret := nvmlDeviceGetVgpuTypeSupportedPlacements(nvmlDeviceHandle(device), nvmlVgpuTypeIdHandle(vgputypeid), pplacementlist)
+	return ret
+}
+
+func (cgoapi) DeviceGetVgpuUtilization(device Device, lastseentimestamp uint64, samplevaltype *ValueType, vgpuinstancesamplescount *uint32, utilizationsamples *VgpuInstanceUtilizationSample) Return {
+	ret := nvmlDeviceGetVgpuUtilization(nvmlDeviceHandle(device), lastseentimestamp, samplevaltype, vgpuinstancesamplescount, utilizationsamples)
+	return ret
+}
+
+func (cgoapi) DeviceGetViolationStatus(device Device, perfpolicytype PerfPolicyType, violtime *ViolationTime) Return {
+	ret := nvmlDeviceGetViolationStatus(nvmlDeviceHandle(device), perfpolicytype, violtime)
+	return ret
+}
+
+func (cgoapi) DeviceGetVirtualizationMode(device Device, pvirtualmode *GpuVirtualizationMode) Return {
+	ret := nvmlDeviceGetVirtualizationMode(nvmlDeviceHandle(device), pvirtualmode)
+	return ret
+}
+
+func (cgoapi) DeviceIsMigDeviceHandle(device Device, ismigdevice *uint32) Return {
+	ret := nvmlDeviceIsMigDeviceHandle(nvmlDeviceHandle(device), ismigdevice)
+	return ret
+}
+
+func (cgoapi) DeviceModifyDrainState(pciinfo *PciInfo, newstate EnableState) Return {
+	ret := nvmlDeviceModifyDrainState(pciinfo, newstate)
+	return ret
+}
+
+func (cgoapi) DeviceOnSameBoard(device1 Device, device2 Device, onsameboard *int32) Return {
+	ret := nvmlDeviceOnSameBoard(nvmlDeviceHandle(device1), nvmlDeviceHandle(device2), onsameboard)
+	return ret
+}
+
+func (cgoapi) DevicePowerSmoothingActivatePresetProfile(device Device, profile *PowerSmoothingProfile) Return {
+	ret := nvmlDevicePowerSmoothingActivatePresetProfile(nvmlDeviceHandle(device), profile)
+	return ret
+}
+
+func (cgoapi) DevicePowerSmoothingSetState(device Device, state *PowerSmoothingState) Return {
+	ret := nvmlDevicePowerSmoothingSetState(nvmlDeviceHandle(device), state)
+	return ret
+}
+
+func (cgoapi) DevicePowerSmoothingUpdatePresetProfileParam(device Device, profile *PowerSmoothingProfile) Return {
+	ret := nvmlDevicePowerSmoothingUpdatePresetProfileParam(nvmlDeviceHandle(device), profile)
+	return ret
+}
+
+func (cgoapi) DeviceQueryDrainState(pciinfo *PciInfo, currentstate *EnableState) Return {
+	ret := nvmlDeviceQueryDrainState(pciinfo, currentstate)
+	return ret
+}
+
+func (cgoapi) DeviceRegisterEvents(device Device, eventtypes uint64, set EventSet) Return {
+	ret := nvmlDeviceRegisterEvents(nvmlDeviceHandle(device), eventtypes, nvmlEventSetHandle(set))
+	return ret
+}
+
+func (cgoapi) DeviceRemoveGpu(pciinfo *PciInfo) Return {
+	ret := nvmlDeviceRemoveGpu(pciinfo)
+	return ret
+}
+
+func (cgoapi) DeviceRemoveGpu_v1(pciinfo *PciInfo) Return {
+	ret := nvmlDeviceRemoveGpu_v1(pciinfo)
+	return ret
+}
+
+func (cgoapi) DeviceRemoveGpu_v2(pciinfo *PciInfo, gpustate DetachGpuState, linkstate PcieLinkState) Return {
+	ret := nvmlDeviceRemoveGpu_v2(pciinfo, gpustate, linkstate)
+	return ret
+}
+
+func (cgoapi) DeviceResetApplicationsClocks(device Device) Return {
+	ret := nvmlDeviceResetApplicationsClocks(nvmlDeviceHandle(device))
+	return ret
+}
+
+func (cgoapi) DeviceResetGpuLockedClocks(device Device) Return {
+	ret := nvmlDeviceResetGpuLockedClocks(nvmlDeviceHandle(device))
+	return ret
+}
+
+func (cgoapi) DeviceResetMemoryLockedClocks(device Device) Return {
+	ret := nvmlDeviceResetMemoryLockedClocks(nvmlDeviceHandle(device))
+	return ret
+}
+
+func (cgoapi) DeviceResetNvLinkErrorCounters(device Device, link uint32) Return {
+	ret := nvmlDeviceResetNvLinkErrorCounters(nvmlDeviceHandle(device), link)
+	return ret
+}
+
+func (cgoapi) DeviceResetNvLinkUtilizationCounter(device Device, link uint32, counter uint32) Return {
+	ret := nvmlDeviceResetNvLinkUtilizationCounter(nvmlDeviceHandle(device), link, counter)
+	return ret
+}
+
+func (cgoapi) DeviceSetAPIRestriction(device Device, apitype RestrictedAPI, isrestricted EnableState) Return {
+	ret := nvmlDeviceSetAPIRestriction(nvmlDeviceHandle(device), apitype, isrestricted)
+	return ret
+}
+
+func (cgoapi) DeviceSetAccountingMode(device Device, mode EnableState) Return {
+	ret := nvmlDeviceSetAccountingMode(nvmlDeviceHandle(device), mode)
+	return ret
+}
+
+func (cgoapi) DeviceSetApplicationsClocks(device Device, memclockmhz uint32, graphicsclockmhz uint32) Return {
+	ret := nvmlDeviceSetApplicationsClocks(nvmlDeviceHandle(device), memclockmhz, graphicsclockmhz)
+	return ret
+}
+
+func (cgoapi) DeviceSetAutoBoostedClocksEnabled(device Device, enabled EnableState) Return {
+	ret := nvmlDeviceSetAutoBoostedClocksEnabled(nvmlDeviceHandle(device), enabled)
+	return ret
+}
+
+func (cgoapi) DeviceSetClockOffsets(device Device, info *ClockOffset) Return {
+	ret := nvmlDeviceSetClockOffsets(nvmlDeviceHandle(device), info)
+	return ret
+}
+
+func (cgoapi) DeviceSetComputeMode(device Device, mode ComputeMode) Return {
+	ret := nvmlDeviceSetComputeMode(nvmlDeviceHandle(device), mode)
+	return ret
+}
+
+func (cgoapi) DeviceSetConfComputeUnprotectedMemSize(device Device, sizekib uint64) Return {
+	ret := nvmlDeviceSetConfComputeUnprotectedMemSize(nvmlDeviceHandle(device), sizekib)
+	return ret
+}
+
+func (cgoapi) DeviceSetCpuAffinity(device Device) Return {
+	ret := nvmlDeviceSetCpuAffinity(nvmlDeviceHandle(device))
+	return ret
+}
+
+func (cgoapi) DeviceSetDefaultAutoBoostedClocksEnabled(device Device, enabled EnableState, flags uint32) Return {
+	ret := nvmlDeviceSetDefaultAutoBoostedClocksEnabled(nvmlDeviceHandle(device), enabled, flags)
+	return ret
+}
+
+func (cgoapi) DeviceSetDefaultFanSpeed_v2(device Device, fan uint32) Return {
+	ret := nvmlDeviceSetDefaultFanSpeed_v2(nvmlDeviceHandle(device), fan)
+	return ret
+}
+
+func (cgoapi) DeviceSetDramEncryptionMode(device Device, dramencryption *DramEncryptionInfo) Return {
+	ret := nvmlDeviceSetDramEncryptionMode(nvmlDeviceHandle(device), dramencryption)
+	return ret
+}
+
+func (cgoapi) DeviceSetDriverModel(device Device, drivermodel DriverModel, flags uint32) Return {
+	ret := nvmlDeviceSetDriverModel(nvmlDeviceHandle(device), drivermodel, flags)
+	return ret
+}
+
+func (cgoapi) DeviceSetEccMode(device Device, ecc EnableState) Return {
+	ret := nvmlDeviceSetEccMode(nvmlDeviceHandle(device), ecc)
+	return ret
+}
+
+func (cgoapi) DeviceSetFanControlPolicy(device Device, fan uint32, policy FanControlPolicy) Return {
+	ret := nvmlDeviceSetFanControlPolicy(nvmlDeviceHandle(device), fan, policy)
+	return ret
+}
+
+func (cgoapi) DeviceSetFanSpeed_v2(device Device, fan uint32, speed uint32) Return {
+	ret := nvmlDeviceSetFanSpeed_v2(nvmlDeviceHandle(device), fan, speed)
+	return ret
+}
+
+func (cgoapi) DeviceSetGpcClkVfOffset(device Device, offset int32) Return {
+	ret := nvmlDeviceSetGpcClkVfOffset(nvmlDeviceHandle(device), offset)
+	return ret
+}
+
+func (cgoapi) DeviceSetGpuLockedClocks(device Device, mingpuclockmhz uint32, maxgpuclockmhz uint32) Return {
+	ret := nvmlDeviceSetGpuLockedClocks(nvmlDeviceHandle(device), mingpuclockmhz, maxgpuclockmhz)
+	return ret
+}
+
+func (cgoapi) DeviceSetGpuOperationMode(device Device, mode GpuOperationMode) Return {
+	ret := nvmlDeviceSetGpuOperationMode(nvmlDeviceHandle(device), mode)
+	return ret
+}
+
+func (cgoapi) DeviceSetMemClkVfOffset(device Device, offset int32) Return {
+	ret := nvmlDeviceSetMemClkVfOffset(nvmlDeviceHandle(device), offset)
+	return ret
+}
+
+func (cgoapi) DeviceSetMemoryLockedClocks(device Device, minmemclockmhz uint32, maxmemclockmhz uint32) Return {
+	ret := nvmlDeviceSetMemoryLockedClocks(nvmlDeviceHandle(device), minmemclockmhz, maxmemclockmhz)
+	return ret
+}
+
+func (cgoapi) DeviceSetMigMode(device Device, mode uint32, activationstatus *Return) Return {
+	ret := nvmlDeviceSetMigMode(nvmlDeviceHandle(device), mode, activationstatus)
+	return ret
+}
+
+func (cgoapi) DeviceSetNvLinkDeviceLowPowerThreshold(device Device, info *NvLinkPowerThres) Return {
+	ret := nvmlDeviceSetNvLinkDeviceLowPowerThreshold(nvmlDeviceHandle(device), info)
+	return ret
+}
+
+func (cgoapi) DeviceSetNvLinkUtilizationControl(device Device, link uint32, counter uint32, control *NvLinkUtilizationControl, reset uint32) Return {
+	ret := nvmlDeviceSetNvLinkUtilizationControl(nvmlDeviceHandle(device), link, counter, control, reset)
+	return ret
+}
+
+func (cgoapi) DeviceSetNvlinkBwMode(device Device, setbwmode *NvlinkSetBwMode) Return {
+	ret := nvmlDeviceSetNvlinkBwMode(nvmlDeviceHandle(device), setbwmode)
+	return ret
+}
+
+func (cgoapi) DeviceSetPersistenceMode(device Device, mode EnableState) Return {
+	ret := nvmlDeviceSetPersistenceMode(nvmlDeviceHandle(device), mode)
+	return ret
+}
+
+func (cgoapi) DeviceSetPowerManagementLimit(device Device, limit uint32) Return {
+	ret := nvmlDeviceSetPowerManagementLimit(nvmlDeviceHandle(device), limit)
+	return ret
+}
+
+func (cgoapi) DeviceSetPowerManagementLimit_v2(device Device, powervalue *PowerValue_v2) Return {
+	ret := nvmlDeviceSetPowerManagementLimit_v2(nvmlDeviceHandle(device), powervalue)
+	return ret
+}
+
+func (cgoapi) DeviceSetTemperatureThreshold(device Device, thresholdtype TemperatureThresholds, temp *int32) Return {
+	ret := nvmlDeviceSetTemperatureThreshold(nvmlDeviceHandle(device), thresholdtype, temp)
+	return ret
+}
+
+func (cgoapi) DeviceSetVgpuCapabilities(device Device, capability DeviceVgpuCapability, state EnableState) Return {
+	ret := nvmlDeviceSetVgpuCapabilities(nvmlDeviceHandle(device), capability, state)
+	return ret
+}
+
+func (cgoapi) DeviceSetVgpuHeterogeneousMode(device Device, pheterogeneousmode *VgpuHeterogeneousMode) Return {
+	ret := nvmlDeviceSetVgpuHeterogeneousMode(nvmlDeviceHandle(device), pheterogeneousmode)
+	return ret
+}
+
+func (cgoapi) DeviceSetVgpuSchedulerState(device Device, pschedulerstate *VgpuSchedulerSetState) Return {
+	ret := nvmlDeviceSetVgpuSchedulerState(nvmlDeviceHandle(device), pschedulerstate)
+	return ret
+}
+
+func (cgoapi) DeviceSetVirtualizationMode(device Device, virtualmode GpuVirtualizationMode) Return {
+	ret := nvmlDeviceSetVirtualizationMode(nvmlDeviceHandle(device), virtualmode)
+	return ret
+}
+
+func (cgoapi) DeviceValidateInforom(device Device) Return {
+	ret := nvmlDeviceValidateInforom(nvmlDeviceHandle(device))
+	return ret
+}
+
+func (cgoapi) DeviceWorkloadPowerProfileClearRequestedProfiles(device Device, requestedprofiles *WorkloadPowerProfileRequestedProfiles) Return {
+	ret := nvmlDeviceWorkloadPowerProfileClearRequestedProfiles(nvmlDeviceHandle(device), requestedprofiles)
+	return ret
+}
+
+func (cgoapi) DeviceWorkloadPowerProfileGetCurrentProfiles(device Device, currentprofiles *WorkloadPowerProfileCurrentProfiles) Return {
+	ret := nvmlDeviceWorkloadPowerProfileGetCurrentProfiles(nvmlDeviceHandle(device), currentprofiles)
+	return ret
+}
+
+func (cgoapi) DeviceWorkloadPowerProfileGetProfilesInfo(device Device, profilesinfo *WorkloadPowerProfileProfilesInfo) Return {
+	ret := nvmlDeviceWorkloadPowerProfileGetProfilesInfo(nvmlDeviceHandle(device), profilesinfo)
+	return ret
+}
+
+func (cgoapi) DeviceWorkloadPowerProfileSetRequestedProfiles(device Device, requestedprofiles *WorkloadPowerProfileRequestedProfiles) Return {
+	ret := nvmlDeviceWorkloadPowerProfileSetRequestedProfiles(nvmlDeviceHandle(device), requestedprofiles)
+	return ret
+}
+
+func (cgoapi) ErrorString(result Return) string {
+	ret := nvmlErrorString(result)
+	return ret
+}
+
+func (cgoapi) EventSetCreate(set *EventSet) Return {
+	var nvmlSet nvmlEventSet
+	ret := nvmlEventSetCreate(&nvmlSet)
+	*set = EventSet(nvmlSet)
+	return ret
+}
+
+func (cgoapi) EventSetFree(set EventSet) Return {
+	ret := nvmlEventSetFree(nvmlEventSetHandle(set))
+	return ret
+}
+
+func (cgoapi) EventSetWait(set EventSet, data *EventData, timeoutms uint32) Return {
+	var nvmlData nvmlEventData
+	ret := nvmlEventSetWait(nvmlEventSetHandle(set), &nvmlData, timeoutms)
+	return ret
+}
+
+func (cgoapi) EventSetWait_v1(set EventSet, data *EventData, timeoutms uint32) Return {
+	var nvmlData nvmlEventData
+	ret := nvmlEventSetWait_v1(nvmlEventSetHandle(set), &nvmlData, timeoutms)
+	return ret
+}
+
+func (cgoapi) EventSetWait_v2(set EventSet, data *EventData, timeoutms uint32) Return {
+	var nvmlData nvmlEventData
+	ret := nvmlEventSetWait_v2(nvmlEventSetHandle(set), &nvmlData, timeoutms)
+	return ret
+}
+
+func (cgoapi) GetBlacklistDeviceCount(devicecount *uint32) Return {
+	ret := nvmlGetBlacklistDeviceCount(devicecount)
+	return ret
+}
+
+func (cgoapi) GetBlacklistDeviceInfoByIndex(index uint32, info *ExcludedDeviceInfo) Return {
+	ret := nvmlGetBlacklistDeviceInfoByIndex(index, info)
+	return ret
+}
+
+func (cgoapi) GetExcludedDeviceCount(devicecount *uint32) Return {
+	ret := nvmlGetExcludedDeviceCount(devicecount)
+	return ret
+}
+
+func (cgoapi) GetExcludedDeviceInfoByIndex(index uint32, info *ExcludedDeviceInfo) Return {
+	ret := nvmlGetExcludedDeviceInfoByIndex(index, info)
+	return ret
+}
+
+func (cgoapi) GetVgpuCompatibility(vgpumetadata *VgpuMetadata, pgpumetadata *VgpuPgpuMetadata, compatibilityinfo *VgpuPgpuCompatibility) Return {
+	ret := nvmlGetVgpuCompatibility(&vgpumetadata.nvmlVgpuMetadata, &pgpumetadata.nvmlVgpuPgpuMetadata, compatibilityinfo)
+	return ret
+}
+
+func (cgoapi) GetVgpuDriverCapabilities(capability VgpuDriverCapability, capresult *uint32) Return {
+	ret := nvmlGetVgpuDriverCapabilities(capability, capresult)
+	return ret
+}
+
+func (cgoapi) GetVgpuVersion(supported *VgpuVersion, current *VgpuVersion) Return {
+	ret := nvmlGetVgpuVersion(supported, current)
+	return ret
+}
+
+func (cgoapi) GpmMetricsGet(metricsget *GpmMetricsGetType) Return {
+	var nvmlMetricsget nvmlGpmMetricsGetType
+	ret := nvmlGpmMetricsGet(&nvmlMetricsget)
+	return ret
+}
+
+func (cgoapi) GpmMigSampleGet(device Device, gpuinstanceid uint32, gpmsample GpmSample) Return {
+	ret := nvmlGpmMigSampleGet(nvmlDeviceHandle(device), gpuinstanceid, nvmlGpmSampleHandle(gpmsample))
+	return ret
+}
+
+func (cgoapi) GpmQueryDeviceSupport(device Device, gpmsupport *GpmSupport) Return {
+	ret := nvmlGpmQueryDeviceSupport(nvmlDeviceHandle(device), gpmsupport)
+	return ret
+}
+
+func (cgoapi) GpmQueryIfStreamingEnabled(device Device, state *uint32) Return {
+	ret := nvmlGpmQueryIfStreamingEnabled(nvmlDeviceHandle(device), state)
+	return ret
+}
+
+func (cgoapi) GpmSampleAlloc(gpmsample *GpmSample) Return {
+	var nvmlGpmsample nvmlGpmSample
+	ret := nvmlGpmSampleAlloc(&nvmlGpmsample)
+	*gpmsample = GpmSample(nvmlGpmsample)
+	return ret
+}
+
+func (cgoapi) GpmSampleFree(gpmsample GpmSample) Return {
+	ret := nvmlGpmSampleFree(nvmlGpmSampleHandle(gpmsample))
+	return ret
+}
+
+func (cgoapi) GpmSampleGet(device Device, gpmsample GpmSample) Return {
+	ret := nvmlGpmSampleGet(nvmlDeviceHandle(device), nvmlGpmSampleHandle(gpmsample))
+	return ret
+}
+
+func (cgoapi) GpmSetStreamingEnabled(device Device, state uint32) Return {
+	ret := nvmlGpmSetStreamingEnabled(nvmlDeviceHandle(device), state)
+	return ret
+}
+
+func (cgoapi) GpuInstanceCreateComputeInstance(gpuinstance GpuInstance, profileid uint32, computeinstance *ComputeInstance) Return {
+	var nvmlComputeinstance nvmlComputeInstance
+	ret := nvmlGpuInstanceCreateComputeInstance(nvmlGpuInstanceHandle(gpuinstance), profileid, &nvmlComputeinstance)
+	*computeinstance = ComputeInstance(nvmlComputeinstance)
+	return ret
+}
+
+func (cgoapi) GpuInstanceCreateComputeInstanceWithPlacement(gpuinstance GpuInstance, profileid uint32, placement *ComputeInstancePlacement, computeinstance *ComputeInstance) Return {
+	var nvmlComputeinstance nvmlComputeInstance
+	ret := nvmlGpuInstanceCreateComputeInstanceWithPlacement(nvmlGpuInstanceHandle(gpuinstance), profileid, placement, &nvmlComputeinstance)
+	*computeinstance = ComputeInstance(nvmlComputeinstance)
+	return ret
+}
+
+func (cgoapi) GpuInstanceDestroy(gpuinstance GpuInstance) Return {
+	ret := nvmlGpuInstanceDestroy(nvmlGpuInstanceHandle(gpuinstance))
+	return ret
+}
+
+func (cgoapi) GpuInstanceGetActiveVgpus(gpuinstance GpuInstance, pvgpuinstanceinfo *ActiveVgpuInstanceInfo) Return {
+	ret := nvmlGpuInstanceGetActiveVgpus(nvmlGpuInstanceHandle(gpuinstance), pvgpuinstanceinfo)
+	return ret
+}
+
+func (cgoapi) GpuInstanceGetComputeInstanceById(gpuinstance GpuInstance, id uint32, computeinstance *ComputeInstance) Return {
+	var nvmlComputeinstance nvmlComputeInstance
+	ret := nvmlGpuInstanceGetComputeInstanceById(nvmlGpuInstanceHandle(gpuinstance), id, &nvmlComputeinstance)
+	*computeinstance = ComputeInstance(nvmlComputeinstance)
+	return ret
+}
+
+func (cgoapi) GpuInstanceGetComputeInstancePossiblePlacements(gpuinstance GpuInstance, profileid uint32, placements *ComputeInstancePlacement, count *uint32) Return {
+	ret := nvmlGpuInstanceGetComputeInstancePossiblePlacements(nvmlGpuInstanceHandle(gpuinstance), profileid, placements, count)
+	return ret
+}
+
+func (cgoapi) GpuInstanceGetComputeInstanceProfileInfo(gpuinstance GpuInstance, profile uint32, engprofile uint32, info *ComputeInstanceProfileInfo) Return {
+	ret := nvmlGpuInstanceGetComputeInstanceProfileInfo(nvmlGpuInstanceHandle(gpuinstance), profile, engprofile, info)
+	return ret
+}
+
+func (cgoapi) GpuInstanceGetComputeInstanceProfileInfoV(gpuinstance GpuInstance, profile uint32, engprofile uint32, info *ComputeInstanceProfileInfo_v2) Return {
+	ret := nvmlGpuInstanceGetComputeInstanceProfileInfoV(nvmlGpuInstanceHandle(gpuinstance), profile, engprofile, info)
+	return ret
+}
+
+func (cgoapi) GpuInstanceGetComputeInstanceRemainingCapacity(gpuinstance GpuInstance, profileid uint32, count *uint32) Return {
+	ret := nvmlGpuInstanceGetComputeInstanceRemainingCapacity(nvmlGpuInstanceHandle(gpuinstance), profileid, count)
+	return ret
+}
+
+func (cgoapi) GpuInstanceGetComputeInstances(gpuinstance GpuInstance, profileid uint32, computeinstances *ComputeInstance, count *uint32) Return {
+	var nvmlComputeinstances nvmlComputeInstance
+	ret := nvmlGpuInstanceGetComputeInstances(nvmlGpuInstanceHandle(gpuinstance), profileid, &nvmlComputeinstances, count)
+	*computeinstances = ComputeInstance(nvmlComputeinstances)
+	return ret
+}
+
+func (cgoapi) GpuInstanceGetCreatableVgpus(gpuinstance GpuInstance, pvgpus *VgpuTypeIdInfo) Return {
+	ret := nvmlGpuInstanceGetCreatableVgpus(nvmlGpuInstanceHandle(gpuinstance), pvgpus)
+	return ret
+}
+
+func (cgoapi) GpuInstanceGetInfo(gpuinstance GpuInstance, info *GpuInstanceInfo) Return {
+	var nvmlInfo nvmlGpuInstanceInfo
+	ret := nvmlGpuInstanceGetInfo(nvmlGpuInstanceHandle(gpuinstance), &nvmlInfo)
+	return ret
+}
+
+func (cgoapi) GpuInstanceGetVgpuHeterogeneousMode(gpuinstance GpuInstance, pheterogeneousmode *VgpuHeterogeneousMode) Return {
+	ret := nvmlGpuInstanceGetVgpuHeterogeneousMode(nvmlGpuInstanceHandle(gpuinstance), pheterogeneousmode)
+	return ret
+}
+
+func (cgoapi) GpuInstanceGetVgpuSchedulerLog(gpuinstance GpuInstance, pschedulerloginfo *VgpuSchedulerLogInfo) Return {
+	ret := nvmlGpuInstanceGetVgpuSchedulerLog(nvmlGpuInstanceHandle(gpuinstance), pschedulerloginfo)
+	return ret
+}
+
+func (cgoapi) GpuInstanceGetVgpuSchedulerState(gpuinstance GpuInstance, pschedulerstateinfo *VgpuSchedulerStateInfo) Return {
+	ret := nvmlGpuInstanceGetVgpuSchedulerState(nvmlGpuInstanceHandle(gpuinstance), pschedulerstateinfo)
+	return ret
+}
+
+func (cgoapi) GpuInstanceGetVgpuTypeCreatablePlacements(gpuinstance GpuInstance, pcreatableplacementinfo *VgpuCreatablePlacementInfo) Return {
+	ret := nvmlGpuInstanceGetVgpuTypeCreatablePlacements(nvmlGpuInstanceHandle(gpuinstance), pcreatableplacementinfo)
+	return ret
+}
+
+func (cgoapi) GpuInstanceSetVgpuHeterogeneousMode(gpuinstance GpuInstance, pheterogeneousmode *VgpuHeterogeneousMode) Return {
+	ret := nvmlGpuInstanceSetVgpuHeterogeneousMode(nvmlGpuInstanceHandle(gpuinstance), pheterogeneousmode)
+	return ret
+}
+
+func (cgoapi) GpuInstanceSetVgpuSchedulerState(gpuinstance GpuInstance, pscheduler *VgpuSchedulerState) Return {
+	ret := nvmlGpuInstanceSetVgpuSchedulerState(nvmlGpuInstanceHandle(gpuinstance), pscheduler)
+	return ret
+}
+
+func (cgoapi) Init() Return {
+	ret := nvmlInit()
+	return ret
+}
+
+func (cgoapi) InitWithFlags(flags uint32) Return {
+	ret := nvmlInitWithFlags(flags)
+	return ret
+}
+
+func (cgoapi) Init_v1() Return {
+	ret := nvmlInit_v1()
+	return ret
+}
+
+func (cgoapi) Init_v2() Return {
+	ret := nvmlInit_v2()
+	return ret
+}
+
+func (cgoapi) SetVgpuVersion(vgpuversion *VgpuVersion) Return {
+	ret := nvmlSetVgpuVersion(vgpuversion)
+	return ret
+}
+
+func (cgoapi) Shutdown() Return {
+	ret := nvmlShutdown()
+	return ret
+}
+
+func (cgoapi) SystemEventSetCreate(request *SystemEventSetCreateRequest) Return {
+	ret := nvmlSystemEventSetCreate(request)
+	return ret
+}
+
+func (cgoapi) SystemEventSetFree(request *SystemEventSetFreeRequest) Return {
+	ret := nvmlSystemEventSetFree(request)
+	return ret
+}
+
+func (cgoapi) SystemEventSetWait(request *SystemEventSetWaitRequest) Return {
+	ret := nvmlSystemEventSetWait(request)
+	return ret
+}
+
+func (cgoapi) SystemGetConfComputeCapabilities(capabilities *ConfComputeSystemCaps) Return {
+	ret := nvmlSystemGetConfComputeCapabilities(capabilities)
+	return ret
+}
+
+func (cgoapi) SystemGetConfComputeGpusReadyState(isacceptingwork *uint32) Return {
+	ret := nvmlSystemGetConfComputeGpusReadyState(isacceptingwork)
+	return ret
+}
+
+func (cgoapi) SystemGetConfComputeKeyRotationThresholdInfo(pkeyrotationthrinfo *ConfComputeGetKeyRotationThresholdInfo) Return {
+	ret := nvmlSystemGetConfComputeKeyRotationThresholdInfo(pkeyrotationthrinfo)
+	return ret
+}
+
+func (cgoapi) SystemGetConfComputeSettings(settings *SystemConfComputeSettings) Return {
+	ret := nvmlSystemGetConfComputeSettings(settings)
+	return ret
+}
+
+func (cgoapi) SystemGetConfComputeState(state *ConfComputeSystemState) Return {
+	ret := nvmlSystemGetConfComputeState(state)
+	return ret
+}
+
+func (cgoapi) SystemGetCudaDriverVersion(cudadriverversion *int32) Return {
+	ret := nvmlSystemGetCudaDriverVersion(cudadriverversion)
+	return ret
+}
+
+func (cgoapi) SystemGetCudaDriverVersion_v2(cudadriverversion *int32) Return {
+	ret := nvmlSystemGetCudaDriverVersion_v2(cudadriverversion)
+	return ret
+}
+
+func (cgoapi) SystemGetDriverBranch(branchinfo *SystemDriverBranchInfo, length uint32) Return {
+	ret := nvmlSystemGetDriverBranch(branchinfo, length)
+	return ret
+}
+
+func (cgoapi) SystemGetDriverVersion(version *byte, length uint32) Return {
+	ret := nvmlSystemGetDriverVersion(version, length)
+	return ret
+}
+
+func (cgoapi) SystemGetHicVersion(hwbccount *uint32, hwbcentries *HwbcEntry) Return {
+	ret := nvmlSystemGetHicVersion(hwbccount, hwbcentries)
+	return ret
+}
+
+func (cgoapi) SystemGetNVMLVersion(version *byte, length uint32) Return {
+	ret := nvmlSystemGetNVMLVersion(version, length)
+	return ret
+}
+
+func (cgoapi) SystemGetNvlinkBwMode(nvlinkbwmode *uint32) Return {
+	ret := nvmlSystemGetNvlinkBwMode(nvlinkbwmode)
+	return ret
+}
+
+func (cgoapi) SystemGetProcessName(pid uint32, name *byte, length uint32) Return {
+	ret := nvmlSystemGetProcessName(pid, name, length)
+	return ret
+}
+
+func (cgoapi) SystemGetTopologyGpuSet(cpunumber uint32, count *uint32, devicearray *Device) Return {
+	var nvmlDevicearray nvmlDevice
+	ret := nvmlSystemGetTopologyGpuSet(cpunumber, count, &nvmlDevicearray)
+	*devicearray = Device(nvmlDevicearray)
+	return ret
+}
+
+func (cgoapi) SystemRegisterEvents(request *SystemRegisterEventRequest) Return {
+	ret := nvmlSystemRegisterEvents(request)
+	return ret
+}
+
+func (cgoapi) SystemSetConfComputeGpusReadyState(isacceptingwork uint32) Return {
+	ret := nvmlSystemSetConfComputeGpusReadyState(isacceptingwork)
+	return ret
+}
+
+func (cgoapi) SystemSetConfComputeKeyRotationThresholdInfo(pkeyrotationthrinfo *ConfComputeSetKeyRotationThresholdInfo) Return {
+	ret := nvmlSystemSetConfComputeKeyRotationThresholdInfo(pkeyrotationthrinfo)
+	return ret
+}
+
+func (cgoapi) SystemSetNvlinkBwMode(nvlinkbwmode uint32) Return {
+	ret := nvmlSystemSetNvlinkBwMode(nvlinkbwmode)
+	return ret
+}
+
+func (cgoapi) UnitGetCount(unitcount *uint32) Return {
+	ret := nvmlUnitGetCount(unitcount)
+	return ret
+}
+
+func (cgoapi) UnitGetDevices(unit Unit, devicecount *uint32, devices *Device) Return {
+	var nvmlDevices nvmlDevice
+	ret := nvmlUnitGetDevices(nvmlUnitHandle(unit), devicecount, &nvmlDevices)
+	*devices = Device(nvmlDevices)
+	return ret
+}
+
+func (cgoapi) UnitGetFanSpeedInfo(unit Unit, fanspeeds *UnitFanSpeeds) Return {
+	ret := nvmlUnitGetFanSpeedInfo(nvmlUnitHandle(unit), fanspeeds)
+	return ret
+}
+
+func (cgoapi) UnitGetHandleByIndex(index uint32, unit *Unit) Return {
+	var nvmlUnit nvmlUnit
+	ret := nvmlUnitGetHandleByIndex(index, &nvmlUnit)
+	*unit = Unit(nvmlUnit)
+	return ret
+}
+
+func (cgoapi) UnitGetLedState(unit Unit, state *LedState) Return {
+	ret := nvmlUnitGetLedState(nvmlUnitHandle(unit), state)
+	return ret
+}
+
+func (cgoapi) UnitGetPsuInfo(unit Unit, psu *PSUInfo) Return {
+	ret := nvmlUnitGetPsuInfo(nvmlUnitHandle(unit), psu)
+	return ret
+}
+
+func (cgoapi) UnitGetTemperature(unit Unit, _type uint32, temp *uint32) Return {
+	ret := nvmlUnitGetTemperature(nvmlUnitHandle(unit), _type, temp)
+	return ret
+}
+
+func (cgoapi) UnitGetUnitInfo(unit Unit, info *UnitInfo) Return {
+	ret := nvmlUnitGetUnitInfo(nvmlUnitHandle(unit), info)
+	return ret
+}
+
+func (cgoapi) UnitSetLedState(unit Unit, color LedColor) Return {
+	ret := nvmlUnitSetLedState(nvmlUnitHandle(unit), color)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceClearAccountingPids(vgpuinstance VgpuInstance) Return {
+	ret := nvmlVgpuInstanceClearAccountingPids(nvmlVgpuInstanceHandle(vgpuinstance))
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetAccountingMode(vgpuinstance VgpuInstance, mode *EnableState) Return {
+	ret := nvmlVgpuInstanceGetAccountingMode(nvmlVgpuInstanceHandle(vgpuinstance), mode)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetAccountingPids(vgpuinstance VgpuInstance, count *uint32, pids *uint32) Return {
+	ret := nvmlVgpuInstanceGetAccountingPids(nvmlVgpuInstanceHandle(vgpuinstance), count, pids)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetAccountingStats(vgpuinstance VgpuInstance, pid uint32, stats *AccountingStats) Return {
+	ret := nvmlVgpuInstanceGetAccountingStats(nvmlVgpuInstanceHandle(vgpuinstance), pid, stats)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetEccMode(vgpuinstance VgpuInstance, eccmode *EnableState) Return {
+	ret := nvmlVgpuInstanceGetEccMode(nvmlVgpuInstanceHandle(vgpuinstance), eccmode)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetEncoderCapacity(vgpuinstance VgpuInstance, encodercapacity *uint32) Return {
+	ret := nvmlVgpuInstanceGetEncoderCapacity(nvmlVgpuInstanceHandle(vgpuinstance), encodercapacity)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetEncoderSessions(vgpuinstance VgpuInstance, sessioncount *uint32, sessioninfo *EncoderSessionInfo) Return {
+	ret := nvmlVgpuInstanceGetEncoderSessions(nvmlVgpuInstanceHandle(vgpuinstance), sessioncount, sessioninfo)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetEncoderStats(vgpuinstance VgpuInstance, sessioncount *uint32, averagefps *uint32, averagelatency *uint32) Return {
+	ret := nvmlVgpuInstanceGetEncoderStats(nvmlVgpuInstanceHandle(vgpuinstance), sessioncount, averagefps, averagelatency)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetFBCSessions(vgpuinstance VgpuInstance, sessioncount *uint32, sessioninfo *FBCSessionInfo) Return {
+	ret := nvmlVgpuInstanceGetFBCSessions(nvmlVgpuInstanceHandle(vgpuinstance), sessioncount, sessioninfo)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetFBCStats(vgpuinstance VgpuInstance, fbcstats *FBCStats) Return {
+	ret := nvmlVgpuInstanceGetFBCStats(nvmlVgpuInstanceHandle(vgpuinstance), fbcstats)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetFbUsage(vgpuinstance VgpuInstance, fbusage *uint64) Return {
+	ret := nvmlVgpuInstanceGetFbUsage(nvmlVgpuInstanceHandle(vgpuinstance), fbusage)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetFrameRateLimit(vgpuinstance VgpuInstance, frameratelimit *uint32) Return {
+	ret := nvmlVgpuInstanceGetFrameRateLimit(nvmlVgpuInstanceHandle(vgpuinstance), frameratelimit)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetGpuInstanceId(vgpuinstance VgpuInstance, gpuinstanceid *uint32) Return {
+	ret := nvmlVgpuInstanceGetGpuInstanceId(nvmlVgpuInstanceHandle(vgpuinstance), gpuinstanceid)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetGpuPciId(vgpuinstance VgpuInstance, vgpupciid *byte, length *uint32) Return {
+	ret := nvmlVgpuInstanceGetGpuPciId(nvmlVgpuInstanceHandle(vgpuinstance), vgpupciid, length)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetLicenseInfo(vgpuinstance VgpuInstance, licenseinfo *VgpuLicenseInfo) Return {
+	ret := nvmlVgpuInstanceGetLicenseInfo(nvmlVgpuInstanceHandle(vgpuinstance), licenseinfo)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetLicenseInfo_v1(vgpuinstance VgpuInstance, licenseinfo *VgpuLicenseInfo) Return {
+	ret := nvmlVgpuInstanceGetLicenseInfo_v1(nvmlVgpuInstanceHandle(vgpuinstance), licenseinfo)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetLicenseInfo_v2(vgpuinstance VgpuInstance, licenseinfo *VgpuLicenseInfo) Return {
+	ret := nvmlVgpuInstanceGetLicenseInfo_v2(nvmlVgpuInstanceHandle(vgpuinstance), licenseinfo)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetLicenseStatus(vgpuinstance VgpuInstance, licensed *uint32) Return {
+	ret := nvmlVgpuInstanceGetLicenseStatus(nvmlVgpuInstanceHandle(vgpuinstance), licensed)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetMdevUUID(vgpuinstance VgpuInstance, mdevuuid *byte, size uint32) Return {
+	ret := nvmlVgpuInstanceGetMdevUUID(nvmlVgpuInstanceHandle(vgpuinstance), mdevuuid, size)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetMetadata(vgpuinstance VgpuInstance, vgpumetadata *VgpuMetadata, buffersize *uint32) Return {
+	ret := nvmlVgpuInstanceGetMetadata(nvmlVgpuInstanceHandle(vgpuinstance), &vgpumetadata.nvmlVgpuMetadata, buffersize)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetPlacementId(vgpuinstance VgpuInstance, pplacement *VgpuPlacementId) Return {
+	ret := nvmlVgpuInstanceGetPlacementId(nvmlVgpuInstanceHandle(vgpuinstance), pplacement)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetRuntimeStateSize(vgpuinstance VgpuInstance, pstate *VgpuRuntimeState) Return {
+	ret := nvmlVgpuInstanceGetRuntimeStateSize(nvmlVgpuInstanceHandle(vgpuinstance), pstate)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetType(vgpuinstance VgpuInstance, vgputypeid *VgpuTypeId) Return {
+	var nvmlVgputypeid nvmlVgpuTypeId
+	ret := nvmlVgpuInstanceGetType(nvmlVgpuInstanceHandle(vgpuinstance), &nvmlVgputypeid)
+	*vgputypeid = VgpuTypeId(nvmlVgputypeid)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetUUID(vgpuinstance VgpuInstance, uuid *byte, size uint32) Return {
+	ret := nvmlVgpuInstanceGetUUID(nvmlVgpuInstanceHandle(vgpuinstance), uuid, size)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetVmDriverVersion(vgpuinstance VgpuInstance, version *byte, length uint32) Return {
+	ret := nvmlVgpuInstanceGetVmDriverVersion(nvmlVgpuInstanceHandle(vgpuinstance), version, length)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceGetVmID(vgpuinstance VgpuInstance, vmid *byte, size uint32, vmidtype *VgpuVmIdType) Return {
+	ret := nvmlVgpuInstanceGetVmID(nvmlVgpuInstanceHandle(vgpuinstance), vmid, size, vmidtype)
+	return ret
+}
+
+func (cgoapi) VgpuInstanceSetEncoderCapacity(vgpuinstance VgpuInstance, encodercapacity uint32) Return {
+	ret := nvmlVgpuInstanceSetEncoderCapacity(nvmlVgpuInstanceHandle(vgpuinstance), encodercapacity)
+	return ret
+}
+
+func (cgoapi) VgpuTypeGetBAR1Info(vgputypeid VgpuTypeId, bar1info *VgpuTypeBar1Info) Return {
+	ret := nvmlVgpuTypeGetBAR1Info(nvmlVgpuTypeIdHandle(vgputypeid), bar1info)
+	return ret
+}
+
+func (cgoapi) VgpuTypeGetCapabilities(vgputypeid VgpuTypeId, capability VgpuCapability, capresult *uint32) Return {
+	ret := nvmlVgpuTypeGetCapabilities(nvmlVgpuTypeIdHandle(vgputypeid), capability, capresult)
+	return ret
+}
+
+func (cgoapi) VgpuTypeGetClass(vgputypeid VgpuTypeId, vgputypeclass *byte, size *uint32) Return {
+	ret := nvmlVgpuTypeGetClass(nvmlVgpuTypeIdHandle(vgputypeid), vgputypeclass, size)
+	return ret
+}
+
+func (cgoapi) VgpuTypeGetDeviceID(vgputypeid VgpuTypeId, deviceid *uint64, subsystemid *uint64) Return {
+	ret := nvmlVgpuTypeGetDeviceID(nvmlVgpuTypeIdHandle(vgputypeid), deviceid, subsystemid)
+	return ret
+}
+
+func (cgoapi) VgpuTypeGetFbReservation(vgputypeid VgpuTypeId, fbreservation *uint64) Return {
+	ret := nvmlVgpuTypeGetFbReservation(nvmlVgpuTypeIdHandle(vgputypeid), fbreservation)
+	return ret
+}
+
+func (cgoapi) VgpuTypeGetFrameRateLimit(vgputypeid VgpuTypeId, frameratelimit *uint32) Return {
+	ret := nvmlVgpuTypeGetFrameRateLimit(nvmlVgpuTypeIdHandle(vgputypeid), frameratelimit)
+	return ret
+}
+
+func (cgoapi) VgpuTypeGetFramebufferSize(vgputypeid VgpuTypeId, fbsize *uint64) Return {
+	ret := nvmlVgpuTypeGetFramebufferSize(nvmlVgpuTypeIdHandle(vgputypeid), fbsize)
+	return ret
+}
+
+func (cgoapi) VgpuTypeGetGpuInstanceProfileId(vgputypeid VgpuTypeId, gpuinstanceprofileid *uint32) Return {
+	ret := nvmlVgpuTypeGetGpuInstanceProfileId(nvmlVgpuTypeIdHandle(vgputypeid), gpuinstanceprofileid)
+	return ret
+}
+
+func (cgoapi) VgpuTypeGetGspHeapSize(vgputypeid VgpuTypeId, gspheapsize *uint64) Return {
+	ret := nvmlVgpuTypeGetGspHeapSize(nvmlVgpuTypeIdHandle(vgputypeid), gspheapsize)
+	return ret
+}
+
+func (cgoapi) VgpuTypeGetLicense(vgputypeid VgpuTypeId, vgputypelicensestring *byte, size uint32) Return {
+	ret := nvmlVgpuTypeGetLicense(nvmlVgpuTypeIdHandle(vgputypeid), vgputypelicensestring, size)
+	return ret
+}
+
+func (cgoapi) VgpuTypeGetMaxInstances(device Device, vgputypeid VgpuTypeId, vgpuinstancecount *uint32) Return {
+	ret := nvmlVgpuTypeGetMaxInstances(nvmlDeviceHandle(device), nvmlVgpuTypeIdHandle(vgputypeid), vgpuinstancecount)
+	return ret
+}
+
+func (cgoapi) VgpuTypeGetMaxInstancesPerGpuInstance(pmaxinstance *VgpuTypeMaxInstance) Return {
+	ret := nvmlVgpuTypeGetMaxInstancesPerGpuInstance(pmaxinstance)
+	return ret
+}
+
+func (cgoapi) VgpuTypeGetMaxInstancesPerVm(vgputypeid VgpuTypeId, vgpuinstancecountpervm *uint32) Return {
+	ret := nvmlVgpuTypeGetMaxInstancesPerVm(nvmlVgpuTypeIdHandle(vgputypeid), vgpuinstancecountpervm)
+	return ret
+}
+
+func (cgoapi) VgpuTypeGetName(vgputypeid VgpuTypeId, vgputypename *byte, size *uint32) Return {
+	ret := nvmlVgpuTypeGetName(nvmlVgpuTypeIdHandle(vgputypeid), vgputypename, size)
+	return ret
+}
+
+func (cgoapi) VgpuTypeGetNumDisplayHeads(vgputypeid VgpuTypeId, numdisplayheads *uint32) Return {
+	ret := nvmlVgpuTypeGetNumDisplayHeads(nvmlVgpuTypeIdHandle(vgputypeid), numdisplayheads)
+	return ret
+}
+
+func (cgoapi) VgpuTypeGetResolution(vgputypeid VgpuTypeId, displayindex uint32, xdim *uint32, ydim *uint32) Return {
+	ret := nvmlVgpuTypeGetResolution(nvmlVgpuTypeIdHandle(vgputypeid), displayindex, xdim, ydim)
+	return ret
+}


### PR DESCRIPTION
    This interface can be used in conjunction with the standard "wrapper"
    interface, including the use its interface abstractions like Devices,
    GPUInstances, ComputeInstances, etc.
    
    It is invoked as nvml.CgoAPI.<api-call>, following the original function
    signatures of the C-API, where there is only a single return value and
    additional return values are passed as arguments.
    
    An example usage is:
    ```
            // Start with using the CgoAPI
            ret := nvml.CgoAPI.Init()
            defer nvml.Shutdown()
            require.Equal(t, SUCCESS, ret, "Init should succeed")
    
            var count uint32
            ret = nvml.CgoAPI.DeviceGetCount(&count)
            require.Equal(t, SUCCESS, ret, "DeviceGetCount should succeed")
    
            var device Device
            ret = nvml.CgoAPI.DeviceGetHandleByIndex(0, &device)
            require.Equal(t, SUCCESS, ret, "DeviceGetHandleByIndex should succeed")
    
            // Now call Device interface methods directly
            name, ret := device.GetName()
            require.Equal(t, SUCCESS, ret, "Device.GetName should succeed")
            t.Logf("Device.GetName: %s", name)
    
            uuid, ret := device.GetUUID()
            require.Equal(t, SUCCESS, ret, "Device.GetUUID should succeed")
            t.Logf("Device.GetUUID: %s", uuid)
    
            brand, ret := device.GetBrand()
            require.Equal(t, SUCCESS, ret, "Device.GetBrand should succeed")
            t.Logf("Device.GetBrand: %v", brand)
    
            busType, ret := device.GetBusType()
            require.Equal(t, SUCCESS, ret, "Device.GetBusType should succeed")
            t.Logf("Device.GetBusType: %v", busType)
    ```