### PR TITLE
device: guard nil info in compute-instance placement methods

### DIFF
--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -2916,6 +2916,9 @@ func (l *library) GpuInstanceGetComputeInstancePossiblePlacements(gpuInstance Gp
 }
 
 func (gpuInstance nvmlGpuInstance) GetComputeInstancePossiblePlacements(info *ComputeInstanceProfileInfo) ([]ComputeInstancePlacement, Return) {
+	if info == nil {
+		return nil, ERROR_INVALID_ARGUMENT
+	}
 	var count uint32
 	ret := nvmlGpuInstanceGetComputeInstancePossiblePlacements(gpuInstance, info.Id, nil, &count)
 	if ret != SUCCESS {
@@ -2935,6 +2938,9 @@ func (l *library) GpuInstanceCreateComputeInstanceWithPlacement(gpuInstance GpuI
 }
 
 func (gpuInstance nvmlGpuInstance) CreateComputeInstanceWithPlacement(info *ComputeInstanceProfileInfo, placement *ComputeInstancePlacement) (ComputeInstance, Return) {
+	if info == nil {
+		return nil, ERROR_INVALID_ARGUMENT
+	}
 	var computeInstance nvmlComputeInstance
 	ret := nvmlGpuInstanceCreateComputeInstanceWithPlacement(gpuInstance, info.Id, placement, &computeInstance)
 	return computeInstance, ret


### PR DESCRIPTION
## Description

`GetComputeInstancePossiblePlacements` and `CreateComputeInstanceWithPlacement` read `info.Id` with no nil check, so passing a nil `*ComputeInstanceProfileInfo` panics (nil-pointer dereference during argument evaluation, before the underlying NVML call).

Their GPU-instance counterparts, `GetGpuInstancePossiblePlacements` and `CreateGpuInstanceWithPlacement`, already guard this and return `ERROR_INVALID_ARGUMENT`. This applies the same guard to the two compute-instance methods, so a nil `info` is a clean error instead of a panic.

## Fix

```go
if info == nil {
    return nil, ERROR_INVALID_ARGUMENT
}
```
at the top of both methods, matching the GPU-instance siblings.

## Testing

`go build ./pkg/nvml/...` and `go vet` pass. The panic occurs before the cgo call, so the guard is exercisable GPU-free (a `recover`-based test), consistent with the existing guarded siblings.
