### PR TITLE
update golang version and golang-ci download link

### DIFF
--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -46,11 +46,10 @@ RUN go install golang.org/x/lint/golint@latest
 RUN go install github.com/matryer/moq@latest
 
 # Install the golangci-lint tool
-RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
+RUN curl -sSfL https://golangci-lint.run/install.sh | sh -s -- -b $(go env GOPATH)/bin ${GOLANGCI_LINT_VERSION}
 
 # Set the permissions on the go module path to ensure that this is accessible from
 # our user containers.
 RUN chmod -R a+rx /go/pkg/mod
 
 ENV JQ=jq
-

--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -31,7 +31,7 @@ func nvmlDeviceHandle(d Device) nvmlDevice {
 			val = val.Elem()
 		}
 
-		if val.Kind() == reflect.Ptr {
+		if val.Kind() == reflect.Pointer {
 			val = val.Elem()
 		}
 

--- a/versions.mk
+++ b/versions.mk
@@ -19,7 +19,7 @@ GIT_TAG ?= $(patsubst v%,%,$(shell git describe --tags 2>/dev/null))
 MODULE := github.com/NVIDIA/go-nvml
 VERSION ?= $(GIT_TAG)
 
-GOLANG_VERSION ?= 1.26.1
+GOLANG_VERSION ?= 1.26.2
 C_FOR_GO_TAG ?= 8eeee8c3b71f9c3c90c4a73db54ed08b0bba971d
 
 ifeq ($(IMAGE),)


### PR DESCRIPTION
This PR updates the golang version to 1.26.2 and the `golangci-lint` download link to the official  one recommended by golangci-lint upstream.

It also addresses the newly raised `govet` issue from the latest version of `golangci-lint`