### PR TITLE
[GetComputeInstancePossiblePlacements] slice output result to actual count

### DIFF
--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -2929,7 +2929,7 @@ func (gpuInstance nvmlGpuInstance) GetComputeInstancePossiblePlacements(info *Co
 	}
 	placementArray := make([]ComputeInstancePlacement, count)
 	ret = nvmlGpuInstanceGetComputeInstancePossiblePlacements(gpuInstance, info.Id, &placementArray[0], &count)
-	return placementArray, ret
+	return placementArray[:count], ret
 }
 
 // nvml.GpuInstanceCreateComputeInstanceWithPlacement()


### PR DESCRIPTION
This is a minor change that brings the `nvmlGpuInstance.GetComputeInstancePossiblePlacements` to parity with its sibling method `nvmlDevice.GetGpuInstancePossiblePlacements`.

The `count` is variable is updated twice and we want to make sure we use the most recent value when slicing the output array.