### PR TITLE
sync nvml.h with CUDA version 13.3 and update go bindings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ clean-bindings:
 	rm -f $(PKG_BINDINGS_DIR)/zz_generated.api.go
 
 # Update nvml.h from the NVIDIA CUDA redistributable JSON
-update-nvml-h: CUDA_VERSION := 13.2.1
+update-nvml-h: CUDA_VERSION := 13.3.0
 update-nvml-h: CUDA_REDIST_BASE_URL := https://developer.download.nvidia.com/compute/cuda/redist
 update-nvml-h: CUDA_REDIST_JSON_URL := $(CUDA_REDIST_BASE_URL)/redistrib_$(CUDA_VERSION).json
 update-nvml-h: NVML_DEV_HEADERS_INFO := $(shell \

--- a/gen/nvml/nvml.h
+++ b/gen/nvml/nvml.h
@@ -1,5 +1,5 @@
-/*** NVML VERSION: 13.2.82 ***/
-/*** From https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvml_dev/linux-x86_64/cuda_nvml_dev-linux-x86_64-13.2.82-archive.tar.xz ***/
+/*** NVML VERSION: 13.3.29 ***/
+/*** From https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvml_dev/linux-x86_64/cuda_nvml_dev-linux-x86_64-13.3.29-archive.tar.xz ***/
 /*
  * Copyright 1993-2026 NVIDIA Corporation.  All rights reserved.
  *
@@ -330,12 +330,24 @@ typedef struct
 } nvmlProcessDetail_v1_t;
 
 /**
+ * Enum to represent process mode.
+ */
+ typedef enum nvmlProcessMode_enum
+ {
+     NVML_PROCESS_MODE_COMPUTE       = 0,   //!< Processes with a compute context
+     NVML_PROCESS_MODE_GRAPHICS      = 1,   //!< Processes with a graphics context
+     NVML_PROCESS_MODE_MPS           = 2,   //!< Processes with a MPS (Multi-Process Service) compute context
+     NVML_PROCESS_MODE_ALL           = 3,   //!< All processes running on the GPU (compute, graphics, MPS, and other types)
+     NVML_PROCESS_MODE_MAX           = NVML_PROCESS_MODE_ALL + 1  //!< Maximum value for bounds checking
+ } nvmlProcessMode_t;
+
+/**
  * Information about all running processes on the GPU for the given mode
  */
 typedef struct
 {
     unsigned int           version;             //!< Struct version, MUST be nvmlProcessDetailList_v1
-    unsigned int           mode;                //!< Process mode(Compute/Graphics/MPSCompute)
+    unsigned int           mode;                //!< Process mode, One of \ref nvmlProcessMode_t
     unsigned int           numProcArrayEntries; //!< Number of process entries in procArray
     nvmlProcessDetail_v1_t *procArray;          //!< Process array
 } nvmlProcessDetailList_v1_t;
@@ -440,7 +452,7 @@ typedef enum nvmlBridgeChipType_enum
 /**
  * Maximum number of NvLink links supported
  */
-#define NVML_NVLINK_MAX_LINKS 18 //!< Maximum number of NVLink links supported.
+#define NVML_NVLINK_MAX_LINKS 36 //!< Maximum number of NVLink links supported.
 
 /**
  * Enum to represent the NvLink utilization counter packet units
@@ -850,6 +862,13 @@ typedef struct
 typedef nvmlPdi_v1_t nvmlPdi_t;
 
 #define nvmlPdi_v1 NVML_STRUCT_VERSION(Pdi, 1) //!< Version macro for \a nvmlPdi_v1_t
+
+/**
+ * BBX Time Data
+ */
+ typedef struct {
+    unsigned int timeRun;  //!< [out] Cumulative number of seconds the GPU has had the driver loaded
+} nvmlBBXTimeData_v1_t;
 
 /** @} */
 
@@ -1533,6 +1552,8 @@ typedef struct
 
 #define NVML_DEVICE_ARCH_BLACKWELL 10 //!< Devices based on the NVIDIA Blackwell architecture
 
+#define NVML_DEVICE_ARCH_RUBIN     13 //!< Devices based on the NVIDIA Rubin architecture.
+
 #define NVML_DEVICE_ARCH_UNKNOWN   0xffffffff //!< Anything else, presumably something newer
 
 typedef unsigned int nvmlDeviceArchitecture_t;
@@ -1626,9 +1647,11 @@ typedef struct nvmlGpuDynamicPstatesInfo_st
 /**
  * Device Scope - This is useful to retrieve the telemetry at GPU and module (e.g. GPU + CPU) level
  */
-#define NVML_POWER_SCOPE_GPU     0U    //!< Targets only GPU
-#define NVML_POWER_SCOPE_MODULE  1U    //!< Targets the whole module
-#define NVML_POWER_SCOPE_MEMORY  2U    //!< Targets the GPU Memory
+#define NVML_POWER_SCOPE_GPU      0U    //!< Targets only GPU
+#define NVML_POWER_SCOPE_MODULE   1U    //!< Targets the whole module
+#define NVML_POWER_SCOPE_MEMORY   2U    //!< Targets the GPU Memory
+#define NVML_POWER_SCOPE_GPU_BASE 3U    //!< Targets base GPU power
+#define NVML_POWER_SCOPE_COUNT    4U    //!< Maximum number of power scopes
 
 typedef unsigned char nvmlPowerScopeType_t;
 
@@ -2174,6 +2197,7 @@ typedef enum nvmlDeviceGpuRecoveryAction_s  {
     NVML_GPU_RECOVERY_ACTION_NODE_REBOOT = 2,         //!< Reboot Node
     NVML_GPU_RECOVERY_ACTION_DRAIN_P2P = 3,           //!< Drain P2P
     NVML_GPU_RECOVERY_ACTION_DRAIN_AND_RESET = 4,     //!< Drain P2P and Reset Gpu
+    NVML_GPU_RECOVERY_ACTION_RECOVER_IMEX_DOMAIN = 5, //!< Recover IMEX Domain.
 } nvmlDeviceGpuRecoveryAction_t;
 
 /**
@@ -2684,7 +2708,9 @@ typedef struct
  *
  * scopeId needs to be specified. It signifies:
  * 0 - GPU Only Scope - Metrics for GPU are retrieved
- * 1 - Module scope - Metrics for the module (e.g. CPU + GPU) are retrieved.
+ * 1 - Module scope   - Metrics for the module (e.g. CPU + GPU) are retrieved.
+ * 2 - GPU base scope - GPU base Power metrics are retrieved.
+ *                      Note: Only supports _MIN_LIMIT, _MAX_LIMIT, _DEFAULT_LIMIT, and _CURRENT_LIMIT fields.
  * Note: CPU here refers to NVIDIA CPU (e.g. Grace). x86 or non-NVIDIA ARM is not supported
  */
 #define NVML_FI_DEV_POWER_AVERAGE                     185 //!< GPU power averaged over 1 sec interval, supported on Ampere (except GA100) or newer architectures.
@@ -2921,10 +2947,21 @@ typedef struct
 #define NVML_FI_DEV_NVLINK_COUNT_RAW_BER_V2                      293 //!< NVLINK total raw BER
 #define NVML_FI_DEV_NVLINK_PLR_XMIT_BLOCKS                       294 //!< NVLINK PLR Xmit Blocks
 #define NVML_FI_DEV_NVLINK_PLR_XMIT_RETRY_BLOCKS                 295 //!< NVLINK PLR Xmit Retry Blocks
-
+#define NVML_FI_DEV_NVLINK_GET_DATA_RATE                         296 //!< The Effective Nvlink Data rate available for transactions after accounting for FEC overhead
+#define NVML_FI_DEV_MMA_STALL_PERCENT                            297 //!< MMA (Matrix Multiply Accumulate) stall percentage
+#define NVML_FI_DEV_MCLK_SWITCH_TYPE                             298 //!< See NVML_MCLK_SWITCH_TYPE_<XYZ> for all enumerations
+#define NVML_FI_DEV_MCLK_MIN_SWITCH_INTERVAL_MILLISECONDS        299 //!< minimum required elapsed time between runtime mclk switches, 0 = no rate limit
+#define NVML_FI_PWR_SMOOTHING_SOC_POWER_SMOOTHING_ENABLED        300 //!< State-Of-Charge Power Smoothing Enabled (0/DISABLED or 1/ENABLED)
 #define NVML_FI_DEV_REMAPPED_ROWS_COR_INACTIVE                  301 //!< Number of inactive row remappings due to correctable errors
 #define NVML_FI_DEV_REMAPPED_ROWS_UNC_INACTIVE                  302 //!< Number of inactive row remappings due to uncorrectable errors
 #define NVML_FI_MAX                                             303 //!< One greater than the largest field ID defined above
+
+/**
+ * NVML_FI_DEV_MCLK_SWITCH_TYPE enumerations
+ */
+#define NVML_MCLK_SWITCH_TYPE_NOT_SUPPORTED 0x0 //!< switching is not supported
+#define NVML_MCLK_SWITCH_TYPE_DEFERRED      0x1 //!< deferred switching (driver reload)
+#define NVML_MCLK_SWITCH_TYPE_RUNTIME       0x2 //!< runtime switching
 
 /**
  * NVML_FI_DEV_NVLINK_GET_POWER_THRESHOLD_UNITS
@@ -3460,6 +3497,37 @@ typedef struct nvmlAccountingStats_st {
 
     unsigned int reserved[5];                   //!< Reserved for future use
 } nvmlAccountingStats_t;
+
+/**
+ * Describes accounting statistics (v2) of a process.
+ */
+typedef struct {
+    unsigned int pid;                           //!< Process Id of the target process to query stats for
+
+    unsigned int isRunning;                     //!< Flag to represent if the process is running (1 for running, 0 for terminated)
+
+    unsigned int gpuUtilization;                //!< Percent of time over the process's lifetime during which one or more kernels was executing on the GPU.
+                                                //! Utilization stats just like returned by \ref nvmlDeviceGetUtilizationRates but for the life time of a
+                                                //! process (not just the last sample period).
+                                                //! Set to NVML_VALUE_NOT_AVAILABLE if nvmlDeviceGetUtilizationRates is not supported
+
+    unsigned int memoryUtilization;             //!< Percent of time over the process's lifetime during which global (device) memory was being read or written.
+                                                //! Set to NVML_VALUE_NOT_AVAILABLE if nvmlDeviceGetUtilizationRates is not supported
+
+    unsigned long long maxMemoryUsage;          //!< Maximum total memory in bytes that was ever allocated by the process.
+                                                //! Set to NVML_VALUE_NOT_AVAILABLE if nvmlProcessInfo_t->usedGpuMemory is not supported
+
+    unsigned int sampleCount;                   //!< The sample counts since the process starts
+
+    unsigned long long sumGpuUtil;              //!< The sum of process's GR engine utilization in unit of pct * 100
+
+    unsigned long long sumFbUtil;               //!< The sum of process's FB bandwidth utilization in unit of pct * 100
+
+    unsigned long long time;                    //!< Amount of time in ms during which the compute context was active. The time is reported as 0 if
+                                                //! the process is not terminated
+
+    unsigned long long startTime;               //!< CPU Timestamp in usec representing start time for the process
+} nvmlAccountingStats_v2_t;
 
 /** @} */
 
@@ -4049,6 +4117,56 @@ const DECLDIR char* nvmlErrorString(nvmlReturn_t result);
 /** @} */
 
 /***************************************************************************************************/
+/** @defgroup nvmlCPER CPER (Common Platform Error Record)
+ * Types and API for retrieving CPER data.
+ *  @{
+ */
+/***************************************************************************************************/
+
+typedef unsigned long long nvmlCPERCursorHandle_t;   //!< Opaque handle to a CPER read position
+
+#define NVML_CPER_CURSOR_HANDLE_INIT ((nvmlCPERCursorHandle_t) 0) //!< Initialize \ref nvmlCPERCursorHandle_t to this value before first use in any CPER API
+
+/**
+ * Bitmask of CPER record types. Multiple values may be combined
+ * to request records from several sources in one call.
+ */
+typedef enum
+{
+    NVML_CPER_ACCESS_TYPE_GPU = (1 << 0),   //!< Access GPU CPER records
+} nvmlCPERType_t;
+
+/**
+ * CPER query and cursor parameters. Groups the filter options and opaque
+ * read position used to iterate through CPER records.
+ *
+ * Cursor semantics for iterative calls:
+ * - Pass the same \a nvmlCPERCursor_v1_t (i.e. the same \a cursor) on every call
+ *   in a single iteration sequence.
+ * - Do not modify this struct between calls.
+ * - To change \a cperTypeMask or \a uuid, set \a handle to \ref NVML_CPER_CURSOR_HANDLE_INIT
+ *   and call again with the updated filter (this starts a new iteration).
+ */
+typedef struct
+{
+    unsigned int cperTypeMask;               //!< [IN] Types of records to access. Bitmask of \ref nvmlCPERType_t values. To change, reset \a handle to \ref NVML_CPER_CURSOR_HANDLE_INIT.
+    char uuid[NVML_DEVICE_UUID_BUFFER_SIZE]; //!< [IN] UUID of target to filter records for. Required for \ref NVML_CPER_ACCESS_TYPE_GPU. To change, reset \a handle to \ref NVML_CPER_CURSOR_HANDLE_INIT.
+    nvmlCPERCursorHandle_t handle;           //!< [IN/OUT] Opaque handle tracking read position. Initialize to \ref NVML_CPER_CURSOR_HANDLE_INIT on first call; pass the same \a nvmlCPERCursor_v1_t on the next call to continue. Caller must not interpret or modify.
+} nvmlCPERCursor_v1_t;
+
+/**
+ * Input/output structure for \ref nvmlSystemGetCPER_v1.
+ */
+typedef struct
+{
+    nvmlCPERCursor_v1_t cursor;  //!< [IN/OUT] Query parameters and cursor. See \ref nvmlCPERCursor_v1_t
+    unsigned char *buffer;       //!< [OUT] Buffer to be filled (allocated by client). May be NULL for size query.
+    unsigned int bufferSize;     //!< [IN/OUT] Size of \a buffer. Set to 0 with \a buffer NULL to query required size. On return, set to required or used size; 0 means no (more) records.
+} nvmlGetCPER_v1_t;
+
+/** @} */
+
+/***************************************************************************************************/
 /** @defgroup nvmlSystemQueries System Queries
  * This chapter describes the queries that NVML can perform against the local system. These queries
  * are not device-specific.
@@ -4223,6 +4341,37 @@ typedef nvmlSystemDriverBranchInfo_v1_t nvmlSystemDriverBranchInfo_t;
  */
 nvmlReturn_t DECLDIR nvmlSystemGetDriverBranch(nvmlSystemDriverBranchInfo_t *branchInfo, unsigned int length);
 
+/**
+ * Retrieves Common Platform Error Record (CPER) data.
+ *
+ * Records are returned in a caller-supplied buffer. Iteration is driven by the
+ * \a cursor (\ref nvmlCPERCursor_v1_t) struct: pass the same \a cursor on every call
+ * in a sequence; the implementation updates \a cursor.handle. Do not modify \a cursor between
+ * calls. To change \a cursor.cperTypeMask or \a cursor.uuid, set \a cursor.handle to
+ * \ref NVML_CPER_CURSOR_HANDLE_INIT and call again (new iteration).
+ *
+ * For a size query, call with \a buffer NULL and \a bufferSize 0; the function
+ * returns \ref NVML_ERROR_INSUFFICIENT_SIZE and sets \a bufferSize when records exist,
+ * or \ref NVML_SUCCESS with \a bufferSize set to 0 when there are no CPER records.
+ * Use \a bufferSize == 0 on return as the indicator for "no records" or "no more records".
+ *
+ * This API requires root privileges. Records are available from initialization.
+ *
+ * @param cper     Pointer to an \ref nvmlGetCPER_v1_t. On entry set \a cursor.cperTypeMask,
+ *                 \a cursor.uuid (empty string for all), \a cursor.handle (to
+ *                 \ref NVML_CPER_CURSOR_HANDLE_INIT for first call), \a buffer (or NULL),
+ *                 \a bufferSize. On return \a cursor.handle and \a bufferSize are updated.
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 Buffer has been populated with CPER data, or \a bufferSize is 0 (no/more records).
+ *         - \ref NVML_ERROR_UNINITIALIZED     The library has not been successfully initialized.
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  \a cper is NULL, or \a buffer is NULL while \a bufferSize is non-zero.
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     The feature is not supported on this system.
+ *         - \ref NVML_ERROR_INSUFFICIENT_SIZE Buffer too small; \a bufferSize set to required size.
+ *         - \ref NVML_ERROR_NO_PERMISSION     Insufficient privileges.
+ *         - \ref NVML_ERROR_UNKNOWN           An unexpected error occurred.
+ */
+nvmlReturn_t DECLDIR nvmlSystemGetCPER_v1(nvmlGetCPER_v1_t *cper);
 
 /** @} */
 
@@ -5192,6 +5341,23 @@ nvmlReturn_t DECLDIR nvmlDeviceValidateInforom(nvmlDevice_t device);
 nvmlReturn_t DECLDIR nvmlDeviceGetLastBBXFlushTime(nvmlDevice_t device, unsigned long long *timestamp,
                                                    unsigned long *durationUs);
 
+/**
+ * Retrieves the cumulative number of seconds the GPU has had the driver loaded.
+ *
+ * For all products with an inforom.
+ *
+ * @param device                               The identifier of the target device
+ * @param timeData                             Reference in which to return the cumulative number of seconds the GPU has had the driver loaded
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if \a timeData has been set
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a timeData is NULL
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support this feature
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ */
+
+nvmlReturn_t DECLDIR nvmlDeviceGetBBXTimeData_v1(nvmlDevice_t device, nvmlBBXTimeData_v1_t *timeData);
 /**
  * Retrieves the display mode for the device.
  *
@@ -6584,13 +6750,15 @@ nvmlReturn_t DECLDIR nvmlDeviceGetMemoryInfo(nvmlDevice_t device, nvmlMemory_t *
 nvmlReturn_t DECLDIR nvmlDeviceGetMemoryInfo_v2(nvmlDevice_t device, nvmlMemory_v2_t *memory);
 
 /**
- * Retrieves the current compute mode for the device.
+ * Retrieves the current compute mode for the device or MIG device.
  *
  * For all products.
  *
+ * @note If MIG is enabled on a GPU, device must be MIG device handle.
+ *
  * See \ref nvmlComputeMode_t for details on allowed compute modes.
  *
- * @param device                               The identifier of the target device
+ * @param device                               The identifier of the target device handle or MIG device handle
  * @param mode                                 Reference in which to return the current compute mode
  *
  * @return
@@ -8116,6 +8284,44 @@ nvmlReturn_t DECLDIR nvmlDeviceGetAccountingPids(nvmlDevice_t device, unsigned i
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetAccountingBufferSize(nvmlDevice_t device, unsigned int *bufferSize);
 
+/**
+ * Queries process's accounting stats (v2).
+ *
+ * For Kepler &tm; or newer fully supported devices.
+ *
+ * Accounting stats (v2) capture GPU utilization and other statistics across the lifetime of a process.
+ * Accounting stats (v2) can be queried during life time of the process and after its termination.
+ * The time field in \ref nvmlAccountingStats_v2_t is reported as 0 during the lifetime of the process and
+ * updated to actual running time after its termination.
+ * Accounting stats (v2) are kept in a circular buffer, newly created processes overwrite information about old
+ * processes.
+ *
+ * See \ref nvmlAccountingStats_v2_t for description of each returned metric.
+ * List of processes that can be queried can be retrieved from \ref nvmlDeviceGetAccountingPids.
+ *
+ * @note Accounting Mode needs to be on. See \ref nvmlDeviceGetAccountingMode.
+ * @note Only compute and graphics applications stats can be queried. Monitoring applications stats can't be
+ *         queried since they don't contribute to GPU utilization.
+ * @note In case of pid collision stats of only the latest process (that terminated last) will be reported
+ *
+ * @warning On Kepler devices per process statistics are accurate only if there's one process running on a GPU.
+ *
+ * @param device                               The identifier of the target device
+ * @param stats                                Reference in which to return the process's accounting stats (v2)
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if stats (v2) have been successfully retrieved
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a stats are NULL
+ *         - \ref NVML_ERROR_NOT_FOUND         if process stats were not found
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if \a device doesn't support this feature or accounting mode is disabled
+ *                                              or on vGPU host.
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlDeviceGetAccountingBufferSize
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetAccountingStats_v2(nvmlDevice_t device, nvmlAccountingStats_v2_t *stats);
+
 /** @} */
 
 /** @addtogroup nvmlDeviceQueries
@@ -8548,7 +8754,7 @@ nvmlReturn_t DECLDIR nvmlUnitSetLedState(nvmlUnit_t unit, nvmlLedColor_t color);
 nvmlReturn_t DECLDIR nvmlDeviceSetPersistenceMode(nvmlDevice_t device, nvmlEnableState_t mode);
 
 /**
- * Set the compute mode for the device.
+ * Set the compute mode for the device or MIG device.
  *
  * For all products.
  * Requires root/admin permissions.
@@ -8561,11 +8767,11 @@ nvmlReturn_t DECLDIR nvmlDeviceSetPersistenceMode(nvmlDevice_t device, nvmlEnabl
  *
  * Under windows compute mode may only be set to DEFAULT when running in WDDM
  *
- * @note On MIG-enabled GPUs, compute mode would be set to DEFAULT and changing it is not supported.
+ * @note If MIG is enabled on a GPU, device must be MIG device handle.
  *
  * See \ref nvmlComputeMode_t for details on available compute modes.
  *
- * @param device                               The identifier of the target device
+ * @param device                               The identifier of the target device handle or MIG device handle
  * @param mode                                 The target compute mode
  *
  * @return
@@ -9198,6 +9404,7 @@ typedef enum nvmlNvlinkVersion_enum
     NVML_NVLINK_VERSION_3_1     = 5, //!< NVLink Version 3.1
     NVML_NVLINK_VERSION_4_0     = 6, //!< NVLink Version 4.0
     NVML_NVLINK_VERSION_5_0     = 7, //!< NVLink Version 5.0
+    NVML_NVLINK_VERSION_6_0     = 8, //!< NVLink Version 6.0
 } nvmlNvlinkVersion_t;
 
 #define NVML_NVLINK_TOTAL_SUPPORTED_BW_MODES 23 //!< Total supported NVLink bandwidth modes.
@@ -12317,8 +12524,9 @@ nvmlReturn_t DECLDIR nvmlDeviceReadPRMCounters_v1(nvmlDevice_t device, nvmlPRMCo
 // Allocation of instance of this profile prevents allocation of
 // all but _NO_ME profiles.
 #define NVML_GPU_INSTANCE_PROFILE_2_SLICE_ALL_ME   0x10
-#define NVML_GPU_INSTANCE_PROFILE_3_SLICE_GFX      0x11    //!< 3_SLICE gfx + media capable profile.
-#define NVML_GPU_INSTANCE_PROFILE_COUNT            0x12    //!< Total number of GPU instance profiles.
+
+#define NVML_GPU_INSTANCE_PROFILE_3_SLICE_GFX           0x11    //!< 3_SLICE gfx + media capable profile.
+#define NVML_GPU_INSTANCE_PROFILE_COUNT                 0x12    //!< Total number of GPU instance profiles.
 
 /**
  * MIG GPU instance profile capability.
@@ -12438,11 +12646,12 @@ typedef struct nvmlGpuInstanceInfo_st
 #define NVML_COMPUTE_INSTANCE_PROFILE_2_SLICE       0x1 //!< 2_SLICE compute instance profile.
 #define NVML_COMPUTE_INSTANCE_PROFILE_3_SLICE       0x2 //!< 3_SLICE compute instance profile.
 #define NVML_COMPUTE_INSTANCE_PROFILE_4_SLICE       0x3 //!< 4_SLICE compute instance profile.
-#define NVML_COMPUTE_INSTANCE_PROFILE_7_SLICE       0x4 //!< 7_SLICE compute instance profile.
+#define NVML_COMPUTE_INSTANCE_PROFILE_7_SLICE       0x4 //!< 7_SLICE compute instance profile  (perf optimized for host work scheduling).
 #define NVML_COMPUTE_INSTANCE_PROFILE_8_SLICE       0x5 //!< 8_SLICE compute instance profile.
 #define NVML_COMPUTE_INSTANCE_PROFILE_6_SLICE       0x6 //!< 6_SLICE compute instance profile.
 #define NVML_COMPUTE_INSTANCE_PROFILE_1_SLICE_REV1  0x7 //!< 1_SLICE compute instance profile (rev1).
-#define NVML_COMPUTE_INSTANCE_PROFILE_COUNT         0x8 //!< Number of compute instance profiles.
+#define NVML_COMPUTE_INSTANCE_PROFILE_7_SLICE_NVL   0x8 //!< 7_SLICE compute instance profile (perf optimized for multi-GPU use).
+#define NVML_COMPUTE_INSTANCE_PROFILE_COUNT         0x9 //!< Number of compute instance profiles.
 
 #define NVML_COMPUTE_INSTANCE_ENGINE_PROFILE_SHARED 0x0 //!< All the engines except multiprocessors would be shared.
 #define NVML_COMPUTE_INSTANCE_ENGINE_PROFILE_COUNT  0x1 //!< Number of engine profiles.
@@ -13451,6 +13660,42 @@ typedef enum
     NVML_GPM_METRIC_GR7_CTXSW_REQUESTS          = 207,
     NVML_GPM_METRIC_GR7_CTXSW_CYCLES_PER_REQ    = 208,
     NVML_GPM_METRIC_GR7_CTXSW_ACTIVE_PCT        = 209,
+    NVML_GPM_METRIC_NVLINK_L18_RX_PER_SEC       = 212,
+    NVML_GPM_METRIC_NVLINK_L18_TX_PER_SEC       = 213,
+    NVML_GPM_METRIC_NVLINK_L19_RX_PER_SEC       = 214,
+    NVML_GPM_METRIC_NVLINK_L19_TX_PER_SEC       = 215,
+    NVML_GPM_METRIC_NVLINK_L20_RX_PER_SEC       = 216,
+    NVML_GPM_METRIC_NVLINK_L20_TX_PER_SEC       = 217,
+    NVML_GPM_METRIC_NVLINK_L21_RX_PER_SEC       = 218,
+    NVML_GPM_METRIC_NVLINK_L21_TX_PER_SEC       = 219,
+    NVML_GPM_METRIC_NVLINK_L22_RX_PER_SEC       = 220,
+    NVML_GPM_METRIC_NVLINK_L22_TX_PER_SEC       = 221,
+    NVML_GPM_METRIC_NVLINK_L23_RX_PER_SEC       = 222,
+    NVML_GPM_METRIC_NVLINK_L23_TX_PER_SEC       = 223,
+    NVML_GPM_METRIC_NVLINK_L24_RX_PER_SEC       = 224,
+    NVML_GPM_METRIC_NVLINK_L24_TX_PER_SEC       = 225,
+    NVML_GPM_METRIC_NVLINK_L25_RX_PER_SEC       = 226,
+    NVML_GPM_METRIC_NVLINK_L25_TX_PER_SEC       = 227,
+    NVML_GPM_METRIC_NVLINK_L26_RX_PER_SEC       = 228,
+    NVML_GPM_METRIC_NVLINK_L26_TX_PER_SEC       = 229,
+    NVML_GPM_METRIC_NVLINK_L27_RX_PER_SEC       = 230,
+    NVML_GPM_METRIC_NVLINK_L27_TX_PER_SEC       = 231,
+    NVML_GPM_METRIC_NVLINK_L28_RX_PER_SEC       = 232,
+    NVML_GPM_METRIC_NVLINK_L28_TX_PER_SEC       = 233,
+    NVML_GPM_METRIC_NVLINK_L29_RX_PER_SEC       = 234,
+    NVML_GPM_METRIC_NVLINK_L29_TX_PER_SEC       = 235,
+    NVML_GPM_METRIC_NVLINK_L30_RX_PER_SEC       = 236,
+    NVML_GPM_METRIC_NVLINK_L30_TX_PER_SEC       = 237,
+    NVML_GPM_METRIC_NVLINK_L31_RX_PER_SEC       = 238,
+    NVML_GPM_METRIC_NVLINK_L31_TX_PER_SEC       = 239,
+    NVML_GPM_METRIC_NVLINK_L32_RX_PER_SEC       = 240,
+    NVML_GPM_METRIC_NVLINK_L32_TX_PER_SEC       = 241,
+    NVML_GPM_METRIC_NVLINK_L33_RX_PER_SEC       = 242,
+    NVML_GPM_METRIC_NVLINK_L33_TX_PER_SEC       = 243,
+    NVML_GPM_METRIC_NVLINK_L34_RX_PER_SEC       = 244,
+    NVML_GPM_METRIC_NVLINK_L34_TX_PER_SEC       = 245,
+    NVML_GPM_METRIC_NVLINK_L35_RX_PER_SEC       = 246,
+    NVML_GPM_METRIC_NVLINK_L35_TX_PER_SEC       = 247,
     NVML_GPM_METRIC_SM_CYCLES_ELAPSED           = 248,  //!< The GPU's SM cycles elapsed since reboot
     NVML_GPM_METRIC_SM_CYCLES_ACTIVE            = 249,  //!< The GPU's SM activity since reboot
     NVML_GPM_METRIC_MMA_CYCLES_ACTIVE           = 250,  //!< The GPU's SM MMA tensor activity since reboot
@@ -13500,6 +13745,42 @@ typedef enum
     NVML_GPM_METRIC_NVLINK_L16_TX               = 294,  //!< NvLink write for link 16 in bytes since reboot
     NVML_GPM_METRIC_NVLINK_L17_RX               = 295,  //!< NvLink read for link 17 in bytes since reboot
     NVML_GPM_METRIC_NVLINK_L17_TX               = 296,  //!< NvLink write for link 17 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L18_RX               = 297,  //!< NvLink read for link 18 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L18_TX               = 298,  //!< NvLink write for link 18 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L19_RX               = 299,  //!< NvLink read for link 19 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L19_TX               = 300,  //!< NvLink write for link 19 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L20_RX               = 301,  //!< NvLink read for link 20 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L20_TX               = 302,  //!< NvLink write for link 20 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L21_RX               = 303,  //!< NvLink read for link 21 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L21_TX               = 304,  //!< NvLink write for link 21 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L22_RX               = 305,  //!< NvLink read for link 22 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L22_TX               = 306,  //!< NvLink write for link 22 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L23_RX               = 307,  //!< NvLink read for link 23 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L23_TX               = 308,  //!< NvLink write for link 23 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L24_RX               = 309,  //!< NvLink read for link 24 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L24_TX               = 310,  //!< NvLink write for link 24 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L25_RX               = 311,  //!< NvLink read for link 25 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L25_TX               = 312,  //!< NvLink write for link 25 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L26_RX               = 313,  //!< NvLink read for link 26 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L26_TX               = 314,  //!< NvLink write for link 26 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L27_RX               = 315,  //!< NvLink read for link 27 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L27_TX               = 316,  //!< NvLink write for link 27 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L28_RX               = 317,  //!< NvLink read for link 28 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L28_TX               = 318,  //!< NvLink write for link 28 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L29_RX               = 319,  //!< NvLink read for link 29 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L29_TX               = 320,  //!< NvLink write for link 29 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L30_RX               = 321,  //!< NvLink read for link 30 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L30_TX               = 322,  //!< NvLink write for link 30 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L31_RX               = 323,  //!< NvLink read for link 31 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L31_TX               = 324,  //!< NvLink write for link 31 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L32_RX               = 325,  //!< NvLink read for link 32 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L32_TX               = 326,  //!< NvLink write for link 32 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L33_RX               = 327,  //!< NvLink read for link 33 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L33_TX               = 328,  //!< NvLink write for link 33 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L34_RX               = 329,  //!< NvLink read for link 34 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L34_TX               = 330,  //!< NvLink write for link 34 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L35_RX               = 331,  //!< NvLink read for link 35 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L35_TX               = 332,  //!< NvLink write for link 35 in bytes since reboot
     NVML_GPM_METRIC_MAX                         = 333,  //!< Maximum value above +1
 } nvmlGpmMetricId_t;
 
@@ -14008,14 +14289,18 @@ nvmlReturn_t DECLDIR nvmlDeviceWorkloadPowerProfileUpdateProfiles_v1(nvmlDevice_
  */
 /***************************************************************************************************/
 /**
- * Macro for accomodating the gap in field values for delayed power smoothing.
+ * Macro for accomodating the gaps in field values for power smoothing.
  */
 #define NVML_POWER_SMOOTHING_IDX_FROM_FIELD_VAL(field_val)  \
     ( \
-        (field_val > NVML_FI_PWR_SMOOTHING_ADMIN_OVERRIDE_RAMP_DOWN_HYST_VAL) ? \
-        (field_val - NVML_FI_PWR_SMOOTHING_ENABLED - \
+        ((field_val) >= NVML_FI_PWR_SMOOTHING_SOC_POWER_SMOOTHING_ENABLED) ? \
+        ((field_val) - NVML_FI_PWR_SMOOTHING_ENABLED - \
+            (NVML_FI_PWR_SMOOTHING_PRIMARY_POWER_FLOOR - NVML_FI_PWR_SMOOTHING_ADMIN_OVERRIDE_RAMP_DOWN_HYST_VAL - 1) - \
+            (NVML_FI_PWR_SMOOTHING_SOC_POWER_SMOOTHING_ENABLED - NVML_FI_PWR_SMOOTHING_ADMIN_OVERRIDE_PRIMARY_FLOOR_ACT_OFFSET - 1)) : \
+        ((field_val) > NVML_FI_PWR_SMOOTHING_ADMIN_OVERRIDE_RAMP_DOWN_HYST_VAL) ? \
+        ((field_val) - NVML_FI_PWR_SMOOTHING_ENABLED - \
             (NVML_FI_PWR_SMOOTHING_PRIMARY_POWER_FLOOR - NVML_FI_PWR_SMOOTHING_ADMIN_OVERRIDE_RAMP_DOWN_HYST_VAL - 1)) : \
-        (field_val - NVML_FI_PWR_SMOOTHING_ENABLED) \
+        ((field_val) - NVML_FI_PWR_SMOOTHING_ENABLED) \
     ) //!< Index from field value.
 
 #define NVML_POWER_SMOOTHING_MAX_NUM_PROFILES                   5 //!< Maximum number of profiles.

--- a/pkg/nvml/const.go
+++ b/pkg/nvml/const.go
@@ -45,7 +45,7 @@ const (
 	// DEVICE_PCI_BUS_ID_FMT as defined in nvml/nvml.h
 	DEVICE_PCI_BUS_ID_FMT = "%08X:%02X:%02X.0"
 	// NVLINK_MAX_LINKS as defined in nvml/nvml.h
-	NVLINK_MAX_LINKS = 18
+	NVLINK_MAX_LINKS = 36
 	// TOPOLOGY_CPU as defined in nvml/nvml.h
 	TOPOLOGY_CPU = 0
 	// MAX_PHYSICAL_BRIDGE as defined in nvml/nvml.h
@@ -118,6 +118,8 @@ const (
 	DEVICE_ARCH_HOPPER = 9
 	// DEVICE_ARCH_BLACKWELL as defined in nvml/nvml.h
 	DEVICE_ARCH_BLACKWELL = 10
+	// DEVICE_ARCH_RUBIN as defined in nvml/nvml.h
+	DEVICE_ARCH_RUBIN = 13
 	// DEVICE_ARCH_UNKNOWN as defined in nvml/nvml.h
 	DEVICE_ARCH_UNKNOWN = 4294967295
 	// BUS_TYPE_UNKNOWN as defined in nvml/nvml.h
@@ -182,6 +184,10 @@ const (
 	POWER_SCOPE_MODULE = 1
 	// POWER_SCOPE_MEMORY as defined in nvml/nvml.h
 	POWER_SCOPE_MEMORY = 2
+	// POWER_SCOPE_GPU_BASE as defined in nvml/nvml.h
+	POWER_SCOPE_GPU_BASE = 3
+	// POWER_SCOPE_COUNT as defined in nvml/nvml.h
+	POWER_SCOPE_COUNT = 4
 	// GRID_LICENSE_EXPIRY_NOT_AVAILABLE as defined in nvml/nvml.h
 	GRID_LICENSE_EXPIRY_NOT_AVAILABLE = 0
 	// GRID_LICENSE_EXPIRY_INVALID as defined in nvml/nvml.h
@@ -834,12 +840,28 @@ const (
 	FI_DEV_NVLINK_PLR_XMIT_BLOCKS = 294
 	// FI_DEV_NVLINK_PLR_XMIT_RETRY_BLOCKS as defined in nvml/nvml.h
 	FI_DEV_NVLINK_PLR_XMIT_RETRY_BLOCKS = 295
+	// FI_DEV_NVLINK_GET_DATA_RATE as defined in nvml/nvml.h
+	FI_DEV_NVLINK_GET_DATA_RATE = 296
+	// FI_DEV_MMA_STALL_PERCENT as defined in nvml/nvml.h
+	FI_DEV_MMA_STALL_PERCENT = 297
+	// FI_DEV_MCLK_SWITCH_TYPE as defined in nvml/nvml.h
+	FI_DEV_MCLK_SWITCH_TYPE = 298
+	// FI_DEV_MCLK_MIN_SWITCH_INTERVAL_MILLISECONDS as defined in nvml/nvml.h
+	FI_DEV_MCLK_MIN_SWITCH_INTERVAL_MILLISECONDS = 299
+	// FI_PWR_SMOOTHING_SOC_POWER_SMOOTHING_ENABLED as defined in nvml/nvml.h
+	FI_PWR_SMOOTHING_SOC_POWER_SMOOTHING_ENABLED = 300
 	// FI_DEV_REMAPPED_ROWS_COR_INACTIVE as defined in nvml/nvml.h
 	FI_DEV_REMAPPED_ROWS_COR_INACTIVE = 301
 	// FI_DEV_REMAPPED_ROWS_UNC_INACTIVE as defined in nvml/nvml.h
 	FI_DEV_REMAPPED_ROWS_UNC_INACTIVE = 302
 	// FI_MAX as defined in nvml/nvml.h
 	FI_MAX = 303
+	// MCLK_SWITCH_TYPE_NOT_SUPPORTED as defined in nvml/nvml.h
+	MCLK_SWITCH_TYPE_NOT_SUPPORTED = 0
+	// MCLK_SWITCH_TYPE_DEFERRED as defined in nvml/nvml.h
+	MCLK_SWITCH_TYPE_DEFERRED = 1
+	// MCLK_SWITCH_TYPE_RUNTIME as defined in nvml/nvml.h
+	MCLK_SWITCH_TYPE_RUNTIME = 2
 	// NVLINK_LOW_POWER_THRESHOLD_UNIT_100US as defined in nvml/nvml.h
 	NVLINK_LOW_POWER_THRESHOLD_UNIT_100US = 0
 	// NVLINK_LOW_POWER_THRESHOLD_UNIT_50US as defined in nvml/nvml.h
@@ -1120,6 +1142,8 @@ const (
 	DEVICE_SERIAL_BUFFER_SIZE = 30
 	// DEVICE_VBIOS_VERSION_BUFFER_SIZE as defined in nvml/nvml.h
 	DEVICE_VBIOS_VERSION_BUFFER_SIZE = 32
+	// CPER_CURSOR_HANDLE_INIT as defined in nvml/nvml.h
+	CPER_CURSOR_HANDLE_INIT = ((CPERCursorHandle)(0))
 	// AFFINITY_SCOPE_NODE as defined in nvml/nvml.h
 	AFFINITY_SCOPE_NODE = 0
 	// AFFINITY_SCOPE_SOCKET as defined in nvml/nvml.h
@@ -1220,8 +1244,10 @@ const (
 	COMPUTE_INSTANCE_PROFILE_6_SLICE = 6
 	// COMPUTE_INSTANCE_PROFILE_1_SLICE_REV1 as defined in nvml/nvml.h
 	COMPUTE_INSTANCE_PROFILE_1_SLICE_REV1 = 7
+	// COMPUTE_INSTANCE_PROFILE_7_SLICE_NVL as defined in nvml/nvml.h
+	COMPUTE_INSTANCE_PROFILE_7_SLICE_NVL = 8
 	// COMPUTE_INSTANCE_PROFILE_COUNT as defined in nvml/nvml.h
-	COMPUTE_INSTANCE_PROFILE_COUNT = 8
+	COMPUTE_INSTANCE_PROFILE_COUNT = 9
 	// COMPUTE_INSTANCE_ENGINE_PROFILE_SHARED as defined in nvml/nvml.h
 	COMPUTE_INSTANCE_ENGINE_PROFILE_SHARED = 0
 	// COMPUTE_INSTANCE_ENGINE_PROFILE_COUNT as defined in nvml/nvml.h
@@ -1256,6 +1282,18 @@ const (
 	POWER_SMOOTHING_PROFILE_PARAM_PRIMARY_FLOOR_TAR_WIN_MULT = 6
 	// POWER_SMOOTHING_PROFILE_PARAM_PRIMARY_FLOOR_ACT_OFFSET as defined in nvml/nvml.h
 	POWER_SMOOTHING_PROFILE_PARAM_PRIMARY_FLOOR_ACT_OFFSET = 7
+)
+
+// ProcessMode as declared in nvml/nvml.h
+type ProcessMode int32
+
+// ProcessMode enumeration from nvml/nvml.h
+const (
+	PROCESS_MODE_COMPUTE  ProcessMode = iota
+	PROCESS_MODE_GRAPHICS ProcessMode = 1
+	PROCESS_MODE_MPS      ProcessMode = 2
+	PROCESS_MODE_ALL      ProcessMode = 3
+	PROCESS_MODE_MAX      ProcessMode = 4
 )
 
 // BridgeChipType as declared in nvml/nvml.h
@@ -1803,11 +1841,12 @@ type DeviceGpuRecoveryAction int32
 
 // DeviceGpuRecoveryAction enumeration from nvml/nvml.h
 const (
-	GPU_RECOVERY_ACTION_NONE            DeviceGpuRecoveryAction = iota
-	GPU_RECOVERY_ACTION_GPU_RESET       DeviceGpuRecoveryAction = 1
-	GPU_RECOVERY_ACTION_NODE_REBOOT     DeviceGpuRecoveryAction = 2
-	GPU_RECOVERY_ACTION_DRAIN_P2P       DeviceGpuRecoveryAction = 3
-	GPU_RECOVERY_ACTION_DRAIN_AND_RESET DeviceGpuRecoveryAction = 4
+	GPU_RECOVERY_ACTION_NONE                DeviceGpuRecoveryAction = iota
+	GPU_RECOVERY_ACTION_GPU_RESET           DeviceGpuRecoveryAction = 1
+	GPU_RECOVERY_ACTION_NODE_REBOOT         DeviceGpuRecoveryAction = 2
+	GPU_RECOVERY_ACTION_DRAIN_P2P           DeviceGpuRecoveryAction = 3
+	GPU_RECOVERY_ACTION_DRAIN_AND_RESET     DeviceGpuRecoveryAction = 4
+	GPU_RECOVERY_ACTION_RECOVER_IMEX_DOMAIN DeviceGpuRecoveryAction = 5
 )
 
 // FanState as declared in nvml/nvml.h
@@ -1892,6 +1931,7 @@ const (
 	NVLINK_VERSION_3_1     NvlinkVersion = 5
 	NVLINK_VERSION_4_0     NvlinkVersion = 6
 	NVLINK_VERSION_5_0     NvlinkVersion = 7
+	NVLINK_VERSION_6_0     NvlinkVersion = 8
 )
 
 // VgpuVmCompatibility as declared in nvml/nvml.h
@@ -1992,6 +2032,14 @@ const (
 	GRID_LICENSE_FEATURE_CODE_VWORKSTATION GridLicenseFeatureCode = 2
 	GRID_LICENSE_FEATURE_CODE_GAMING       GridLicenseFeatureCode = 3
 	GRID_LICENSE_FEATURE_CODE_COMPUTE      GridLicenseFeatureCode = 4
+)
+
+// CPERType as declared in nvml/nvml.h
+type CPERType int32
+
+// CPERType enumeration from nvml/nvml.h
+const (
+	CPER_ACCESS_TYPE_GPU CPERType = 1
 )
 
 // PRMCounterId as declared in nvml/nvml.h
@@ -2202,6 +2250,42 @@ const (
 	GPM_METRIC_GR7_CTXSW_REQUESTS          GpmMetricId = 207
 	GPM_METRIC_GR7_CTXSW_CYCLES_PER_REQ    GpmMetricId = 208
 	GPM_METRIC_GR7_CTXSW_ACTIVE_PCT        GpmMetricId = 209
+	GPM_METRIC_NVLINK_L18_RX_PER_SEC       GpmMetricId = 212
+	GPM_METRIC_NVLINK_L18_TX_PER_SEC       GpmMetricId = 213
+	GPM_METRIC_NVLINK_L19_RX_PER_SEC       GpmMetricId = 214
+	GPM_METRIC_NVLINK_L19_TX_PER_SEC       GpmMetricId = 215
+	GPM_METRIC_NVLINK_L20_RX_PER_SEC       GpmMetricId = 216
+	GPM_METRIC_NVLINK_L20_TX_PER_SEC       GpmMetricId = 217
+	GPM_METRIC_NVLINK_L21_RX_PER_SEC       GpmMetricId = 218
+	GPM_METRIC_NVLINK_L21_TX_PER_SEC       GpmMetricId = 219
+	GPM_METRIC_NVLINK_L22_RX_PER_SEC       GpmMetricId = 220
+	GPM_METRIC_NVLINK_L22_TX_PER_SEC       GpmMetricId = 221
+	GPM_METRIC_NVLINK_L23_RX_PER_SEC       GpmMetricId = 222
+	GPM_METRIC_NVLINK_L23_TX_PER_SEC       GpmMetricId = 223
+	GPM_METRIC_NVLINK_L24_RX_PER_SEC       GpmMetricId = 224
+	GPM_METRIC_NVLINK_L24_TX_PER_SEC       GpmMetricId = 225
+	GPM_METRIC_NVLINK_L25_RX_PER_SEC       GpmMetricId = 226
+	GPM_METRIC_NVLINK_L25_TX_PER_SEC       GpmMetricId = 227
+	GPM_METRIC_NVLINK_L26_RX_PER_SEC       GpmMetricId = 228
+	GPM_METRIC_NVLINK_L26_TX_PER_SEC       GpmMetricId = 229
+	GPM_METRIC_NVLINK_L27_RX_PER_SEC       GpmMetricId = 230
+	GPM_METRIC_NVLINK_L27_TX_PER_SEC       GpmMetricId = 231
+	GPM_METRIC_NVLINK_L28_RX_PER_SEC       GpmMetricId = 232
+	GPM_METRIC_NVLINK_L28_TX_PER_SEC       GpmMetricId = 233
+	GPM_METRIC_NVLINK_L29_RX_PER_SEC       GpmMetricId = 234
+	GPM_METRIC_NVLINK_L29_TX_PER_SEC       GpmMetricId = 235
+	GPM_METRIC_NVLINK_L30_RX_PER_SEC       GpmMetricId = 236
+	GPM_METRIC_NVLINK_L30_TX_PER_SEC       GpmMetricId = 237
+	GPM_METRIC_NVLINK_L31_RX_PER_SEC       GpmMetricId = 238
+	GPM_METRIC_NVLINK_L31_TX_PER_SEC       GpmMetricId = 239
+	GPM_METRIC_NVLINK_L32_RX_PER_SEC       GpmMetricId = 240
+	GPM_METRIC_NVLINK_L32_TX_PER_SEC       GpmMetricId = 241
+	GPM_METRIC_NVLINK_L33_RX_PER_SEC       GpmMetricId = 242
+	GPM_METRIC_NVLINK_L33_TX_PER_SEC       GpmMetricId = 243
+	GPM_METRIC_NVLINK_L34_RX_PER_SEC       GpmMetricId = 244
+	GPM_METRIC_NVLINK_L34_TX_PER_SEC       GpmMetricId = 245
+	GPM_METRIC_NVLINK_L35_RX_PER_SEC       GpmMetricId = 246
+	GPM_METRIC_NVLINK_L35_TX_PER_SEC       GpmMetricId = 247
 	GPM_METRIC_SM_CYCLES_ELAPSED           GpmMetricId = 248
 	GPM_METRIC_SM_CYCLES_ACTIVE            GpmMetricId = 249
 	GPM_METRIC_MMA_CYCLES_ACTIVE           GpmMetricId = 250
@@ -2251,6 +2335,42 @@ const (
 	GPM_METRIC_NVLINK_L16_TX               GpmMetricId = 294
 	GPM_METRIC_NVLINK_L17_RX               GpmMetricId = 295
 	GPM_METRIC_NVLINK_L17_TX               GpmMetricId = 296
+	GPM_METRIC_NVLINK_L18_RX               GpmMetricId = 297
+	GPM_METRIC_NVLINK_L18_TX               GpmMetricId = 298
+	GPM_METRIC_NVLINK_L19_RX               GpmMetricId = 299
+	GPM_METRIC_NVLINK_L19_TX               GpmMetricId = 300
+	GPM_METRIC_NVLINK_L20_RX               GpmMetricId = 301
+	GPM_METRIC_NVLINK_L20_TX               GpmMetricId = 302
+	GPM_METRIC_NVLINK_L21_RX               GpmMetricId = 303
+	GPM_METRIC_NVLINK_L21_TX               GpmMetricId = 304
+	GPM_METRIC_NVLINK_L22_RX               GpmMetricId = 305
+	GPM_METRIC_NVLINK_L22_TX               GpmMetricId = 306
+	GPM_METRIC_NVLINK_L23_RX               GpmMetricId = 307
+	GPM_METRIC_NVLINK_L23_TX               GpmMetricId = 308
+	GPM_METRIC_NVLINK_L24_RX               GpmMetricId = 309
+	GPM_METRIC_NVLINK_L24_TX               GpmMetricId = 310
+	GPM_METRIC_NVLINK_L25_RX               GpmMetricId = 311
+	GPM_METRIC_NVLINK_L25_TX               GpmMetricId = 312
+	GPM_METRIC_NVLINK_L26_RX               GpmMetricId = 313
+	GPM_METRIC_NVLINK_L26_TX               GpmMetricId = 314
+	GPM_METRIC_NVLINK_L27_RX               GpmMetricId = 315
+	GPM_METRIC_NVLINK_L27_TX               GpmMetricId = 316
+	GPM_METRIC_NVLINK_L28_RX               GpmMetricId = 317
+	GPM_METRIC_NVLINK_L28_TX               GpmMetricId = 318
+	GPM_METRIC_NVLINK_L29_RX               GpmMetricId = 319
+	GPM_METRIC_NVLINK_L29_TX               GpmMetricId = 320
+	GPM_METRIC_NVLINK_L30_RX               GpmMetricId = 321
+	GPM_METRIC_NVLINK_L30_TX               GpmMetricId = 322
+	GPM_METRIC_NVLINK_L31_RX               GpmMetricId = 323
+	GPM_METRIC_NVLINK_L31_TX               GpmMetricId = 324
+	GPM_METRIC_NVLINK_L32_RX               GpmMetricId = 325
+	GPM_METRIC_NVLINK_L32_TX               GpmMetricId = 326
+	GPM_METRIC_NVLINK_L33_RX               GpmMetricId = 327
+	GPM_METRIC_NVLINK_L33_TX               GpmMetricId = 328
+	GPM_METRIC_NVLINK_L34_RX               GpmMetricId = 329
+	GPM_METRIC_NVLINK_L34_TX               GpmMetricId = 330
+	GPM_METRIC_NVLINK_L35_RX               GpmMetricId = 331
+	GPM_METRIC_NVLINK_L35_TX               GpmMetricId = 332
 	GPM_METRIC_MAX                         GpmMetricId = 333
 )
 

--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -1460,6 +1460,18 @@ func (device nvmlDevice) GetAccountingBufferSize() (int, Return) {
 	return int(bufferSize), ret
 }
 
+// nvml.DeviceGetAccountingStats_v2()
+func (l *library) DeviceGetAccountingStats_v2(device Device, pid uint32) (AccountingStats_v2, Return) {
+	return device.GetAccountingStats_v2(pid)
+}
+
+func (device nvmlDevice) GetAccountingStats_v2(pid uint32) (AccountingStats_v2, Return) {
+	var stats AccountingStats_v2
+	stats.Pid = pid
+	ret := nvmlDeviceGetAccountingStats_v2(device, &stats)
+	return stats, ret
+}
+
 // nvml.DeviceGetRetiredPages()
 func (l *library) DeviceGetRetiredPages(device Device, cause PageRetirementCause) ([]uint64, Return) {
 	return device.GetRetiredPages(cause)
@@ -3144,6 +3156,17 @@ func (device nvmlDevice) GetLastBBXFlushTime() (uint64, uint, Return) {
 	var durationUs uint
 	ret := nvmlDeviceGetLastBBXFlushTime(device, &timestamp, &durationUs)
 	return timestamp, durationUs, ret
+}
+
+// nvml.DeviceGetBBXTimeData_v1()
+func (l *library) DeviceGetBBXTimeData_v1(device Device) (BBXTimeData_v1, Return) {
+	return device.GetBBXTimeData_v1()
+}
+
+func (device nvmlDevice) GetBBXTimeData_v1() (BBXTimeData_v1, Return) {
+	var timeData BBXTimeData_v1
+	ret := nvmlDeviceGetBBXTimeData_v1(device, &timeData)
+	return timeData, ret
 }
 
 // nvml.DeviceGetNumaNodeId()

--- a/pkg/nvml/mock/device.go
+++ b/pkg/nvml/mock/device.go
@@ -54,6 +54,9 @@ var _ nvml.Device = &Device{}
 //			GetAccountingStatsFunc: func(v uint32) (nvml.AccountingStats, nvml.Return) {
 //				panic("mock out the GetAccountingStats method")
 //			},
+//			GetAccountingStats_v2Func: func(v uint32) (nvml.AccountingStats_v2, nvml.Return) {
+//				panic("mock out the GetAccountingStats_v2 method")
+//			},
 //			GetActiveVgpusFunc: func() ([]nvml.VgpuInstance, nvml.Return) {
 //				panic("mock out the GetActiveVgpus method")
 //			},
@@ -77,6 +80,9 @@ var _ nvml.Device = &Device{}
 //			},
 //			GetBAR1MemoryInfoFunc: func() (nvml.BAR1Memory, nvml.Return) {
 //				panic("mock out the GetBAR1MemoryInfo method")
+//			},
+//			GetBBXTimeData_v1Func: func() (nvml.BBXTimeData_v1, nvml.Return) {
+//				panic("mock out the GetBBXTimeData_v1 method")
 //			},
 //			GetBoardIdFunc: func() (uint32, nvml.Return) {
 //				panic("mock out the GetBoardId method")
@@ -868,6 +874,9 @@ type Device struct {
 	// GetAccountingStatsFunc mocks the GetAccountingStats method.
 	GetAccountingStatsFunc func(v uint32) (nvml.AccountingStats, nvml.Return)
 
+	// GetAccountingStats_v2Func mocks the GetAccountingStats_v2 method.
+	GetAccountingStats_v2Func func(v uint32) (nvml.AccountingStats_v2, nvml.Return)
+
 	// GetActiveVgpusFunc mocks the GetActiveVgpus method.
 	GetActiveVgpusFunc func() ([]nvml.VgpuInstance, nvml.Return)
 
@@ -891,6 +900,9 @@ type Device struct {
 
 	// GetBAR1MemoryInfoFunc mocks the GetBAR1MemoryInfo method.
 	GetBAR1MemoryInfoFunc func() (nvml.BAR1Memory, nvml.Return)
+
+	// GetBBXTimeData_v1Func mocks the GetBBXTimeData_v1 method.
+	GetBBXTimeData_v1Func func() (nvml.BBXTimeData_v1, nvml.Return)
 
 	// GetBoardIdFunc mocks the GetBoardId method.
 	GetBoardIdFunc func() (uint32, nvml.Return)
@@ -1697,6 +1709,11 @@ type Device struct {
 			// V is the v argument value.
 			V uint32
 		}
+		// GetAccountingStats_v2 holds details about calls to the GetAccountingStats_v2 method.
+		GetAccountingStats_v2 []struct {
+			// V is the v argument value.
+			V uint32
+		}
 		// GetActiveVgpus holds details about calls to the GetActiveVgpus method.
 		GetActiveVgpus []struct {
 		}
@@ -1722,6 +1739,9 @@ type Device struct {
 		}
 		// GetBAR1MemoryInfo holds details about calls to the GetBAR1MemoryInfo method.
 		GetBAR1MemoryInfo []struct {
+		}
+		// GetBBXTimeData_v1 holds details about calls to the GetBBXTimeData_v1 method.
+		GetBBXTimeData_v1 []struct {
 		}
 		// GetBoardId holds details about calls to the GetBoardId method.
 		GetBoardId []struct {
@@ -2759,6 +2779,7 @@ type Device struct {
 	lockGetAccountingMode                          sync.RWMutex
 	lockGetAccountingPids                          sync.RWMutex
 	lockGetAccountingStats                         sync.RWMutex
+	lockGetAccountingStats_v2                      sync.RWMutex
 	lockGetActiveVgpus                             sync.RWMutex
 	lockGetAdaptiveClockInfoStatus                 sync.RWMutex
 	lockGetAddressingMode                          sync.RWMutex
@@ -2767,6 +2788,7 @@ type Device struct {
 	lockGetAttributes                              sync.RWMutex
 	lockGetAutoBoostedClocksEnabled                sync.RWMutex
 	lockGetBAR1MemoryInfo                          sync.RWMutex
+	lockGetBBXTimeData_v1                          sync.RWMutex
 	lockGetBoardId                                 sync.RWMutex
 	lockGetBoardPartNumber                         sync.RWMutex
 	lockGetBrand                                   sync.RWMutex
@@ -3389,6 +3411,38 @@ func (mock *Device) GetAccountingStatsCalls() []struct {
 	return calls
 }
 
+// GetAccountingStats_v2 calls GetAccountingStats_v2Func.
+func (mock *Device) GetAccountingStats_v2(v uint32) (nvml.AccountingStats_v2, nvml.Return) {
+	if mock.GetAccountingStats_v2Func == nil {
+		panic("Device.GetAccountingStats_v2Func: method is nil but Device.GetAccountingStats_v2 was just called")
+	}
+	callInfo := struct {
+		V uint32
+	}{
+		V: v,
+	}
+	mock.lockGetAccountingStats_v2.Lock()
+	mock.calls.GetAccountingStats_v2 = append(mock.calls.GetAccountingStats_v2, callInfo)
+	mock.lockGetAccountingStats_v2.Unlock()
+	return mock.GetAccountingStats_v2Func(v)
+}
+
+// GetAccountingStats_v2Calls gets all the calls that were made to GetAccountingStats_v2.
+// Check the length with:
+//
+//	len(mockedDevice.GetAccountingStats_v2Calls())
+func (mock *Device) GetAccountingStats_v2Calls() []struct {
+	V uint32
+} {
+	var calls []struct {
+		V uint32
+	}
+	mock.lockGetAccountingStats_v2.RLock()
+	calls = mock.calls.GetAccountingStats_v2
+	mock.lockGetAccountingStats_v2.RUnlock()
+	return calls
+}
+
 // GetActiveVgpus calls GetActiveVgpusFunc.
 func (mock *Device) GetActiveVgpus() ([]nvml.VgpuInstance, nvml.Return) {
 	if mock.GetActiveVgpusFunc == nil {
@@ -3607,6 +3661,33 @@ func (mock *Device) GetBAR1MemoryInfoCalls() []struct {
 	mock.lockGetBAR1MemoryInfo.RLock()
 	calls = mock.calls.GetBAR1MemoryInfo
 	mock.lockGetBAR1MemoryInfo.RUnlock()
+	return calls
+}
+
+// GetBBXTimeData_v1 calls GetBBXTimeData_v1Func.
+func (mock *Device) GetBBXTimeData_v1() (nvml.BBXTimeData_v1, nvml.Return) {
+	if mock.GetBBXTimeData_v1Func == nil {
+		panic("Device.GetBBXTimeData_v1Func: method is nil but Device.GetBBXTimeData_v1 was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockGetBBXTimeData_v1.Lock()
+	mock.calls.GetBBXTimeData_v1 = append(mock.calls.GetBBXTimeData_v1, callInfo)
+	mock.lockGetBBXTimeData_v1.Unlock()
+	return mock.GetBBXTimeData_v1Func()
+}
+
+// GetBBXTimeData_v1Calls gets all the calls that were made to GetBBXTimeData_v1.
+// Check the length with:
+//
+//	len(mockedDevice.GetBBXTimeData_v1Calls())
+func (mock *Device) GetBBXTimeData_v1Calls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockGetBBXTimeData_v1.RLock()
+	calls = mock.calls.GetBBXTimeData_v1
+	mock.lockGetBBXTimeData_v1.RUnlock()
 	return calls
 }
 

--- a/pkg/nvml/mock/interface.go
+++ b/pkg/nvml/mock/interface.go
@@ -63,6 +63,9 @@ var _ nvml.Interface = &Interface{}
 //			DeviceGetAccountingStatsFunc: func(device nvml.Device, v uint32) (nvml.AccountingStats, nvml.Return) {
 //				panic("mock out the DeviceGetAccountingStats method")
 //			},
+//			DeviceGetAccountingStats_v2Func: func(device nvml.Device, v uint32) (nvml.AccountingStats_v2, nvml.Return) {
+//				panic("mock out the DeviceGetAccountingStats_v2 method")
+//			},
 //			DeviceGetActiveVgpusFunc: func(device nvml.Device) ([]nvml.VgpuInstance, nvml.Return) {
 //				panic("mock out the DeviceGetActiveVgpus method")
 //			},
@@ -86,6 +89,9 @@ var _ nvml.Interface = &Interface{}
 //			},
 //			DeviceGetBAR1MemoryInfoFunc: func(device nvml.Device) (nvml.BAR1Memory, nvml.Return) {
 //				panic("mock out the DeviceGetBAR1MemoryInfo method")
+//			},
+//			DeviceGetBBXTimeData_v1Func: func(device nvml.Device) (nvml.BBXTimeData_v1, nvml.Return) {
+//				panic("mock out the DeviceGetBBXTimeData_v1 method")
 //			},
 //			DeviceGetBoardIdFunc: func(device nvml.Device) (uint32, nvml.Return) {
 //				panic("mock out the DeviceGetBoardId method")
@@ -987,6 +993,9 @@ var _ nvml.Interface = &Interface{}
 //			SystemEventSetWaitFunc: func(systemEventSetWaitRequest *nvml.SystemEventSetWaitRequest) nvml.Return {
 //				panic("mock out the SystemEventSetWait method")
 //			},
+//			SystemGetCPER_v1Func: func(getCPER_v1 *nvml.GetCPER_v1) nvml.Return {
+//				panic("mock out the SystemGetCPER_v1 method")
+//			},
 //			SystemGetConfComputeCapabilitiesFunc: func() (nvml.ConfComputeSystemCaps, nvml.Return) {
 //				panic("mock out the SystemGetConfComputeCapabilities method")
 //			},
@@ -1234,6 +1243,9 @@ type Interface struct {
 	// DeviceGetAccountingStatsFunc mocks the DeviceGetAccountingStats method.
 	DeviceGetAccountingStatsFunc func(device nvml.Device, v uint32) (nvml.AccountingStats, nvml.Return)
 
+	// DeviceGetAccountingStats_v2Func mocks the DeviceGetAccountingStats_v2 method.
+	DeviceGetAccountingStats_v2Func func(device nvml.Device, v uint32) (nvml.AccountingStats_v2, nvml.Return)
+
 	// DeviceGetActiveVgpusFunc mocks the DeviceGetActiveVgpus method.
 	DeviceGetActiveVgpusFunc func(device nvml.Device) ([]nvml.VgpuInstance, nvml.Return)
 
@@ -1257,6 +1269,9 @@ type Interface struct {
 
 	// DeviceGetBAR1MemoryInfoFunc mocks the DeviceGetBAR1MemoryInfo method.
 	DeviceGetBAR1MemoryInfoFunc func(device nvml.Device) (nvml.BAR1Memory, nvml.Return)
+
+	// DeviceGetBBXTimeData_v1Func mocks the DeviceGetBBXTimeData_v1 method.
+	DeviceGetBBXTimeData_v1Func func(device nvml.Device) (nvml.BBXTimeData_v1, nvml.Return)
 
 	// DeviceGetBoardIdFunc mocks the DeviceGetBoardId method.
 	DeviceGetBoardIdFunc func(device nvml.Device) (uint32, nvml.Return)
@@ -2158,6 +2173,9 @@ type Interface struct {
 	// SystemEventSetWaitFunc mocks the SystemEventSetWait method.
 	SystemEventSetWaitFunc func(systemEventSetWaitRequest *nvml.SystemEventSetWaitRequest) nvml.Return
 
+	// SystemGetCPER_v1Func mocks the SystemGetCPER_v1 method.
+	SystemGetCPER_v1Func func(getCPER_v1 *nvml.GetCPER_v1) nvml.Return
+
 	// SystemGetConfComputeCapabilitiesFunc mocks the SystemGetConfComputeCapabilities method.
 	SystemGetConfComputeCapabilitiesFunc func() (nvml.ConfComputeSystemCaps, nvml.Return)
 
@@ -2448,6 +2466,13 @@ type Interface struct {
 			// V is the v argument value.
 			V uint32
 		}
+		// DeviceGetAccountingStats_v2 holds details about calls to the DeviceGetAccountingStats_v2 method.
+		DeviceGetAccountingStats_v2 []struct {
+			// Device is the device argument value.
+			Device nvml.Device
+			// V is the v argument value.
+			V uint32
+		}
 		// DeviceGetActiveVgpus holds details about calls to the DeviceGetActiveVgpus method.
 		DeviceGetActiveVgpus []struct {
 			// Device is the device argument value.
@@ -2487,6 +2512,11 @@ type Interface struct {
 		}
 		// DeviceGetBAR1MemoryInfo holds details about calls to the DeviceGetBAR1MemoryInfo method.
 		DeviceGetBAR1MemoryInfo []struct {
+			// Device is the device argument value.
+			Device nvml.Device
+		}
+		// DeviceGetBBXTimeData_v1 holds details about calls to the DeviceGetBBXTimeData_v1 method.
+		DeviceGetBBXTimeData_v1 []struct {
 			// Device is the device argument value.
 			Device nvml.Device
 		}
@@ -4290,6 +4320,11 @@ type Interface struct {
 			// SystemEventSetWaitRequest is the systemEventSetWaitRequest argument value.
 			SystemEventSetWaitRequest *nvml.SystemEventSetWaitRequest
 		}
+		// SystemGetCPER_v1 holds details about calls to the SystemGetCPER_v1 method.
+		SystemGetCPER_v1 []struct {
+			// GetCPER_v1 is the getCPER_v1 argument value.
+			GetCPER_v1 *nvml.GetCPER_v1
+		}
 		// SystemGetConfComputeCapabilities holds details about calls to the SystemGetConfComputeCapabilities method.
 		SystemGetConfComputeCapabilities []struct {
 		}
@@ -4619,6 +4654,7 @@ type Interface struct {
 	lockDeviceGetAccountingMode                          sync.RWMutex
 	lockDeviceGetAccountingPids                          sync.RWMutex
 	lockDeviceGetAccountingStats                         sync.RWMutex
+	lockDeviceGetAccountingStats_v2                      sync.RWMutex
 	lockDeviceGetActiveVgpus                             sync.RWMutex
 	lockDeviceGetAdaptiveClockInfoStatus                 sync.RWMutex
 	lockDeviceGetAddressingMode                          sync.RWMutex
@@ -4627,6 +4663,7 @@ type Interface struct {
 	lockDeviceGetAttributes                              sync.RWMutex
 	lockDeviceGetAutoBoostedClocksEnabled                sync.RWMutex
 	lockDeviceGetBAR1MemoryInfo                          sync.RWMutex
+	lockDeviceGetBBXTimeData_v1                          sync.RWMutex
 	lockDeviceGetBoardId                                 sync.RWMutex
 	lockDeviceGetBoardPartNumber                         sync.RWMutex
 	lockDeviceGetBrand                                   sync.RWMutex
@@ -4927,6 +4964,7 @@ type Interface struct {
 	lockSystemEventSetCreate                             sync.RWMutex
 	lockSystemEventSetFree                               sync.RWMutex
 	lockSystemEventSetWait                               sync.RWMutex
+	lockSystemGetCPER_v1                                 sync.RWMutex
 	lockSystemGetConfComputeCapabilities                 sync.RWMutex
 	lockSystemGetConfComputeGpusReadyState               sync.RWMutex
 	lockSystemGetConfComputeKeyRotationThresholdInfo     sync.RWMutex
@@ -5509,6 +5547,42 @@ func (mock *Interface) DeviceGetAccountingStatsCalls() []struct {
 	return calls
 }
 
+// DeviceGetAccountingStats_v2 calls DeviceGetAccountingStats_v2Func.
+func (mock *Interface) DeviceGetAccountingStats_v2(device nvml.Device, v uint32) (nvml.AccountingStats_v2, nvml.Return) {
+	if mock.DeviceGetAccountingStats_v2Func == nil {
+		panic("Interface.DeviceGetAccountingStats_v2Func: method is nil but Interface.DeviceGetAccountingStats_v2 was just called")
+	}
+	callInfo := struct {
+		Device nvml.Device
+		V      uint32
+	}{
+		Device: device,
+		V:      v,
+	}
+	mock.lockDeviceGetAccountingStats_v2.Lock()
+	mock.calls.DeviceGetAccountingStats_v2 = append(mock.calls.DeviceGetAccountingStats_v2, callInfo)
+	mock.lockDeviceGetAccountingStats_v2.Unlock()
+	return mock.DeviceGetAccountingStats_v2Func(device, v)
+}
+
+// DeviceGetAccountingStats_v2Calls gets all the calls that were made to DeviceGetAccountingStats_v2.
+// Check the length with:
+//
+//	len(mockedInterface.DeviceGetAccountingStats_v2Calls())
+func (mock *Interface) DeviceGetAccountingStats_v2Calls() []struct {
+	Device nvml.Device
+	V      uint32
+} {
+	var calls []struct {
+		Device nvml.Device
+		V      uint32
+	}
+	mock.lockDeviceGetAccountingStats_v2.RLock()
+	calls = mock.calls.DeviceGetAccountingStats_v2
+	mock.lockDeviceGetAccountingStats_v2.RUnlock()
+	return calls
+}
+
 // DeviceGetActiveVgpus calls DeviceGetActiveVgpusFunc.
 func (mock *Interface) DeviceGetActiveVgpus(device nvml.Device) ([]nvml.VgpuInstance, nvml.Return) {
 	if mock.DeviceGetActiveVgpusFunc == nil {
@@ -5766,6 +5840,38 @@ func (mock *Interface) DeviceGetBAR1MemoryInfoCalls() []struct {
 	mock.lockDeviceGetBAR1MemoryInfo.RLock()
 	calls = mock.calls.DeviceGetBAR1MemoryInfo
 	mock.lockDeviceGetBAR1MemoryInfo.RUnlock()
+	return calls
+}
+
+// DeviceGetBBXTimeData_v1 calls DeviceGetBBXTimeData_v1Func.
+func (mock *Interface) DeviceGetBBXTimeData_v1(device nvml.Device) (nvml.BBXTimeData_v1, nvml.Return) {
+	if mock.DeviceGetBBXTimeData_v1Func == nil {
+		panic("Interface.DeviceGetBBXTimeData_v1Func: method is nil but Interface.DeviceGetBBXTimeData_v1 was just called")
+	}
+	callInfo := struct {
+		Device nvml.Device
+	}{
+		Device: device,
+	}
+	mock.lockDeviceGetBBXTimeData_v1.Lock()
+	mock.calls.DeviceGetBBXTimeData_v1 = append(mock.calls.DeviceGetBBXTimeData_v1, callInfo)
+	mock.lockDeviceGetBBXTimeData_v1.Unlock()
+	return mock.DeviceGetBBXTimeData_v1Func(device)
+}
+
+// DeviceGetBBXTimeData_v1Calls gets all the calls that were made to DeviceGetBBXTimeData_v1.
+// Check the length with:
+//
+//	len(mockedInterface.DeviceGetBBXTimeData_v1Calls())
+func (mock *Interface) DeviceGetBBXTimeData_v1Calls() []struct {
+	Device nvml.Device
+} {
+	var calls []struct {
+		Device nvml.Device
+	}
+	mock.lockDeviceGetBBXTimeData_v1.RLock()
+	calls = mock.calls.DeviceGetBBXTimeData_v1
+	mock.lockDeviceGetBBXTimeData_v1.RUnlock()
 	return calls
 }
 
@@ -15958,6 +16064,38 @@ func (mock *Interface) SystemEventSetWaitCalls() []struct {
 	mock.lockSystemEventSetWait.RLock()
 	calls = mock.calls.SystemEventSetWait
 	mock.lockSystemEventSetWait.RUnlock()
+	return calls
+}
+
+// SystemGetCPER_v1 calls SystemGetCPER_v1Func.
+func (mock *Interface) SystemGetCPER_v1(getCPER_v1 *nvml.GetCPER_v1) nvml.Return {
+	if mock.SystemGetCPER_v1Func == nil {
+		panic("Interface.SystemGetCPER_v1Func: method is nil but Interface.SystemGetCPER_v1 was just called")
+	}
+	callInfo := struct {
+		GetCPER_v1 *nvml.GetCPER_v1
+	}{
+		GetCPER_v1: getCPER_v1,
+	}
+	mock.lockSystemGetCPER_v1.Lock()
+	mock.calls.SystemGetCPER_v1 = append(mock.calls.SystemGetCPER_v1, callInfo)
+	mock.lockSystemGetCPER_v1.Unlock()
+	return mock.SystemGetCPER_v1Func(getCPER_v1)
+}
+
+// SystemGetCPER_v1Calls gets all the calls that were made to SystemGetCPER_v1.
+// Check the length with:
+//
+//	len(mockedInterface.SystemGetCPER_v1Calls())
+func (mock *Interface) SystemGetCPER_v1Calls() []struct {
+	GetCPER_v1 *nvml.GetCPER_v1
+} {
+	var calls []struct {
+		GetCPER_v1 *nvml.GetCPER_v1
+	}
+	mock.lockSystemGetCPER_v1.RLock()
+	calls = mock.calls.SystemGetCPER_v1
+	mock.lockSystemGetCPER_v1.RUnlock()
 	return calls
 }
 

--- a/pkg/nvml/nvml.go
+++ b/pkg/nvml/nvml.go
@@ -130,6 +130,14 @@ func nvmlSystemGetDriverBranch(BranchInfo *SystemDriverBranchInfo, Length uint32
 	return __v
 }
 
+// nvmlSystemGetCPER_v1 function as declared in nvml/nvml.h
+func nvmlSystemGetCPER_v1(Cper *GetCPER_v1) Return {
+	cCper, _ := (*C.nvmlGetCPER_v1_t)(unsafe.Pointer(Cper)), cgoAllocsUnknown
+	__ret := C.nvmlSystemGetCPER_v1(cCper)
+	__v := (Return)(__ret)
+	return __v
+}
+
 // nvmlUnitGetCount function as declared in nvml/nvml.h
 func nvmlUnitGetCount(UnitCount *uint32) Return {
 	cUnitCount, _ := (*C.uint)(unsafe.Pointer(UnitCount)), cgoAllocsUnknown
@@ -510,6 +518,15 @@ func nvmlDeviceGetLastBBXFlushTime(nvmlDevice nvmlDevice, Timestamp *uint64, Dur
 	cTimestamp, _ := (*C.ulonglong)(unsafe.Pointer(Timestamp)), cgoAllocsUnknown
 	cDurationUs, _ := (*C.ulong)(unsafe.Pointer(DurationUs)), cgoAllocsUnknown
 	__ret := C.nvmlDeviceGetLastBBXFlushTime(cnvmlDevice, cTimestamp, cDurationUs)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlDeviceGetBBXTimeData_v1 function as declared in nvml/nvml.h
+func nvmlDeviceGetBBXTimeData_v1(nvmlDevice nvmlDevice, TimeData *BBXTimeData_v1) Return {
+	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
+	cTimeData, _ := (*C.nvmlBBXTimeData_v1_t)(unsafe.Pointer(TimeData)), cgoAllocsUnknown
+	__ret := C.nvmlDeviceGetBBXTimeData_v1(cnvmlDevice, cTimeData)
 	__v := (Return)(__ret)
 	return __v
 }
@@ -1698,6 +1715,15 @@ func nvmlDeviceGetAccountingBufferSize(nvmlDevice nvmlDevice, BufferSize *uint32
 	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
 	cBufferSize, _ := (*C.uint)(unsafe.Pointer(BufferSize)), cgoAllocsUnknown
 	__ret := C.nvmlDeviceGetAccountingBufferSize(cnvmlDevice, cBufferSize)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlDeviceGetAccountingStats_v2 function as declared in nvml/nvml.h
+func nvmlDeviceGetAccountingStats_v2(nvmlDevice nvmlDevice, Stats *AccountingStats_v2) Return {
+	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
+	cStats, _ := (*C.nvmlAccountingStats_v2_t)(unsafe.Pointer(Stats)), cgoAllocsUnknown
+	__ret := C.nvmlDeviceGetAccountingStats_v2(cnvmlDevice, cStats)
 	__v := (Return)(__ret)
 	return __v
 }

--- a/pkg/nvml/nvml.h
+++ b/pkg/nvml/nvml.h
@@ -1,5 +1,5 @@
-/*** NVML VERSION: 13.2.82 ***/
-/*** From https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvml_dev/linux-x86_64/cuda_nvml_dev-linux-x86_64-13.2.82-archive.tar.xz ***/
+/*** NVML VERSION: 13.3.29 ***/
+/*** From https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvml_dev/linux-x86_64/cuda_nvml_dev-linux-x86_64-13.3.29-archive.tar.xz ***/
 /*
  * Copyright 1993-2026 NVIDIA Corporation.  All rights reserved.
  *
@@ -336,12 +336,24 @@ typedef struct
 } nvmlProcessDetail_v1_t;
 
 /**
+ * Enum to represent process mode.
+ */
+ typedef enum nvmlProcessMode_enum
+ {
+     NVML_PROCESS_MODE_COMPUTE       = 0,   //!< Processes with a compute context
+     NVML_PROCESS_MODE_GRAPHICS      = 1,   //!< Processes with a graphics context
+     NVML_PROCESS_MODE_MPS           = 2,   //!< Processes with a MPS (Multi-Process Service) compute context
+     NVML_PROCESS_MODE_ALL           = 3,   //!< All processes running on the GPU (compute, graphics, MPS, and other types)
+     NVML_PROCESS_MODE_MAX           = NVML_PROCESS_MODE_ALL + 1  //!< Maximum value for bounds checking
+ } nvmlProcessMode_t;
+
+/**
  * Information about all running processes on the GPU for the given mode
  */
 typedef struct
 {
     unsigned int           version;             //!< Struct version, MUST be nvmlProcessDetailList_v1
-    unsigned int           mode;                //!< Process mode(Compute/Graphics/MPSCompute)
+    unsigned int           mode;                //!< Process mode, One of \ref nvmlProcessMode_t
     unsigned int           numProcArrayEntries; //!< Number of process entries in procArray
     nvmlProcessDetail_v1_t *procArray;          //!< Process array
 } nvmlProcessDetailList_v1_t;
@@ -446,7 +458,7 @@ typedef enum nvmlBridgeChipType_enum
 /**
  * Maximum number of NvLink links supported
  */
-#define NVML_NVLINK_MAX_LINKS 18 //!< Maximum number of NVLink links supported.
+#define NVML_NVLINK_MAX_LINKS 36 //!< Maximum number of NVLink links supported.
 
 /**
  * Enum to represent the NvLink utilization counter packet units
@@ -857,6 +869,13 @@ typedef struct
 typedef nvmlPdi_v1_t nvmlPdi_t;
 
 #define nvmlPdi_v1 NVML_STRUCT_VERSION(Pdi, 1) //!< Version macro for \a nvmlPdi_v1_t
+
+/**
+ * BBX Time Data
+ */
+ typedef struct {
+    unsigned int timeRun;  //!< [out] Cumulative number of seconds the GPU has had the driver loaded
+} nvmlBBXTimeData_v1_t;
 
 /** @} */
 
@@ -1540,6 +1559,8 @@ typedef struct
 
 #define NVML_DEVICE_ARCH_BLACKWELL 10 //!< Devices based on the NVIDIA Blackwell architecture
 
+#define NVML_DEVICE_ARCH_RUBIN     13 //!< Devices based on the NVIDIA Rubin architecture.
+
 #define NVML_DEVICE_ARCH_UNKNOWN   0xffffffff //!< Anything else, presumably something newer
 
 typedef unsigned int nvmlDeviceArchitecture_t;
@@ -1634,9 +1655,11 @@ typedef struct nvmlGpuDynamicPstatesInfo_st
 /**
  * Device Scope - This is useful to retrieve the telemetry at GPU and module (e.g. GPU + CPU) level
  */
-#define NVML_POWER_SCOPE_GPU     0U    //!< Targets only GPU
-#define NVML_POWER_SCOPE_MODULE  1U    //!< Targets the whole module
-#define NVML_POWER_SCOPE_MEMORY  2U    //!< Targets the GPU Memory
+#define NVML_POWER_SCOPE_GPU      0U    //!< Targets only GPU
+#define NVML_POWER_SCOPE_MODULE   1U    //!< Targets the whole module
+#define NVML_POWER_SCOPE_MEMORY   2U    //!< Targets the GPU Memory
+#define NVML_POWER_SCOPE_GPU_BASE 3U    //!< Targets base GPU power
+#define NVML_POWER_SCOPE_COUNT    4U    //!< Maximum number of power scopes
 
 typedef unsigned char nvmlPowerScopeType_t;
 
@@ -2186,6 +2209,7 @@ typedef enum nvmlDeviceGpuRecoveryAction_s  {
     NVML_GPU_RECOVERY_ACTION_NODE_REBOOT = 2,         //!< Reboot Node
     NVML_GPU_RECOVERY_ACTION_DRAIN_P2P = 3,           //!< Drain P2P
     NVML_GPU_RECOVERY_ACTION_DRAIN_AND_RESET = 4,     //!< Drain P2P and Reset Gpu
+    NVML_GPU_RECOVERY_ACTION_RECOVER_IMEX_DOMAIN = 5, //!< Recover IMEX Domain.
 } nvmlDeviceGpuRecoveryAction_t;
 
 /**
@@ -2696,7 +2720,9 @@ typedef struct
  *
  * scopeId needs to be specified. It signifies:
  * 0 - GPU Only Scope - Metrics for GPU are retrieved
- * 1 - Module scope - Metrics for the module (e.g. CPU + GPU) are retrieved.
+ * 1 - Module scope   - Metrics for the module (e.g. CPU + GPU) are retrieved.
+ * 2 - GPU base scope - GPU base Power metrics are retrieved.
+ *                      Note: Only supports _MIN_LIMIT, _MAX_LIMIT, _DEFAULT_LIMIT, and _CURRENT_LIMIT fields.
  * Note: CPU here refers to NVIDIA CPU (e.g. Grace). x86 or non-NVIDIA ARM is not supported
  */
 #define NVML_FI_DEV_POWER_AVERAGE                     185 //!< GPU power averaged over 1 sec interval, supported on Ampere (except GA100) or newer architectures.
@@ -2933,10 +2959,21 @@ typedef struct
 #define NVML_FI_DEV_NVLINK_COUNT_RAW_BER_V2                      293 //!< NVLINK total raw BER
 #define NVML_FI_DEV_NVLINK_PLR_XMIT_BLOCKS                       294 //!< NVLINK PLR Xmit Blocks
 #define NVML_FI_DEV_NVLINK_PLR_XMIT_RETRY_BLOCKS                 295 //!< NVLINK PLR Xmit Retry Blocks
-
+#define NVML_FI_DEV_NVLINK_GET_DATA_RATE                         296 //!< The Effective Nvlink Data rate available for transactions after accounting for FEC overhead
+#define NVML_FI_DEV_MMA_STALL_PERCENT                            297 //!< MMA (Matrix Multiply Accumulate) stall percentage
+#define NVML_FI_DEV_MCLK_SWITCH_TYPE                             298 //!< See NVML_MCLK_SWITCH_TYPE_<XYZ> for all enumerations
+#define NVML_FI_DEV_MCLK_MIN_SWITCH_INTERVAL_MILLISECONDS        299 //!< minimum required elapsed time between runtime mclk switches, 0 = no rate limit
+#define NVML_FI_PWR_SMOOTHING_SOC_POWER_SMOOTHING_ENABLED        300 //!< State-Of-Charge Power Smoothing Enabled (0/DISABLED or 1/ENABLED)
 #define NVML_FI_DEV_REMAPPED_ROWS_COR_INACTIVE                  301 //!< Number of inactive row remappings due to correctable errors
 #define NVML_FI_DEV_REMAPPED_ROWS_UNC_INACTIVE                  302 //!< Number of inactive row remappings due to uncorrectable errors
 #define NVML_FI_MAX                                             303 //!< One greater than the largest field ID defined above
+
+/**
+ * NVML_FI_DEV_MCLK_SWITCH_TYPE enumerations
+ */
+#define NVML_MCLK_SWITCH_TYPE_NOT_SUPPORTED 0x0 //!< switching is not supported
+#define NVML_MCLK_SWITCH_TYPE_DEFERRED      0x1 //!< deferred switching (driver reload)
+#define NVML_MCLK_SWITCH_TYPE_RUNTIME       0x2 //!< runtime switching
 
 /**
  * NVML_FI_DEV_NVLINK_GET_POWER_THRESHOLD_UNITS
@@ -3481,6 +3518,37 @@ typedef struct nvmlAccountingStats_st {
 
     unsigned int reserved[5];                   //!< Reserved for future use
 } nvmlAccountingStats_t;
+
+/**
+ * Describes accounting statistics (v2) of a process.
+ */
+typedef struct {
+    unsigned int pid;                           //!< Process Id of the target process to query stats for
+
+    unsigned int isRunning;                     //!< Flag to represent if the process is running (1 for running, 0 for terminated)
+
+    unsigned int gpuUtilization;                //!< Percent of time over the process's lifetime during which one or more kernels was executing on the GPU.
+                                                //! Utilization stats just like returned by \ref nvmlDeviceGetUtilizationRates but for the life time of a
+                                                //! process (not just the last sample period).
+                                                //! Set to NVML_VALUE_NOT_AVAILABLE if nvmlDeviceGetUtilizationRates is not supported
+
+    unsigned int memoryUtilization;             //!< Percent of time over the process's lifetime during which global (device) memory was being read or written.
+                                                //! Set to NVML_VALUE_NOT_AVAILABLE if nvmlDeviceGetUtilizationRates is not supported
+
+    unsigned long long maxMemoryUsage;          //!< Maximum total memory in bytes that was ever allocated by the process.
+                                                //! Set to NVML_VALUE_NOT_AVAILABLE if nvmlProcessInfo_t->usedGpuMemory is not supported
+
+    unsigned int sampleCount;                   //!< The sample counts since the process starts
+
+    unsigned long long sumGpuUtil;              //!< The sum of process's GR engine utilization in unit of pct * 100
+
+    unsigned long long sumFbUtil;               //!< The sum of process's FB bandwidth utilization in unit of pct * 100
+
+    unsigned long long time;                    //!< Amount of time in ms during which the compute context was active. The time is reported as 0 if
+                                                //! the process is not terminated
+
+    unsigned long long startTime;               //!< CPU Timestamp in usec representing start time for the process
+} nvmlAccountingStats_v2_t;
 
 /** @} */
 
@@ -4070,6 +4138,56 @@ const DECLDIR char* nvmlErrorString(nvmlReturn_t result);
 /** @} */
 
 /***************************************************************************************************/
+/** @defgroup nvmlCPER CPER (Common Platform Error Record)
+ * Types and API for retrieving CPER data.
+ *  @{
+ */
+/***************************************************************************************************/
+
+typedef unsigned long long nvmlCPERCursorHandle_t;   //!< Opaque handle to a CPER read position
+
+#define NVML_CPER_CURSOR_HANDLE_INIT ((nvmlCPERCursorHandle_t) 0) //!< Initialize \ref nvmlCPERCursorHandle_t to this value before first use in any CPER API
+
+/**
+ * Bitmask of CPER record types. Multiple values may be combined
+ * to request records from several sources in one call.
+ */
+typedef enum
+{
+    NVML_CPER_ACCESS_TYPE_GPU = (1 << 0),   //!< Access GPU CPER records
+} nvmlCPERType_t;
+
+/**
+ * CPER query and cursor parameters. Groups the filter options and opaque
+ * read position used to iterate through CPER records.
+ *
+ * Cursor semantics for iterative calls:
+ * - Pass the same \a nvmlCPERCursor_v1_t (i.e. the same \a cursor) on every call
+ *   in a single iteration sequence.
+ * - Do not modify this struct between calls.
+ * - To change \a cperTypeMask or \a uuid, set \a handle to \ref NVML_CPER_CURSOR_HANDLE_INIT
+ *   and call again with the updated filter (this starts a new iteration).
+ */
+typedef struct
+{
+    unsigned int cperTypeMask;               //!< [IN] Types of records to access. Bitmask of \ref nvmlCPERType_t values. To change, reset \a handle to \ref NVML_CPER_CURSOR_HANDLE_INIT.
+    char uuid[NVML_DEVICE_UUID_BUFFER_SIZE]; //!< [IN] UUID of target to filter records for. Required for \ref NVML_CPER_ACCESS_TYPE_GPU. To change, reset \a handle to \ref NVML_CPER_CURSOR_HANDLE_INIT.
+    nvmlCPERCursorHandle_t handle;           //!< [IN/OUT] Opaque handle tracking read position. Initialize to \ref NVML_CPER_CURSOR_HANDLE_INIT on first call; pass the same \a nvmlCPERCursor_v1_t on the next call to continue. Caller must not interpret or modify.
+} nvmlCPERCursor_v1_t;
+
+/**
+ * Input/output structure for \ref nvmlSystemGetCPER_v1.
+ */
+typedef struct
+{
+    nvmlCPERCursor_v1_t cursor;  //!< [IN/OUT] Query parameters and cursor. See \ref nvmlCPERCursor_v1_t
+    unsigned char *buffer;       //!< [OUT] Buffer to be filled (allocated by client). May be NULL for size query.
+    unsigned int bufferSize;     //!< [IN/OUT] Size of \a buffer. Set to 0 with \a buffer NULL to query required size. On return, set to required or used size; 0 means no (more) records.
+} nvmlGetCPER_v1_t;
+
+/** @} */
+
+/***************************************************************************************************/
 /** @defgroup nvmlSystemQueries System Queries
  * This chapter describes the queries that NVML can perform against the local system. These queries
  * are not device-specific.
@@ -4244,6 +4362,37 @@ typedef nvmlSystemDriverBranchInfo_v1_t nvmlSystemDriverBranchInfo_t;
  */
 nvmlReturn_t DECLDIR nvmlSystemGetDriverBranch(nvmlSystemDriverBranchInfo_t *branchInfo, unsigned int length);
 
+/**
+ * Retrieves Common Platform Error Record (CPER) data.
+ *
+ * Records are returned in a caller-supplied buffer. Iteration is driven by the
+ * \a cursor (\ref nvmlCPERCursor_v1_t) struct: pass the same \a cursor on every call
+ * in a sequence; the implementation updates \a cursor.handle. Do not modify \a cursor between
+ * calls. To change \a cursor.cperTypeMask or \a cursor.uuid, set \a cursor.handle to
+ * \ref NVML_CPER_CURSOR_HANDLE_INIT and call again (new iteration).
+ *
+ * For a size query, call with \a buffer NULL and \a bufferSize 0; the function
+ * returns \ref NVML_ERROR_INSUFFICIENT_SIZE and sets \a bufferSize when records exist,
+ * or \ref NVML_SUCCESS with \a bufferSize set to 0 when there are no CPER records.
+ * Use \a bufferSize == 0 on return as the indicator for "no records" or "no more records".
+ *
+ * This API requires root privileges. Records are available from initialization.
+ *
+ * @param cper     Pointer to an \ref nvmlGetCPER_v1_t. On entry set \a cursor.cperTypeMask,
+ *                 \a cursor.uuid (empty string for all), \a cursor.handle (to
+ *                 \ref NVML_CPER_CURSOR_HANDLE_INIT for first call), \a buffer (or NULL),
+ *                 \a bufferSize. On return \a cursor.handle and \a bufferSize are updated.
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 Buffer has been populated with CPER data, or \a bufferSize is 0 (no/more records).
+ *         - \ref NVML_ERROR_UNINITIALIZED     The library has not been successfully initialized.
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  \a cper is NULL, or \a buffer is NULL while \a bufferSize is non-zero.
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     The feature is not supported on this system.
+ *         - \ref NVML_ERROR_INSUFFICIENT_SIZE Buffer too small; \a bufferSize set to required size.
+ *         - \ref NVML_ERROR_NO_PERMISSION     Insufficient privileges.
+ *         - \ref NVML_ERROR_UNKNOWN           An unexpected error occurred.
+ */
+nvmlReturn_t DECLDIR nvmlSystemGetCPER_v1(nvmlGetCPER_v1_t *cper);
 
 /** @} */
 
@@ -5213,6 +5362,23 @@ nvmlReturn_t DECLDIR nvmlDeviceValidateInforom(nvmlDevice_t device);
 nvmlReturn_t DECLDIR nvmlDeviceGetLastBBXFlushTime(nvmlDevice_t device, unsigned long long *timestamp,
                                                    unsigned long *durationUs);
 
+/**
+ * Retrieves the cumulative number of seconds the GPU has had the driver loaded.
+ *
+ * For all products with an inforom.
+ *
+ * @param device                               The identifier of the target device
+ * @param timeData                             Reference in which to return the cumulative number of seconds the GPU has had the driver loaded
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if \a timeData has been set
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a timeData is NULL
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support this feature
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ */
+
+nvmlReturn_t DECLDIR nvmlDeviceGetBBXTimeData_v1(nvmlDevice_t device, nvmlBBXTimeData_v1_t *timeData);
 /**
  * Retrieves the display mode for the device.
  *
@@ -6605,13 +6771,15 @@ nvmlReturn_t DECLDIR nvmlDeviceGetMemoryInfo(nvmlDevice_t device, nvmlMemory_t *
 nvmlReturn_t DECLDIR nvmlDeviceGetMemoryInfo_v2(nvmlDevice_t device, nvmlMemory_v2_t *memory);
 
 /**
- * Retrieves the current compute mode for the device.
+ * Retrieves the current compute mode for the device or MIG device.
  *
  * For all products.
  *
+ * @note If MIG is enabled on a GPU, device must be MIG device handle.
+ *
  * See \ref nvmlComputeMode_t for details on allowed compute modes.
  *
- * @param device                               The identifier of the target device
+ * @param device                               The identifier of the target device handle or MIG device handle
  * @param mode                                 Reference in which to return the current compute mode
  *
  * @return
@@ -8137,6 +8305,44 @@ nvmlReturn_t DECLDIR nvmlDeviceGetAccountingPids(nvmlDevice_t device, unsigned i
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetAccountingBufferSize(nvmlDevice_t device, unsigned int *bufferSize);
 
+/**
+ * Queries process's accounting stats (v2).
+ *
+ * For Kepler &tm; or newer fully supported devices.
+ *
+ * Accounting stats (v2) capture GPU utilization and other statistics across the lifetime of a process.
+ * Accounting stats (v2) can be queried during life time of the process and after its termination.
+ * The time field in \ref nvmlAccountingStats_v2_t is reported as 0 during the lifetime of the process and
+ * updated to actual running time after its termination.
+ * Accounting stats (v2) are kept in a circular buffer, newly created processes overwrite information about old
+ * processes.
+ *
+ * See \ref nvmlAccountingStats_v2_t for description of each returned metric.
+ * List of processes that can be queried can be retrieved from \ref nvmlDeviceGetAccountingPids.
+ *
+ * @note Accounting Mode needs to be on. See \ref nvmlDeviceGetAccountingMode.
+ * @note Only compute and graphics applications stats can be queried. Monitoring applications stats can't be
+ *         queried since they don't contribute to GPU utilization.
+ * @note In case of pid collision stats of only the latest process (that terminated last) will be reported
+ *
+ * @warning On Kepler devices per process statistics are accurate only if there's one process running on a GPU.
+ *
+ * @param device                               The identifier of the target device
+ * @param stats                                Reference in which to return the process's accounting stats (v2)
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if stats (v2) have been successfully retrieved
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a stats are NULL
+ *         - \ref NVML_ERROR_NOT_FOUND         if process stats were not found
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if \a device doesn't support this feature or accounting mode is disabled
+ *                                              or on vGPU host.
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlDeviceGetAccountingBufferSize
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetAccountingStats_v2(nvmlDevice_t device, nvmlAccountingStats_v2_t *stats);
+
 /** @} */
 
 /** @addtogroup nvmlDeviceQueries
@@ -8569,7 +8775,7 @@ nvmlReturn_t DECLDIR nvmlUnitSetLedState(nvmlUnit_t unit, nvmlLedColor_t color);
 nvmlReturn_t DECLDIR nvmlDeviceSetPersistenceMode(nvmlDevice_t device, nvmlEnableState_t mode);
 
 /**
- * Set the compute mode for the device.
+ * Set the compute mode for the device or MIG device.
  *
  * For all products.
  * Requires root/admin permissions.
@@ -8582,11 +8788,11 @@ nvmlReturn_t DECLDIR nvmlDeviceSetPersistenceMode(nvmlDevice_t device, nvmlEnabl
  *
  * Under windows compute mode may only be set to DEFAULT when running in WDDM
  *
- * @note On MIG-enabled GPUs, compute mode would be set to DEFAULT and changing it is not supported.
+ * @note If MIG is enabled on a GPU, device must be MIG device handle.
  *
  * See \ref nvmlComputeMode_t for details on available compute modes.
  *
- * @param device                               The identifier of the target device
+ * @param device                               The identifier of the target device handle or MIG device handle
  * @param mode                                 The target compute mode
  *
  * @return
@@ -9219,6 +9425,7 @@ typedef enum nvmlNvlinkVersion_enum
     NVML_NVLINK_VERSION_3_1     = 5, //!< NVLink Version 3.1
     NVML_NVLINK_VERSION_4_0     = 6, //!< NVLink Version 4.0
     NVML_NVLINK_VERSION_5_0     = 7, //!< NVLink Version 5.0
+    NVML_NVLINK_VERSION_6_0     = 8, //!< NVLink Version 6.0
 } nvmlNvlinkVersion_t;
 
 #define NVML_NVLINK_TOTAL_SUPPORTED_BW_MODES 23 //!< Total supported NVLink bandwidth modes.
@@ -12338,8 +12545,9 @@ nvmlReturn_t DECLDIR nvmlDeviceReadPRMCounters_v1(nvmlDevice_t device, nvmlPRMCo
 // Allocation of instance of this profile prevents allocation of
 // all but _NO_ME profiles.
 #define NVML_GPU_INSTANCE_PROFILE_2_SLICE_ALL_ME   0x10
-#define NVML_GPU_INSTANCE_PROFILE_3_SLICE_GFX      0x11    //!< 3_SLICE gfx + media capable profile.
-#define NVML_GPU_INSTANCE_PROFILE_COUNT            0x12    //!< Total number of GPU instance profiles.
+
+#define NVML_GPU_INSTANCE_PROFILE_3_SLICE_GFX           0x11    //!< 3_SLICE gfx + media capable profile.
+#define NVML_GPU_INSTANCE_PROFILE_COUNT                 0x12    //!< Total number of GPU instance profiles.
 
 /**
  * MIG GPU instance profile capability.
@@ -12459,11 +12667,12 @@ typedef struct nvmlGpuInstanceInfo_st
 #define NVML_COMPUTE_INSTANCE_PROFILE_2_SLICE       0x1 //!< 2_SLICE compute instance profile.
 #define NVML_COMPUTE_INSTANCE_PROFILE_3_SLICE       0x2 //!< 3_SLICE compute instance profile.
 #define NVML_COMPUTE_INSTANCE_PROFILE_4_SLICE       0x3 //!< 4_SLICE compute instance profile.
-#define NVML_COMPUTE_INSTANCE_PROFILE_7_SLICE       0x4 //!< 7_SLICE compute instance profile.
+#define NVML_COMPUTE_INSTANCE_PROFILE_7_SLICE       0x4 //!< 7_SLICE compute instance profile  (perf optimized for host work scheduling).
 #define NVML_COMPUTE_INSTANCE_PROFILE_8_SLICE       0x5 //!< 8_SLICE compute instance profile.
 #define NVML_COMPUTE_INSTANCE_PROFILE_6_SLICE       0x6 //!< 6_SLICE compute instance profile.
 #define NVML_COMPUTE_INSTANCE_PROFILE_1_SLICE_REV1  0x7 //!< 1_SLICE compute instance profile (rev1).
-#define NVML_COMPUTE_INSTANCE_PROFILE_COUNT         0x8 //!< Number of compute instance profiles.
+#define NVML_COMPUTE_INSTANCE_PROFILE_7_SLICE_NVL   0x8 //!< 7_SLICE compute instance profile (perf optimized for multi-GPU use).
+#define NVML_COMPUTE_INSTANCE_PROFILE_COUNT         0x9 //!< Number of compute instance profiles.
 
 #define NVML_COMPUTE_INSTANCE_ENGINE_PROFILE_SHARED 0x0 //!< All the engines except multiprocessors would be shared.
 #define NVML_COMPUTE_INSTANCE_ENGINE_PROFILE_COUNT  0x1 //!< Number of engine profiles.
@@ -13475,6 +13684,42 @@ typedef enum
     NVML_GPM_METRIC_GR7_CTXSW_REQUESTS          = 207,
     NVML_GPM_METRIC_GR7_CTXSW_CYCLES_PER_REQ    = 208,
     NVML_GPM_METRIC_GR7_CTXSW_ACTIVE_PCT        = 209,
+    NVML_GPM_METRIC_NVLINK_L18_RX_PER_SEC       = 212,
+    NVML_GPM_METRIC_NVLINK_L18_TX_PER_SEC       = 213,
+    NVML_GPM_METRIC_NVLINK_L19_RX_PER_SEC       = 214,
+    NVML_GPM_METRIC_NVLINK_L19_TX_PER_SEC       = 215,
+    NVML_GPM_METRIC_NVLINK_L20_RX_PER_SEC       = 216,
+    NVML_GPM_METRIC_NVLINK_L20_TX_PER_SEC       = 217,
+    NVML_GPM_METRIC_NVLINK_L21_RX_PER_SEC       = 218,
+    NVML_GPM_METRIC_NVLINK_L21_TX_PER_SEC       = 219,
+    NVML_GPM_METRIC_NVLINK_L22_RX_PER_SEC       = 220,
+    NVML_GPM_METRIC_NVLINK_L22_TX_PER_SEC       = 221,
+    NVML_GPM_METRIC_NVLINK_L23_RX_PER_SEC       = 222,
+    NVML_GPM_METRIC_NVLINK_L23_TX_PER_SEC       = 223,
+    NVML_GPM_METRIC_NVLINK_L24_RX_PER_SEC       = 224,
+    NVML_GPM_METRIC_NVLINK_L24_TX_PER_SEC       = 225,
+    NVML_GPM_METRIC_NVLINK_L25_RX_PER_SEC       = 226,
+    NVML_GPM_METRIC_NVLINK_L25_TX_PER_SEC       = 227,
+    NVML_GPM_METRIC_NVLINK_L26_RX_PER_SEC       = 228,
+    NVML_GPM_METRIC_NVLINK_L26_TX_PER_SEC       = 229,
+    NVML_GPM_METRIC_NVLINK_L27_RX_PER_SEC       = 230,
+    NVML_GPM_METRIC_NVLINK_L27_TX_PER_SEC       = 231,
+    NVML_GPM_METRIC_NVLINK_L28_RX_PER_SEC       = 232,
+    NVML_GPM_METRIC_NVLINK_L28_TX_PER_SEC       = 233,
+    NVML_GPM_METRIC_NVLINK_L29_RX_PER_SEC       = 234,
+    NVML_GPM_METRIC_NVLINK_L29_TX_PER_SEC       = 235,
+    NVML_GPM_METRIC_NVLINK_L30_RX_PER_SEC       = 236,
+    NVML_GPM_METRIC_NVLINK_L30_TX_PER_SEC       = 237,
+    NVML_GPM_METRIC_NVLINK_L31_RX_PER_SEC       = 238,
+    NVML_GPM_METRIC_NVLINK_L31_TX_PER_SEC       = 239,
+    NVML_GPM_METRIC_NVLINK_L32_RX_PER_SEC       = 240,
+    NVML_GPM_METRIC_NVLINK_L32_TX_PER_SEC       = 241,
+    NVML_GPM_METRIC_NVLINK_L33_RX_PER_SEC       = 242,
+    NVML_GPM_METRIC_NVLINK_L33_TX_PER_SEC       = 243,
+    NVML_GPM_METRIC_NVLINK_L34_RX_PER_SEC       = 244,
+    NVML_GPM_METRIC_NVLINK_L34_TX_PER_SEC       = 245,
+    NVML_GPM_METRIC_NVLINK_L35_RX_PER_SEC       = 246,
+    NVML_GPM_METRIC_NVLINK_L35_TX_PER_SEC       = 247,
     NVML_GPM_METRIC_SM_CYCLES_ELAPSED           = 248,  //!< The GPU's SM cycles elapsed since reboot
     NVML_GPM_METRIC_SM_CYCLES_ACTIVE            = 249,  //!< The GPU's SM activity since reboot
     NVML_GPM_METRIC_MMA_CYCLES_ACTIVE           = 250,  //!< The GPU's SM MMA tensor activity since reboot
@@ -13524,6 +13769,42 @@ typedef enum
     NVML_GPM_METRIC_NVLINK_L16_TX               = 294,  //!< NvLink write for link 16 in bytes since reboot
     NVML_GPM_METRIC_NVLINK_L17_RX               = 295,  //!< NvLink read for link 17 in bytes since reboot
     NVML_GPM_METRIC_NVLINK_L17_TX               = 296,  //!< NvLink write for link 17 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L18_RX               = 297,  //!< NvLink read for link 18 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L18_TX               = 298,  //!< NvLink write for link 18 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L19_RX               = 299,  //!< NvLink read for link 19 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L19_TX               = 300,  //!< NvLink write for link 19 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L20_RX               = 301,  //!< NvLink read for link 20 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L20_TX               = 302,  //!< NvLink write for link 20 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L21_RX               = 303,  //!< NvLink read for link 21 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L21_TX               = 304,  //!< NvLink write for link 21 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L22_RX               = 305,  //!< NvLink read for link 22 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L22_TX               = 306,  //!< NvLink write for link 22 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L23_RX               = 307,  //!< NvLink read for link 23 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L23_TX               = 308,  //!< NvLink write for link 23 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L24_RX               = 309,  //!< NvLink read for link 24 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L24_TX               = 310,  //!< NvLink write for link 24 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L25_RX               = 311,  //!< NvLink read for link 25 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L25_TX               = 312,  //!< NvLink write for link 25 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L26_RX               = 313,  //!< NvLink read for link 26 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L26_TX               = 314,  //!< NvLink write for link 26 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L27_RX               = 315,  //!< NvLink read for link 27 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L27_TX               = 316,  //!< NvLink write for link 27 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L28_RX               = 317,  //!< NvLink read for link 28 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L28_TX               = 318,  //!< NvLink write for link 28 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L29_RX               = 319,  //!< NvLink read for link 29 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L29_TX               = 320,  //!< NvLink write for link 29 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L30_RX               = 321,  //!< NvLink read for link 30 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L30_TX               = 322,  //!< NvLink write for link 30 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L31_RX               = 323,  //!< NvLink read for link 31 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L31_TX               = 324,  //!< NvLink write for link 31 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L32_RX               = 325,  //!< NvLink read for link 32 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L32_TX               = 326,  //!< NvLink write for link 32 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L33_RX               = 327,  //!< NvLink read for link 33 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L33_TX               = 328,  //!< NvLink write for link 33 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L34_RX               = 329,  //!< NvLink read for link 34 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L34_TX               = 330,  //!< NvLink write for link 34 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L35_RX               = 331,  //!< NvLink read for link 35 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L35_TX               = 332,  //!< NvLink write for link 35 in bytes since reboot
     NVML_GPM_METRIC_MAX                         = 333,  //!< Maximum value above +1
 } nvmlGpmMetricId_t;
 
@@ -14036,14 +14317,18 @@ nvmlReturn_t DECLDIR nvmlDeviceWorkloadPowerProfileUpdateProfiles_v1(nvmlDevice_
  */
 /***************************************************************************************************/
 /**
- * Macro for accomodating the gap in field values for delayed power smoothing.
+ * Macro for accomodating the gaps in field values for power smoothing.
  */
 #define NVML_POWER_SMOOTHING_IDX_FROM_FIELD_VAL(field_val)  \
     ( \
-        (field_val > NVML_FI_PWR_SMOOTHING_ADMIN_OVERRIDE_RAMP_DOWN_HYST_VAL) ? \
-        (field_val - NVML_FI_PWR_SMOOTHING_ENABLED - \
+        ((field_val) >= NVML_FI_PWR_SMOOTHING_SOC_POWER_SMOOTHING_ENABLED) ? \
+        ((field_val) - NVML_FI_PWR_SMOOTHING_ENABLED - \
+            (NVML_FI_PWR_SMOOTHING_PRIMARY_POWER_FLOOR - NVML_FI_PWR_SMOOTHING_ADMIN_OVERRIDE_RAMP_DOWN_HYST_VAL - 1) - \
+            (NVML_FI_PWR_SMOOTHING_SOC_POWER_SMOOTHING_ENABLED - NVML_FI_PWR_SMOOTHING_ADMIN_OVERRIDE_PRIMARY_FLOOR_ACT_OFFSET - 1)) : \
+        ((field_val) > NVML_FI_PWR_SMOOTHING_ADMIN_OVERRIDE_RAMP_DOWN_HYST_VAL) ? \
+        ((field_val) - NVML_FI_PWR_SMOOTHING_ENABLED - \
             (NVML_FI_PWR_SMOOTHING_PRIMARY_POWER_FLOOR - NVML_FI_PWR_SMOOTHING_ADMIN_OVERRIDE_RAMP_DOWN_HYST_VAL - 1)) : \
-        (field_val - NVML_FI_PWR_SMOOTHING_ENABLED) \
+        ((field_val) - NVML_FI_PWR_SMOOTHING_ENABLED) \
     ) //!< Index from field value.
 
 #define NVML_POWER_SMOOTHING_MAX_NUM_PROFILES                   5 //!< Maximum number of profiles.

--- a/pkg/nvml/system.go
+++ b/pkg/nvml/system.go
@@ -146,3 +146,8 @@ func (l *library) SystemGetDriverBranch() (SystemDriverBranchInfo, Return) {
 	ret := nvmlSystemGetDriverBranch(&branchInfo, SYSTEM_DRIVER_VERSION_BUFFER_SIZE)
 	return branchInfo, ret
 }
+
+func (l *library) SystemGetCPER_v1(cper *GetCPER_v1) Return {
+	ret := nvmlSystemGetCPER_v1(cper)
+	return ret
+}

--- a/pkg/nvml/types_gen.go
+++ b/pkg/nvml/types_gen.go
@@ -254,6 +254,10 @@ type Pdi struct {
 	Value   uint64
 }
 
+type BBXTimeData_v1 struct {
+	TimeRun uint32
+}
+
 type DramEncryptionInfo_v1 struct {
 	Version         uint32
 	EncryptionState uint32
@@ -1042,6 +1046,19 @@ type AccountingStats struct {
 	Reserved          [5]uint32
 }
 
+type AccountingStats_v2 struct {
+	Pid               uint32
+	IsRunning         uint32
+	GpuUtilization    uint32
+	MemoryUtilization uint32
+	MaxMemoryUsage    uint64
+	SampleCount       uint32
+	SumGpuUtil        uint64
+	SumFbUtil         uint64
+	Time              uint64
+	StartTime         uint64
+}
+
 type EncoderSessionInfo struct {
 	SessionId      uint32
 	Pid            uint32
@@ -1181,6 +1198,21 @@ type GpuFabricInfoV struct {
 	HealthMask    uint32
 	HealthSummary uint8
 	Pad_cgo_0     [3]byte
+}
+
+type CPERCursorHandle uint64
+
+type CPERCursor_v1 struct {
+	CperTypeMask uint32
+	Uuid         [80]int8
+	Handle       uint64
+}
+
+type GetCPER_v1 struct {
+	Cursor     CPERCursor_v1
+	Buffer     *uint8
+	BufferSize uint32
+	Pad_cgo_0  [4]byte
 }
 
 type SystemDriverBranchInfo_v1 struct {

--- a/pkg/nvml/zz_generated.api.go
+++ b/pkg/nvml/zz_generated.api.go
@@ -35,6 +35,7 @@ var (
 	DeviceGetAccountingMode                          = libnvml.DeviceGetAccountingMode
 	DeviceGetAccountingPids                          = libnvml.DeviceGetAccountingPids
 	DeviceGetAccountingStats                         = libnvml.DeviceGetAccountingStats
+	DeviceGetAccountingStats_v2                      = libnvml.DeviceGetAccountingStats_v2
 	DeviceGetActiveVgpus                             = libnvml.DeviceGetActiveVgpus
 	DeviceGetAdaptiveClockInfoStatus                 = libnvml.DeviceGetAdaptiveClockInfoStatus
 	DeviceGetAddressingMode                          = libnvml.DeviceGetAddressingMode
@@ -43,6 +44,7 @@ var (
 	DeviceGetAttributes                              = libnvml.DeviceGetAttributes
 	DeviceGetAutoBoostedClocksEnabled                = libnvml.DeviceGetAutoBoostedClocksEnabled
 	DeviceGetBAR1MemoryInfo                          = libnvml.DeviceGetBAR1MemoryInfo
+	DeviceGetBBXTimeData_v1                          = libnvml.DeviceGetBBXTimeData_v1
 	DeviceGetBoardId                                 = libnvml.DeviceGetBoardId
 	DeviceGetBoardPartNumber                         = libnvml.DeviceGetBoardPartNumber
 	DeviceGetBrand                                   = libnvml.DeviceGetBrand
@@ -343,6 +345,7 @@ var (
 	SystemEventSetCreate                             = libnvml.SystemEventSetCreate
 	SystemEventSetFree                               = libnvml.SystemEventSetFree
 	SystemEventSetWait                               = libnvml.SystemEventSetWait
+	SystemGetCPER_v1                                 = libnvml.SystemGetCPER_v1
 	SystemGetConfComputeCapabilities                 = libnvml.SystemGetConfComputeCapabilities
 	SystemGetConfComputeGpusReadyState               = libnvml.SystemGetConfComputeGpusReadyState
 	SystemGetConfComputeKeyRotationThresholdInfo     = libnvml.SystemGetConfComputeKeyRotationThresholdInfo
@@ -429,6 +432,7 @@ type Interface interface {
 	DeviceGetAccountingMode(Device) (EnableState, Return)
 	DeviceGetAccountingPids(Device) ([]int, Return)
 	DeviceGetAccountingStats(Device, uint32) (AccountingStats, Return)
+	DeviceGetAccountingStats_v2(Device, uint32) (AccountingStats_v2, Return)
 	DeviceGetActiveVgpus(Device) ([]VgpuInstance, Return)
 	DeviceGetAdaptiveClockInfoStatus(Device) (uint32, Return)
 	DeviceGetAddressingMode(Device) (DeviceAddressingMode, Return)
@@ -437,6 +441,7 @@ type Interface interface {
 	DeviceGetAttributes(Device) (DeviceAttributes, Return)
 	DeviceGetAutoBoostedClocksEnabled(Device) (EnableState, EnableState, Return)
 	DeviceGetBAR1MemoryInfo(Device) (BAR1Memory, Return)
+	DeviceGetBBXTimeData_v1(Device) (BBXTimeData_v1, Return)
 	DeviceGetBoardId(Device) (uint32, Return)
 	DeviceGetBoardPartNumber(Device) (string, Return)
 	DeviceGetBrand(Device) (BrandType, Return)
@@ -737,6 +742,7 @@ type Interface interface {
 	SystemEventSetCreate(*SystemEventSetCreateRequest) Return
 	SystemEventSetFree(*SystemEventSetFreeRequest) Return
 	SystemEventSetWait(*SystemEventSetWaitRequest) Return
+	SystemGetCPER_v1(*GetCPER_v1) Return
 	SystemGetConfComputeCapabilities() (ConfComputeSystemCaps, Return)
 	SystemGetConfComputeGpusReadyState() (uint32, Return)
 	SystemGetConfComputeKeyRotationThresholdInfo() (ConfComputeGetKeyRotationThresholdInfo, Return)
@@ -820,6 +826,7 @@ type Device interface {
 	GetAccountingMode() (EnableState, Return)
 	GetAccountingPids() ([]int, Return)
 	GetAccountingStats(uint32) (AccountingStats, Return)
+	GetAccountingStats_v2(uint32) (AccountingStats_v2, Return)
 	GetActiveVgpus() ([]VgpuInstance, Return)
 	GetAdaptiveClockInfoStatus() (uint32, Return)
 	GetAddressingMode() (DeviceAddressingMode, Return)
@@ -828,6 +835,7 @@ type Device interface {
 	GetAttributes() (DeviceAttributes, Return)
 	GetAutoBoostedClocksEnabled() (EnableState, EnableState, Return)
 	GetBAR1MemoryInfo() (BAR1Memory, Return)
+	GetBBXTimeData_v1() (BBXTimeData_v1, Return)
 	GetBoardId() (uint32, Return)
 	GetBoardPartNumber() (string, Return)
 	GetBrand() (BrandType, Return)


### PR DESCRIPTION
This PR ppdates go-nvml bindings from CUDA 13.2.1 → 13.3.0.

It adds the following new API methods: 
- DeviceGetAccountingStats_v2
- DeviceGetBBXTimeData_v1
- SystemGetCPER_v1