### PR TITLE
device: guard zero instance count in GetGpuInstances/GetComputeInstances

### DIFF
--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -2376,6 +2376,9 @@ func (device nvmlDevice) GetGpuInstances(info *GpuInstanceProfileInfo) ([]GpuIns
 		return nil, ERROR_INVALID_ARGUMENT
 	}
 	var count = info.InstanceCount
+	if count == 0 {
+		return nil, ERROR_INVALID_ARGUMENT
+	}
 	gpuInstances := make([]nvmlGpuInstance, count)
 	ret := nvmlDeviceGetGpuInstances(device, info.Id, &gpuInstances[0], &count)
 	return convertSlice[nvmlGpuInstance, GpuInstance](gpuInstances[:count]), ret
@@ -2494,6 +2497,9 @@ func (gpuInstance nvmlGpuInstance) GetComputeInstances(info *ComputeInstanceProf
 		return nil, ERROR_INVALID_ARGUMENT
 	}
 	var count = info.InstanceCount
+	if count == 0 {
+		return nil, ERROR_INVALID_ARGUMENT
+	}
 	computeInstances := make([]nvmlComputeInstance, count)
 	ret := nvmlGpuInstanceGetComputeInstances(gpuInstance, info.Id, &computeInstances[0], &count)
 	return convertSlice[nvmlComputeInstance, ComputeInstance](computeInstances[:count]), ret


### PR DESCRIPTION
## Problem

`Device.GetGpuInstances` and `Device.GetComputeInstances` read the instance count from the profile info and immediately take the address of the first slice element:

```go
var count = info.InstanceCount
gpuInstances := make([]nvmlGpuInstance, count)
ret := nvmlDeviceGetGpuInstances(device, info.Id, &gpuInstances[0], &count)
```

When `count` is 0 (a zero-valued or hand-built `GpuInstanceProfileInfo` / `ComputeInstanceProfileInfo`, i.e. an invalid profile, since `InstanceCount` is the profile's maximum instance count) `&gpuInstances[0]` panics with an index-out-of-range instead of returning a `Return` code.

## Fix

Guard the zero case (mirroring the existing `nil`-info guard just above): return `nil, ERROR_INVALID_ARGUMENT` when the count is zero, before indexing.

## Testing

`go build ./...` and `go vet ./pkg/nvml/` pass.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.

