### PR TITLE
device: call the ByID profile-info API in GpuInstanceProfileInfoByIdHandler.V3

### DIFF
--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -2281,7 +2281,7 @@ func (handler GpuInstanceProfileInfoByIdHandler) V2() (GpuInstanceProfileInfo_v2
 func (handler GpuInstanceProfileInfoByIdHandler) V3() (GpuInstanceProfileInfo_v3, Return) {
 	var info GpuInstanceProfileInfo_v3
 	info.Version = STRUCT_VERSION(info, 3)
-	ret := nvmlDeviceGetGpuInstanceProfileInfoV(handler.device, uint32(handler.profileId), (*GpuInstanceProfileInfo_v2)(unsafe.Pointer(&info)))
+	ret := nvmlDeviceGetGpuInstanceProfileInfoByIdV(handler.device, uint32(handler.profileId), (*GpuInstanceProfileInfo_v2)(unsafe.Pointer(&info)))
 	return info, ret
 }
 


### PR DESCRIPTION
## Description

`GpuInstanceProfileInfoByIdHandler` is the *by-id* handler (it carries a `profileId` and is returned by `DeviceGetGpuInstanceProfileInfoByIdV`). Its `V2()` correctly calls `nvmlDeviceGetGpuInstanceProfileInfoByIdV`, but `V3()` calls `nvmlDeviceGetGpuInstanceProfileInfoV` — the profile-*by-index* API — passing `handler.profileId` into the `Profile` (index) parameter.

So `DeviceGetGpuInstanceProfileInfoByIdV(id).V3()` queries by index instead of by id, returning the wrong profile's info (or `ERROR_INVALID_ARGUMENT` for an id that isn't a valid index).

## Fix

Call `nvmlDeviceGetGpuInstanceProfileInfoByIdV` in `V3()`, matching the `V2()` sibling. Both C bindings take `*GpuInstanceProfileInfo_v2`; the struct version is carried in `.Version` (already set to 3 here), so the existing pointer cast is unchanged.

## Testing

`go build ./pkg/nvml/...` and `go vet` pass. The bug is proven by the internal V2-vs-V3 asymmetry (V2 uses `...ByIdV`, V3 used the non-ById `...V`) — MIG hardware not required.
