### PR TITLE
bump CUDA version to 13.3.1 and go version to 1.26.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ clean-bindings:
 	rm -f $(PKG_BINDINGS_DIR)/zz_generated.api.go
 
 # Update nvml.h from the NVIDIA CUDA redistributable JSON
-update-nvml-h: CUDA_VERSION := 13.3.0
+update-nvml-h: CUDA_VERSION := 13.3.1
 update-nvml-h: CUDA_REDIST_BASE_URL := https://developer.download.nvidia.com/compute/cuda/redist
 update-nvml-h: CUDA_REDIST_JSON_URL := $(CUDA_REDIST_BASE_URL)/redistrib_$(CUDA_VERSION).json
 update-nvml-h: NVML_DEV_HEADERS_INFO := $(shell \

--- a/versions.mk
+++ b/versions.mk
@@ -19,7 +19,7 @@ GIT_TAG ?= $(patsubst v%,%,$(shell git describe --tags 2>/dev/null))
 MODULE := github.com/NVIDIA/go-nvml
 VERSION ?= $(GIT_TAG)
 
-GOLANG_VERSION ?= 1.26.4
+GOLANG_VERSION ?= 1.26.5
 C_FOR_GO_TAG ?= 8eeee8c3b71f9c3c90c4a73db54ed08b0bba971d
 
 ifeq ($(IMAGE),)


### PR DESCRIPTION
Note: We are just bumping the CUDA version to denote that this repo is synchronised with the CUDA NVML upto 13.3.1. No actual `nvml.h` changes as the CUDA NVML version was never changed in CUDA 13.3.1 Update. The `nvml.h` version of `13.3.29` remains unchanged between the two CUDA toolkit version updates