### PR TITLE
Restored default nvml api

### DIFF
--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -3276,21 +3276,23 @@ func (device nvmlDevice) GetCoolerInfo() (CoolerInfo, Return) {
 // nvml.DeviceGetTemperatureV()
 type TemperatureHandler struct {
 	device nvmlDevice
+	sensorType TemperatureSensors
 }
 
 func (handler TemperatureHandler) V1() (Temperature, Return) {
 	var temperature Temperature
 	temperature.Version = STRUCT_VERSION(temperature, 1)
+	temperature.SensorType = uint32(handler.sensorType)
 	ret := nvmlDeviceGetTemperatureV(handler.device, &temperature)
 	return temperature, ret
 }
 
-func (l *library) DeviceGetTemperatureV(device Device) TemperatureHandler {
-	return device.GetTemperatureV()
+func (l *library) DeviceGetTemperatureV(device Device, sensorType TemperatureSensors) TemperatureHandler {
+	return device.GetTemperatureV(sensorType)
 }
 
-func (device nvmlDevice) GetTemperatureV() TemperatureHandler {
-	return TemperatureHandler{device}
+func (device nvmlDevice) GetTemperatureV(sensorType TemperatureSensors) TemperatureHandler {
+	return TemperatureHandler{device, sensorType}
 }
 
 // nvml.DeviceGetMarginTemperature()

--- a/pkg/nvml/mock/device.go
+++ b/pkg/nvml/mock/device.go
@@ -555,7 +555,7 @@ var _ nvml.Device = &Device{}
 //			GetTemperatureThresholdFunc: func(temperatureThresholds nvml.TemperatureThresholds) (uint32, nvml.Return) {
 //				panic("mock out the GetTemperatureThreshold method")
 //			},
-//			GetTemperatureVFunc: func() nvml.TemperatureHandler {
+//			GetTemperatureVFunc: func(temperatureSensors nvml.TemperatureSensors) nvml.TemperatureHandler {
 //				panic("mock out the GetTemperatureV method")
 //			},
 //			GetThermalSettingsFunc: func(v uint32) (nvml.GpuThermalSettings, nvml.Return) {
@@ -1337,7 +1337,7 @@ type Device struct {
 	GetTemperatureThresholdFunc func(temperatureThresholds nvml.TemperatureThresholds) (uint32, nvml.Return)
 
 	// GetTemperatureVFunc mocks the GetTemperatureV method.
-	GetTemperatureVFunc func() nvml.TemperatureHandler
+	GetTemperatureVFunc func(temperatureSensors nvml.TemperatureSensors) nvml.TemperatureHandler
 
 	// GetThermalSettingsFunc mocks the GetThermalSettings method.
 	GetThermalSettingsFunc func(v uint32) (nvml.GpuThermalSettings, nvml.Return)
@@ -8048,7 +8048,7 @@ func (mock *Device) GetTemperatureThresholdCalls() []struct {
 }
 
 // GetTemperatureV calls GetTemperatureVFunc.
-func (mock *Device) GetTemperatureV() nvml.TemperatureHandler {
+func (mock *Device) GetTemperatureV(temperatureSensors nvml.TemperatureSensors) nvml.TemperatureHandler {
 	if mock.GetTemperatureVFunc == nil {
 		panic("Device.GetTemperatureVFunc: method is nil but Device.GetTemperatureV was just called")
 	}
@@ -8057,7 +8057,7 @@ func (mock *Device) GetTemperatureV() nvml.TemperatureHandler {
 	mock.lockGetTemperatureV.Lock()
 	mock.calls.GetTemperatureV = append(mock.calls.GetTemperatureV, callInfo)
 	mock.lockGetTemperatureV.Unlock()
-	return mock.GetTemperatureVFunc()
+	return mock.GetTemperatureVFunc(temperatureSensors)
 }
 
 // GetTemperatureVCalls gets all the calls that were made to GetTemperatureV.

--- a/pkg/nvml/mock/interface.go
+++ b/pkg/nvml/mock/interface.go
@@ -582,7 +582,7 @@ var _ nvml.Interface = &Interface{}
 //			DeviceGetTemperatureThresholdFunc: func(device nvml.Device, temperatureThresholds nvml.TemperatureThresholds) (uint32, nvml.Return) {
 //				panic("mock out the DeviceGetTemperatureThreshold method")
 //			},
-//			DeviceGetTemperatureVFunc: func(device nvml.Device) nvml.TemperatureHandler {
+//			DeviceGetTemperatureVFunc: func(device nvml.Device, temperatureSensors nvml.TemperatureSensors) nvml.TemperatureHandler {
 //				panic("mock out the DeviceGetTemperatureV method")
 //			},
 //			DeviceGetThermalSettingsFunc: func(device nvml.Device, v uint32) (nvml.GpuThermalSettings, nvml.Return) {
@@ -1712,7 +1712,7 @@ type Interface struct {
 	DeviceGetTemperatureThresholdFunc func(device nvml.Device, temperatureThresholds nvml.TemperatureThresholds) (uint32, nvml.Return)
 
 	// DeviceGetTemperatureVFunc mocks the DeviceGetTemperatureV method.
-	DeviceGetTemperatureVFunc func(device nvml.Device) nvml.TemperatureHandler
+	DeviceGetTemperatureVFunc func(device nvml.Device, temperatureSensors nvml.TemperatureSensors) nvml.TemperatureHandler
 
 	// DeviceGetThermalSettingsFunc mocks the DeviceGetThermalSettings method.
 	DeviceGetThermalSettingsFunc func(device nvml.Device, v uint32) (nvml.GpuThermalSettings, nvml.Return)
@@ -11081,7 +11081,7 @@ func (mock *Interface) DeviceGetTemperatureThresholdCalls() []struct {
 }
 
 // DeviceGetTemperatureV calls DeviceGetTemperatureVFunc.
-func (mock *Interface) DeviceGetTemperatureV(device nvml.Device) nvml.TemperatureHandler {
+func (mock *Interface) DeviceGetTemperatureV(device nvml.Device, temperatureSensors nvml.TemperatureSensors) nvml.TemperatureHandler {
 	if mock.DeviceGetTemperatureVFunc == nil {
 		panic("Interface.DeviceGetTemperatureVFunc: method is nil but Interface.DeviceGetTemperatureV was just called")
 	}
@@ -11093,7 +11093,7 @@ func (mock *Interface) DeviceGetTemperatureV(device nvml.Device) nvml.Temperatur
 	mock.lockDeviceGetTemperatureV.Lock()
 	mock.calls.DeviceGetTemperatureV = append(mock.calls.DeviceGetTemperatureV, callInfo)
 	mock.lockDeviceGetTemperatureV.Unlock()
-	return mock.DeviceGetTemperatureVFunc(device)
+	return mock.DeviceGetTemperatureVFunc(device, temperatureSensors)
 }
 
 // DeviceGetTemperatureVCalls gets all the calls that were made to DeviceGetTemperatureV.

--- a/pkg/nvml/zz_generated.api.go
+++ b/pkg/nvml/zz_generated.api.go
@@ -588,7 +588,7 @@ type Interface interface {
 	DeviceGetTargetFanSpeed(Device, int) (int, Return)
 	DeviceGetTemperature(Device, TemperatureSensors) (uint32, Return)
 	DeviceGetTemperatureThreshold(Device, TemperatureThresholds) (uint32, Return)
-	DeviceGetTemperatureV(Device) TemperatureHandler
+	DeviceGetTemperatureV(Device, TemperatureSensors) TemperatureHandler
 	DeviceGetThermalSettings(Device, uint32) (GpuThermalSettings, Return)
 	DeviceGetTopologyCommonAncestor(Device, Device) (GpuTopologyLevel, Return)
 	DeviceGetTopologyNearestGpus(Device, GpuTopologyLevel) ([]Device, Return)
@@ -959,7 +959,7 @@ type Device interface {
 	GetTargetFanSpeed(int) (int, Return)
 	GetTemperature(TemperatureSensors) (uint32, Return)
 	GetTemperatureThreshold(TemperatureThresholds) (uint32, Return)
-	GetTemperatureV() TemperatureHandler
+	GetTemperatureV(TemperatureSensors) TemperatureHandler
 	GetThermalSettings(uint32) (GpuThermalSettings, Return)
 	GetTopologyCommonAncestor(Device) (GpuTopologyLevel, Return)
 	GetTopologyNearestGpus(GpuTopologyLevel) ([]Device, Return)


### PR DESCRIPTION
Restored default nvml api
The original (C) nvml let user specify what
type of temperature sensor he want to query.

This is why we change GO implementation, and
user can call the functions with familiar
manner.

Signed-off-by: Dmitrii Chervov <dschervov@yandex-team.ru>
