### PR TITLE
docs: fix typo in libraryOptions godoc comment

### DIFF
--- a/pkg/nvml/api.go
+++ b/pkg/nvml/api.go
@@ -27,7 +27,7 @@ type ExtendedInterface interface {
 	LookupSymbol(string) error
 }
 
-// libraryOptions hold the paramaters than can be set by a LibraryOption
+// libraryOptions hold the parameters that can be set by a LibraryOption
 type libraryOptions struct {
 	path  string
 	flags int


### PR DESCRIPTION
## Hi 👋

While running golangci-lint over a fork of this repo, `misspell` caught a small typo in `pkg/nvml/api.go`. Same line also has a "than" → "that" word-substitution that the linter doesn't catch but jumps out on read, so I fixed both in one tiny patch.

```diff
-// libraryOptions hold the paramaters than can be set by a LibraryOption
+// libraryOptions hold the parameters that can be set by a LibraryOption
```

Comment-only, no behavior change.

## Test plan

- [x] `go build ./pkg/...`
- [x] `go vet ./pkg/nvml/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)