### PR TITLE
Set Version on GetProcessesUtilizationInfo and GetVgpuInstancesUtilizationInfo

### DIFF
--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -3239,6 +3239,7 @@ func (l *library) DeviceGetProcessesUtilizationInfo(device Device) (ProcessesUti
 
 func (device nvmlDevice) GetProcessesUtilizationInfo() (ProcessesUtilizationInfo, Return) {
 	var processesUtilInfo ProcessesUtilizationInfo
+	processesUtilInfo.Version = STRUCT_VERSION(processesUtilInfo, 1)
 	ret := nvmlDeviceGetProcessesUtilizationInfo(device, &processesUtilInfo)
 	return processesUtilInfo, ret
 }
@@ -3314,6 +3315,7 @@ func (l *library) DeviceGetVgpuInstancesUtilizationInfo(device Device) (VgpuInst
 
 func (device nvmlDevice) GetVgpuInstancesUtilizationInfo() (VgpuInstancesUtilizationInfo, Return) {
 	var vgpuUtilInfo VgpuInstancesUtilizationInfo
+	vgpuUtilInfo.Version = STRUCT_VERSION(vgpuUtilInfo, 1)
 	ret := nvmlDeviceGetVgpuInstancesUtilizationInfo(device, &vgpuUtilInfo)
 	return vgpuUtilInfo, ret
 }


### PR DESCRIPTION
## Description

`GetProcessesUtilizationInfo` and `GetVgpuInstancesUtilizationInfo` declare their info struct and call the underlying NVML function **without** initializing the leading `Version` field. `STRUCT_VERSION` encodes the struct size and version, so a zero `Version` is an invalid tag and NVML rejects **every** call with `ERROR_ARGUMENT_VERSION_MISMATCH`.

The sibling `GetVgpuProcessesUtilizationInfo` (and the other versioned getters) correctly set `Version = STRUCT_VERSION(x, 1)` before the call — this just applies the same one line to the two methods that were missed. It is a follow-up to #139, which fixed the same omission for a batch of siblings.

## Fix

```go
processesUtilInfo.Version = STRUCT_VERSION(processesUtilInfo, 1)
vgpuUtilInfo.Version = STRUCT_VERSION(vgpuUtilInfo, 1)
```

## Testing

`go build ./pkg/nvml/...` and `go vet` pass. Verified on an RTX 5050 (driver via WSL2):

| Method | Before | After |
|--------|--------|-------|
| `GetProcessesUtilizationInfo` | `Argument version mismatch` | `Insufficient Size` (expected two-pass sizing code) |
| `GetVgpuInstancesUtilizationInfo` | `Argument version mismatch` | `Not Supported` (no vGPU on this GPU) |
