### PR TITLE
vgpu: expose underlying uint32 via VgpuTypeId.GetID()

### DIFF
--- a/pkg/nvml/mock/interface.go
+++ b/pkg/nvml/mock/interface.go
@@ -1170,6 +1170,9 @@ var _ nvml.Interface = &Interface{}
 //			VgpuTypeGetGpuInstanceProfileIdFunc: func(vgpuTypeId nvml.VgpuTypeId) (uint32, nvml.Return) {
 //				panic("mock out the VgpuTypeGetGpuInstanceProfileId method")
 //			},
+//			VgpuTypeGetIDFunc: func(vgpuTypeId nvml.VgpuTypeId) uint32 {
+//				panic("mock out the VgpuTypeGetID method")
+//			},
 //			VgpuTypeGetLicenseFunc: func(vgpuTypeId nvml.VgpuTypeId) (string, nvml.Return) {
 //				panic("mock out the VgpuTypeGetLicense method")
 //			},
@@ -2349,6 +2352,9 @@ type Interface struct {
 
 	// VgpuTypeGetGpuInstanceProfileIdFunc mocks the VgpuTypeGetGpuInstanceProfileId method.
 	VgpuTypeGetGpuInstanceProfileIdFunc func(vgpuTypeId nvml.VgpuTypeId) (uint32, nvml.Return)
+
+	// VgpuTypeGetIDFunc mocks the VgpuTypeGetID method.
+	VgpuTypeGetIDFunc func(vgpuTypeId nvml.VgpuTypeId) uint32
 
 	// VgpuTypeGetLicenseFunc mocks the VgpuTypeGetLicense method.
 	VgpuTypeGetLicenseFunc func(vgpuTypeId nvml.VgpuTypeId) (string, nvml.Return)
@@ -4599,6 +4605,11 @@ type Interface struct {
 			// VgpuTypeId is the vgpuTypeId argument value.
 			VgpuTypeId nvml.VgpuTypeId
 		}
+		// VgpuTypeGetID holds details about calls to the VgpuTypeGetID method.
+		VgpuTypeGetID []struct {
+			// VgpuTypeId is the vgpuTypeId argument value.
+			VgpuTypeId nvml.VgpuTypeId
+		}
 		// VgpuTypeGetLicense holds details about calls to the VgpuTypeGetLicense method.
 		VgpuTypeGetLicense []struct {
 			// VgpuTypeId is the vgpuTypeId argument value.
@@ -5023,6 +5034,7 @@ type Interface struct {
 	lockVgpuTypeGetFrameRateLimit                        sync.RWMutex
 	lockVgpuTypeGetFramebufferSize                       sync.RWMutex
 	lockVgpuTypeGetGpuInstanceProfileId                  sync.RWMutex
+	lockVgpuTypeGetID                                    sync.RWMutex
 	lockVgpuTypeGetLicense                               sync.RWMutex
 	lockVgpuTypeGetMaxInstances                          sync.RWMutex
 	lockVgpuTypeGetMaxInstancesPerGpuInstance            sync.RWMutex
@@ -17907,6 +17919,38 @@ func (mock *Interface) VgpuTypeGetGpuInstanceProfileIdCalls() []struct {
 	mock.lockVgpuTypeGetGpuInstanceProfileId.RLock()
 	calls = mock.calls.VgpuTypeGetGpuInstanceProfileId
 	mock.lockVgpuTypeGetGpuInstanceProfileId.RUnlock()
+	return calls
+}
+
+// VgpuTypeGetID calls VgpuTypeGetIDFunc.
+func (mock *Interface) VgpuTypeGetID(vgpuTypeId nvml.VgpuTypeId) uint32 {
+	if mock.VgpuTypeGetIDFunc == nil {
+		panic("Interface.VgpuTypeGetIDFunc: method is nil but Interface.VgpuTypeGetID was just called")
+	}
+	callInfo := struct {
+		VgpuTypeId nvml.VgpuTypeId
+	}{
+		VgpuTypeId: vgpuTypeId,
+	}
+	mock.lockVgpuTypeGetID.Lock()
+	mock.calls.VgpuTypeGetID = append(mock.calls.VgpuTypeGetID, callInfo)
+	mock.lockVgpuTypeGetID.Unlock()
+	return mock.VgpuTypeGetIDFunc(vgpuTypeId)
+}
+
+// VgpuTypeGetIDCalls gets all the calls that were made to VgpuTypeGetID.
+// Check the length with:
+//
+//	len(mockedInterface.VgpuTypeGetIDCalls())
+func (mock *Interface) VgpuTypeGetIDCalls() []struct {
+	VgpuTypeId nvml.VgpuTypeId
+} {
+	var calls []struct {
+		VgpuTypeId nvml.VgpuTypeId
+	}
+	mock.lockVgpuTypeGetID.RLock()
+	calls = mock.calls.VgpuTypeGetID
+	mock.lockVgpuTypeGetID.RUnlock()
 	return calls
 }
 

--- a/pkg/nvml/mock/vgputypeid.go
+++ b/pkg/nvml/mock/vgputypeid.go
@@ -42,6 +42,9 @@ var _ nvml.VgpuTypeId = &VgpuTypeId{}
 //			GetGpuInstanceProfileIdFunc: func() (uint32, nvml.Return) {
 //				panic("mock out the GetGpuInstanceProfileId method")
 //			},
+//			GetIDFunc: func() uint32 {
+//				panic("mock out the GetID method")
+//			},
 //			GetLicenseFunc: func() (string, nvml.Return) {
 //				panic("mock out the GetLicense method")
 //			},
@@ -94,6 +97,9 @@ type VgpuTypeId struct {
 	// GetGpuInstanceProfileIdFunc mocks the GetGpuInstanceProfileId method.
 	GetGpuInstanceProfileIdFunc func() (uint32, nvml.Return)
 
+	// GetIDFunc mocks the GetID method.
+	GetIDFunc func() uint32
+
 	// GetLicenseFunc mocks the GetLicense method.
 	GetLicenseFunc func() (string, nvml.Return)
 
@@ -145,6 +151,9 @@ type VgpuTypeId struct {
 		// GetGpuInstanceProfileId holds details about calls to the GetGpuInstanceProfileId method.
 		GetGpuInstanceProfileId []struct {
 		}
+		// GetID holds details about calls to the GetID method.
+		GetID []struct {
+		}
 		// GetLicense holds details about calls to the GetLicense method.
 		GetLicense []struct {
 		}
@@ -181,6 +190,7 @@ type VgpuTypeId struct {
 	lockGetFrameRateLimit       sync.RWMutex
 	lockGetFramebufferSize      sync.RWMutex
 	lockGetGpuInstanceProfileId sync.RWMutex
+	lockGetID                   sync.RWMutex
 	lockGetLicense              sync.RWMutex
 	lockGetMaxInstances         sync.RWMutex
 	lockGetMaxInstancesPerVm    sync.RWMutex
@@ -413,6 +423,33 @@ func (mock *VgpuTypeId) GetGpuInstanceProfileIdCalls() []struct {
 	mock.lockGetGpuInstanceProfileId.RLock()
 	calls = mock.calls.GetGpuInstanceProfileId
 	mock.lockGetGpuInstanceProfileId.RUnlock()
+	return calls
+}
+
+// GetID calls GetIDFunc.
+func (mock *VgpuTypeId) GetID() uint32 {
+	if mock.GetIDFunc == nil {
+		panic("VgpuTypeId.GetIDFunc: method is nil but VgpuTypeId.GetID was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockGetID.Lock()
+	mock.calls.GetID = append(mock.calls.GetID, callInfo)
+	mock.lockGetID.Unlock()
+	return mock.GetIDFunc()
+}
+
+// GetIDCalls gets all the calls that were made to GetID.
+// Check the length with:
+//
+//	len(mockedVgpuTypeId.GetIDCalls())
+func (mock *VgpuTypeId) GetIDCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockGetID.RLock()
+	calls = mock.calls.GetID
+	mock.lockGetID.RUnlock()
 	return calls
 }
 

--- a/pkg/nvml/vgpu.go
+++ b/pkg/nvml/vgpu.go
@@ -42,6 +42,19 @@ func (vgpuTypeId nvmlVgpuTypeId) GetClass() (string, Return) {
 	return string(vgpuTypeClass[:clen(vgpuTypeClass)]), ret
 }
 
+// nvml.VgpuTypeGetID()
+// It doesn't have an NVML C API symbol because the base type `nvmlVgpuTypeId`
+// is a non-exported type defined as `uint32`. When using the `VgpuTypeId` type,
+// it is not possible to read the underlying value without using reflection.
+// This method adds an idiomatic Go getter to access the type's value.
+func (l *library) VgpuTypeGetID(vgpuTypeId VgpuTypeId) uint32 {
+	return vgpuTypeId.GetID()
+}
+
+func (vgpuTypeId nvmlVgpuTypeId) GetID() uint32 {
+	return uint32(vgpuTypeId)
+}
+
 // nvml.VgpuTypeGetName()
 func (l *library) VgpuTypeGetName(vgpuTypeId VgpuTypeId) (string, Return) {
 	return vgpuTypeId.GetName()

--- a/pkg/nvml/zz_generated.api.go
+++ b/pkg/nvml/zz_generated.api.go
@@ -404,6 +404,7 @@ var (
 	VgpuTypeGetFrameRateLimit                        = libnvml.VgpuTypeGetFrameRateLimit
 	VgpuTypeGetFramebufferSize                       = libnvml.VgpuTypeGetFramebufferSize
 	VgpuTypeGetGpuInstanceProfileId                  = libnvml.VgpuTypeGetGpuInstanceProfileId
+	VgpuTypeGetID                                    = libnvml.VgpuTypeGetID
 	VgpuTypeGetLicense                               = libnvml.VgpuTypeGetLicense
 	VgpuTypeGetMaxInstances                          = libnvml.VgpuTypeGetMaxInstances
 	VgpuTypeGetMaxInstancesPerGpuInstance            = libnvml.VgpuTypeGetMaxInstancesPerGpuInstance
@@ -801,6 +802,7 @@ type Interface interface {
 	VgpuTypeGetFrameRateLimit(VgpuTypeId) (uint32, Return)
 	VgpuTypeGetFramebufferSize(VgpuTypeId) (uint64, Return)
 	VgpuTypeGetGpuInstanceProfileId(VgpuTypeId) (uint32, Return)
+	VgpuTypeGetID(VgpuTypeId) uint32
 	VgpuTypeGetLicense(VgpuTypeId) (string, Return)
 	VgpuTypeGetMaxInstances(Device, VgpuTypeId) (int, Return)
 	VgpuTypeGetMaxInstancesPerGpuInstance(*VgpuTypeMaxInstance) Return
@@ -1194,6 +1196,7 @@ type VgpuTypeId interface {
 	GetFrameRateLimit() (uint32, Return)
 	GetFramebufferSize() (uint64, Return)
 	GetGpuInstanceProfileId() (uint32, Return)
+	GetID() uint32
 	GetLicense() (string, Return)
 	GetMaxInstances(Device) (int, Return)
 	GetMaxInstancesPerVm() (int, Return)


### PR DESCRIPTION
While iterating supported/creatable vGPU types there is no way to map back to the legacy mediated-device profile names (e.g. "nvidia-577") exposed under /sys/.../nvidia/creatable_vgpu_types — those entries are keyed by the raw nvmlVgpuTypeId uint32, and GetName() returns the device-specific name instead.
Add GetID() uint32 on nvmlVgpuTypeId so callers can read the underlying handle.