### PR TITLE
device: pass byte size to nvmlDeviceGetSupportedPerformanceStates

### DIFF
--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -2734,7 +2734,7 @@ func (l *library) DeviceGetSupportedPerformanceStates(device Device) ([]Pstates,
 
 func (device nvmlDevice) GetSupportedPerformanceStates() ([]Pstates, Return) {
 	pstates := make([]Pstates, MAX_GPU_PERF_PSTATES)
-	ret := nvmlDeviceGetSupportedPerformanceStates(device, &pstates[0], MAX_GPU_PERF_PSTATES)
+	ret := nvmlDeviceGetSupportedPerformanceStates(device, &pstates[0], MAX_GPU_PERF_PSTATES*uint32(unsafe.Sizeof(Pstates(0))))
 	for i := 0; i < MAX_GPU_PERF_PSTATES; i++ {
 		if pstates[i] == PSTATE_UNKNOWN {
 			return pstates[0:i], ret


### PR DESCRIPTION
## Problem

`Device.GetSupportedPerformanceStates` passes `MAX_GPU_PERF_PSTATES` (the element count, 16) as the third argument to `nvmlDeviceGetSupportedPerformanceStates`, but that argument is the size of the supplied `pstates` array in bytes.

The buffer is `make([]Pstates, 16)` = 64 bytes, but the driver is told it is 16 bytes, so it fills only the first few entries and leaves the rest at the zero value `PSTATE_0`. The truncation loop stops at `PSTATE_UNKNOWN` (32), never `0`, so the function returns a list padded with phantom `PSTATE_0` entries. On a GPU whose supported-P-state list needs more than 16 bytes, the call instead fails with `ERROR_INSUFFICIENT_SIZE`.

## Fix

Pass the size in bytes, `MAX_GPU_PERF_PSTATES * uint32(unsafe.Sizeof(Pstates(0)))` (= 64). The driver then pads the unused entries with `PSTATE_UNKNOWN`, and the existing truncation loop returns the correct list.

## Testing

`go build ./...` and `go vet ./pkg/nvml/` pass. No GPU on my dev box, so this is a static/contract fix; the byte-vs-count contract is confirmed by the observed phantom `PSTATE_0` padding, which only occurs if the driver read `16` as a byte size.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
