### PR TITLE
Update DeviceGetconfComputeGpuAttestationReport to take struct as input

### DIFF
--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -2971,14 +2971,12 @@ func (device nvmlDevice) GetConfComputeGpuCertificate() (ConfComputeGpuCertifica
 }
 
 // nvml.DeviceGetConfComputeGpuAttestationReport()
-func (l *library) DeviceGetConfComputeGpuAttestationReport(device Device) (ConfComputeGpuAttestationReport, Return) {
-	return device.GetConfComputeGpuAttestationReport()
+func (l *library) DeviceGetConfComputeGpuAttestationReport(device Device, gpuAtstReport *ConfComputeGpuAttestationReport) Return {
+	return device.GetConfComputeGpuAttestationReport(gpuAtstReport)
 }
 
-func (device nvmlDevice) GetConfComputeGpuAttestationReport() (ConfComputeGpuAttestationReport, Return) {
-	var gpuAtstReport ConfComputeGpuAttestationReport
-	ret := nvmlDeviceGetConfComputeGpuAttestationReport(device, &gpuAtstReport)
-	return gpuAtstReport, ret
+func (device nvmlDevice) GetConfComputeGpuAttestationReport(gpuAtstReport *ConfComputeGpuAttestationReport) Return {
+	return nvmlDeviceGetConfComputeGpuAttestationReport(device, gpuAtstReport)
 }
 
 // nvml.DeviceSetConfComputeUnprotectedMemSize()

--- a/pkg/nvml/mock/device.go
+++ b/pkg/nvml/mock/device.go
@@ -120,7 +120,7 @@ var _ nvml.Device = &Device{}
 //			GetComputeRunningProcessesFunc: func() ([]nvml.ProcessInfo, nvml.Return) {
 //				panic("mock out the GetComputeRunningProcesses method")
 //			},
-//			GetConfComputeGpuAttestationReportFunc: func() (nvml.ConfComputeGpuAttestationReport, nvml.Return) {
+//			GetConfComputeGpuAttestationReportFunc: func(confComputeGpuAttestationReport *nvml.ConfComputeGpuAttestationReport) nvml.Return {
 //				panic("mock out the GetConfComputeGpuAttestationReport method")
 //			},
 //			GetConfComputeGpuCertificateFunc: func() (nvml.ConfComputeGpuCertificate, nvml.Return) {
@@ -902,7 +902,7 @@ type Device struct {
 	GetComputeRunningProcessesFunc func() ([]nvml.ProcessInfo, nvml.Return)
 
 	// GetConfComputeGpuAttestationReportFunc mocks the GetConfComputeGpuAttestationReport method.
-	GetConfComputeGpuAttestationReportFunc func() (nvml.ConfComputeGpuAttestationReport, nvml.Return)
+	GetConfComputeGpuAttestationReportFunc func(confComputeGpuAttestationReport *nvml.ConfComputeGpuAttestationReport) nvml.Return
 
 	// GetConfComputeGpuCertificateFunc mocks the GetConfComputeGpuCertificate method.
 	GetConfComputeGpuCertificateFunc func() (nvml.ConfComputeGpuCertificate, nvml.Return)
@@ -1707,6 +1707,8 @@ type Device struct {
 		}
 		// GetConfComputeGpuAttestationReport holds details about calls to the GetConfComputeGpuAttestationReport method.
 		GetConfComputeGpuAttestationReport []struct {
+			// ConfComputeGpuAttestationReport is the confComputeGpuAttestationReport argument value.
+			ConfComputeGpuAttestationReport *nvml.ConfComputeGpuAttestationReport
 		}
 		// GetConfComputeGpuCertificate holds details about calls to the GetConfComputeGpuCertificate method.
 		GetConfComputeGpuCertificate []struct {
@@ -3873,16 +3875,19 @@ func (mock *Device) GetComputeRunningProcessesCalls() []struct {
 }
 
 // GetConfComputeGpuAttestationReport calls GetConfComputeGpuAttestationReportFunc.
-func (mock *Device) GetConfComputeGpuAttestationReport() (nvml.ConfComputeGpuAttestationReport, nvml.Return) {
+func (mock *Device) GetConfComputeGpuAttestationReport(confComputeGpuAttestationReport *nvml.ConfComputeGpuAttestationReport) nvml.Return {
 	if mock.GetConfComputeGpuAttestationReportFunc == nil {
 		panic("Device.GetConfComputeGpuAttestationReportFunc: method is nil but Device.GetConfComputeGpuAttestationReport was just called")
 	}
 	callInfo := struct {
-	}{}
+		ConfComputeGpuAttestationReport *nvml.ConfComputeGpuAttestationReport
+	}{
+		ConfComputeGpuAttestationReport: confComputeGpuAttestationReport,
+	}
 	mock.lockGetConfComputeGpuAttestationReport.Lock()
 	mock.calls.GetConfComputeGpuAttestationReport = append(mock.calls.GetConfComputeGpuAttestationReport, callInfo)
 	mock.lockGetConfComputeGpuAttestationReport.Unlock()
-	return mock.GetConfComputeGpuAttestationReportFunc()
+	return mock.GetConfComputeGpuAttestationReportFunc(confComputeGpuAttestationReport)
 }
 
 // GetConfComputeGpuAttestationReportCalls gets all the calls that were made to GetConfComputeGpuAttestationReport.
@@ -3890,8 +3895,10 @@ func (mock *Device) GetConfComputeGpuAttestationReport() (nvml.ConfComputeGpuAtt
 //
 //	len(mockedDevice.GetConfComputeGpuAttestationReportCalls())
 func (mock *Device) GetConfComputeGpuAttestationReportCalls() []struct {
+	ConfComputeGpuAttestationReport *nvml.ConfComputeGpuAttestationReport
 } {
 	var calls []struct {
+		ConfComputeGpuAttestationReport *nvml.ConfComputeGpuAttestationReport
 	}
 	mock.lockGetConfComputeGpuAttestationReport.RLock()
 	calls = mock.calls.GetConfComputeGpuAttestationReport

--- a/pkg/nvml/mock/interface.go
+++ b/pkg/nvml/mock/interface.go
@@ -129,7 +129,7 @@ var _ nvml.Interface = &Interface{}
 //			DeviceGetComputeRunningProcessesFunc: func(device nvml.Device) ([]nvml.ProcessInfo, nvml.Return) {
 //				panic("mock out the DeviceGetComputeRunningProcesses method")
 //			},
-//			DeviceGetConfComputeGpuAttestationReportFunc: func(device nvml.Device) (nvml.ConfComputeGpuAttestationReport, nvml.Return) {
+//			DeviceGetConfComputeGpuAttestationReportFunc: func(device nvml.Device, confComputeGpuAttestationReport *nvml.ConfComputeGpuAttestationReport) nvml.Return {
 //				panic("mock out the DeviceGetConfComputeGpuAttestationReport method")
 //			},
 //			DeviceGetConfComputeGpuCertificateFunc: func(device nvml.Device) (nvml.ConfComputeGpuCertificate, nvml.Return) {
@@ -1259,7 +1259,7 @@ type Interface struct {
 	DeviceGetComputeRunningProcessesFunc func(device nvml.Device) ([]nvml.ProcessInfo, nvml.Return)
 
 	// DeviceGetConfComputeGpuAttestationReportFunc mocks the DeviceGetConfComputeGpuAttestationReport method.
-	DeviceGetConfComputeGpuAttestationReportFunc func(device nvml.Device) (nvml.ConfComputeGpuAttestationReport, nvml.Return)
+	DeviceGetConfComputeGpuAttestationReportFunc func(device nvml.Device, confComputeGpuAttestationReport *nvml.ConfComputeGpuAttestationReport) nvml.Return
 
 	// DeviceGetConfComputeGpuCertificateFunc mocks the DeviceGetConfComputeGpuCertificate method.
 	DeviceGetConfComputeGpuCertificateFunc func(device nvml.Device) (nvml.ConfComputeGpuCertificate, nvml.Return)
@@ -2486,6 +2486,8 @@ type Interface struct {
 		DeviceGetConfComputeGpuAttestationReport []struct {
 			// Device is the device argument value.
 			Device nvml.Device
+			// ConfComputeGpuAttestationReport is the confComputeGpuAttestationReport argument value.
+			ConfComputeGpuAttestationReport *nvml.ConfComputeGpuAttestationReport
 		}
 		// DeviceGetConfComputeGpuCertificate holds details about calls to the DeviceGetConfComputeGpuCertificate method.
 		DeviceGetConfComputeGpuCertificate []struct {
@@ -6036,19 +6038,21 @@ func (mock *Interface) DeviceGetComputeRunningProcessesCalls() []struct {
 }
 
 // DeviceGetConfComputeGpuAttestationReport calls DeviceGetConfComputeGpuAttestationReportFunc.
-func (mock *Interface) DeviceGetConfComputeGpuAttestationReport(device nvml.Device) (nvml.ConfComputeGpuAttestationReport, nvml.Return) {
+func (mock *Interface) DeviceGetConfComputeGpuAttestationReport(device nvml.Device, confComputeGpuAttestationReport *nvml.ConfComputeGpuAttestationReport) nvml.Return {
 	if mock.DeviceGetConfComputeGpuAttestationReportFunc == nil {
 		panic("Interface.DeviceGetConfComputeGpuAttestationReportFunc: method is nil but Interface.DeviceGetConfComputeGpuAttestationReport was just called")
 	}
 	callInfo := struct {
-		Device nvml.Device
+		Device                          nvml.Device
+		ConfComputeGpuAttestationReport *nvml.ConfComputeGpuAttestationReport
 	}{
-		Device: device,
+		Device:                          device,
+		ConfComputeGpuAttestationReport: confComputeGpuAttestationReport,
 	}
 	mock.lockDeviceGetConfComputeGpuAttestationReport.Lock()
 	mock.calls.DeviceGetConfComputeGpuAttestationReport = append(mock.calls.DeviceGetConfComputeGpuAttestationReport, callInfo)
 	mock.lockDeviceGetConfComputeGpuAttestationReport.Unlock()
-	return mock.DeviceGetConfComputeGpuAttestationReportFunc(device)
+	return mock.DeviceGetConfComputeGpuAttestationReportFunc(device, confComputeGpuAttestationReport)
 }
 
 // DeviceGetConfComputeGpuAttestationReportCalls gets all the calls that were made to DeviceGetConfComputeGpuAttestationReport.
@@ -6056,10 +6060,12 @@ func (mock *Interface) DeviceGetConfComputeGpuAttestationReport(device nvml.Devi
 //
 //	len(mockedInterface.DeviceGetConfComputeGpuAttestationReportCalls())
 func (mock *Interface) DeviceGetConfComputeGpuAttestationReportCalls() []struct {
-	Device nvml.Device
+	Device                          nvml.Device
+	ConfComputeGpuAttestationReport *nvml.ConfComputeGpuAttestationReport
 } {
 	var calls []struct {
-		Device nvml.Device
+		Device                          nvml.Device
+		ConfComputeGpuAttestationReport *nvml.ConfComputeGpuAttestationReport
 	}
 	mock.lockDeviceGetConfComputeGpuAttestationReport.RLock()
 	calls = mock.calls.DeviceGetConfComputeGpuAttestationReport

--- a/pkg/nvml/zz_generated.api.go
+++ b/pkg/nvml/zz_generated.api.go
@@ -437,7 +437,7 @@ type Interface interface {
 	DeviceGetComputeInstanceId(Device) (int, Return)
 	DeviceGetComputeMode(Device) (ComputeMode, Return)
 	DeviceGetComputeRunningProcesses(Device) ([]ProcessInfo, Return)
-	DeviceGetConfComputeGpuAttestationReport(Device) (ConfComputeGpuAttestationReport, Return)
+	DeviceGetConfComputeGpuAttestationReport(Device, *ConfComputeGpuAttestationReport) Return
 	DeviceGetConfComputeGpuCertificate(Device) (ConfComputeGpuCertificate, Return)
 	DeviceGetConfComputeMemSizeInfo(Device) (ConfComputeMemSizeInfo, Return)
 	DeviceGetConfComputeProtectedMemoryUsage(Device) (Memory, Return)
@@ -814,7 +814,7 @@ type Device interface {
 	GetComputeInstanceId() (int, Return)
 	GetComputeMode() (ComputeMode, Return)
 	GetComputeRunningProcesses() ([]ProcessInfo, Return)
-	GetConfComputeGpuAttestationReport() (ConfComputeGpuAttestationReport, Return)
+	GetConfComputeGpuAttestationReport(*ConfComputeGpuAttestationReport) Return
 	GetConfComputeGpuCertificate() (ConfComputeGpuCertificate, Return)
 	GetConfComputeMemSizeInfo() (ConfComputeMemSizeInfo, Return)
 	GetConfComputeProtectedMemoryUsage() (Memory, Return)


### PR DESCRIPTION
This is a BREAKING CHANGE, but one that is necessary, because the API is unusable in its current form. In the C API, the input struct us used to pass _both_ input _and_ output. In our original implementation we didn't take this struct as input, so there was no way to get this input passed into the function. The API has now been updated to correct this.

One option could have been to just add the single input field as an input to the API call on its own, but this is not scalable in cases where one my add more input fields to the struct in the future.

In the end, (even though this goes against our other wrapper API calls), we decided it was best to just pass the whole struct and assume its usage as both input and output just like the C API.

We plan to revisit how to more comprehensively accommodate APIS such as this in the future.