### PR TITLE
Fix GPM query device support version

### DIFF
--- a/pkg/nvml/gpm.go
+++ b/pkg/nvml/gpm.go
@@ -58,6 +58,7 @@ func (l *library) GpmMetricsGetV(metricsGet *GpmMetricsGetType) GpmMetricsGetVTy
 
 // nvmlGpmMetricsGetStub is a stub function that can be overridden for testing.
 var nvmlGpmMetricsGetStub = nvmlGpmMetricsGet
+var nvmlGpmQueryDeviceSupportStub = nvmlGpmQueryDeviceSupport
 
 func (metricsGetV GpmMetricsGetVType) V1() Return {
 	metricsGetV.metricsGet.Version = 1
@@ -120,8 +121,8 @@ func (device nvmlDevice) GpmQueryDeviceSupportV() GpmSupportV {
 
 func (gpmSupportV GpmSupportV) V1() (GpmSupport, Return) {
 	var gpmSupport GpmSupport
-	gpmSupport.Version = STRUCT_VERSION(gpmSupport, 1)
-	ret := nvmlGpmQueryDeviceSupport(gpmSupportV.device, &gpmSupport)
+	gpmSupport.Version = GPM_SUPPORT_VERSION
+	ret := nvmlGpmQueryDeviceSupportStub(gpmSupportV.device, &gpmSupport)
 	return gpmSupport, ret
 }
 
@@ -131,8 +132,8 @@ func (l *library) GpmQueryDeviceSupport(device Device) (GpmSupport, Return) {
 
 func (device nvmlDevice) GpmQueryDeviceSupport() (GpmSupport, Return) {
 	var gpmSupport GpmSupport
-	gpmSupport.Version = STRUCT_VERSION(gpmSupport, GPM_SUPPORT_VERSION)
-	ret := nvmlGpmQueryDeviceSupport(device, &gpmSupport)
+	gpmSupport.Version = GPM_SUPPORT_VERSION
+	ret := nvmlGpmQueryDeviceSupportStub(device, &gpmSupport)
 	return gpmSupport, ret
 }
 

--- a/pkg/nvml/gpm_test.go
+++ b/pkg/nvml/gpm_test.go
@@ -69,11 +69,48 @@ func TestGpmMetricsGetV(t *testing.T) {
 	require.EqualValues(t, overrideMetrics, metrics.Metrics)
 }
 
+func TestGpmQueryDeviceSupportUsesStructVersionV1(t *testing.T) {
+	defer setNvmlGpmQueryDeviceSupportStubForTest(func(device nvmlDevice, gpmSupport *GpmSupport) Return {
+		require.EqualValues(t, GPM_SUPPORT_VERSION, gpmSupport.Version)
+		gpmSupport.IsSupportedDevice = 1
+		return SUCCESS
+	})()
+
+	gpmSupport, ret := nvmlDevice{}.GpmQueryDeviceSupport()
+
+	require.Equal(t, SUCCESS, ret)
+	require.EqualValues(t, GPM_SUPPORT_VERSION, gpmSupport.Version)
+	require.EqualValues(t, 1, gpmSupport.IsSupportedDevice)
+}
+
+func TestGpmQueryDeviceSupportV1UsesStructVersionV1(t *testing.T) {
+	defer setNvmlGpmQueryDeviceSupportStubForTest(func(device nvmlDevice, gpmSupport *GpmSupport) Return {
+		require.EqualValues(t, GPM_SUPPORT_VERSION, gpmSupport.Version)
+		gpmSupport.IsSupportedDevice = 1
+		return SUCCESS
+	})()
+
+	gpmSupport, ret := nvmlDevice{}.GpmQueryDeviceSupportV().V1()
+
+	require.Equal(t, SUCCESS, ret)
+	require.EqualValues(t, GPM_SUPPORT_VERSION, gpmSupport.Version)
+	require.EqualValues(t, 1, gpmSupport.IsSupportedDevice)
+}
+
 func setNvmlGpmMetricsGetStubForTest(mock func(metricsGet *nvmlGpmMetricsGetType) Return) func() {
 	original := nvmlGpmMetricsGetStub
 
 	nvmlGpmMetricsGetStub = mock
 	return func() {
 		nvmlGpmMetricsGetStub = original
+	}
+}
+
+func setNvmlGpmQueryDeviceSupportStubForTest(mock func(device nvmlDevice, gpmSupport *GpmSupport) Return) func() {
+	original := nvmlGpmQueryDeviceSupportStub
+
+	nvmlGpmQueryDeviceSupportStub = mock
+	return func() {
+		nvmlGpmQueryDeviceSupportStub = original
 	}
 }


### PR DESCRIPTION
Use the raw GPM support version expected by NVML so the example no longer fails with argument version mismatch, and add regression coverage for both helper paths. 

Should fix https://github.com/NVIDIA/go-nvml/issues/168