### PR TITLE
Fix DeviceGetRunningProcessDetailList API

### DIFF
--- a/pkg/nvml/cgo_helpers_static.go
+++ b/pkg/nvml/cgo_helpers_static.go
@@ -18,6 +18,9 @@ import (
 	"unsafe"
 )
 
+/*
+#include <stdlib.h>
+*/
 import "C"
 
 var cgoAllocsUnknown = new(struct{})
@@ -72,4 +75,12 @@ func packPCharString(p *C.char) (raw string) {
 func unpackPCharString(str string) (*C.char, *struct{}) {
 	h := (*stringHeader)(unsafe.Pointer(&str))
 	return (*C.char)(h.Data), cgoAllocsUnknown
+}
+
+func malloc(size uintptr) unsafe.Pointer {
+	return C.malloc(C.size_t(size))
+}
+
+func free(ptr unsafe.Pointer) {
+	C.free(ptr)
 }


### PR DESCRIPTION
The DeviceGetRunningProcessDetailList API constantly returns ERROR_INSUFFICIENT_SIZE since we did not setup ProcessDetailList properly. Let's allocate memory for ProcessDetailList::ProcArray before invoking nvmlDeviceGetRunningProcessDetailList() so that we can retrieve the process list. Note that the memory allocation has to be done in cgo otherwise we will hit a Golang runtime error.