### PR TITLE
update: When no query is required for the return, directly return success instead of propagating the error code to the upper layer.

### DIFF
--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -1905,7 +1905,7 @@ func (device nvmlDevice) GetProcessUtilization(lastSeenTimestamp uint64) ([]Proc
 		return nil, ret
 	}
 	if processSamplesCount == 0 {
-		return []ProcessUtilizationSample{}, ret
+		return []ProcessUtilizationSample{}, SUCCESS
 	}
 	utilization := make([]ProcessUtilizationSample, processSamplesCount)
 	ret = nvmlDeviceGetProcessUtilization(device, &utilization[0], &processSamplesCount, lastSeenTimestamp)


### PR DESCRIPTION
The goal is to prevent the upper layer from having to handle excessive exceptions.