### PR TITLE
device/system: stamp STRUCT_VERSION in by-value Set wrappers that omit it

### DIFF
--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -3291,6 +3291,7 @@ func (l *library) DeviceSetVgpuHeterogeneousMode(device Device, heterogeneousMod
 }
 
 func (device nvmlDevice) SetVgpuHeterogeneousMode(heterogeneousMode VgpuHeterogeneousMode) Return {
+	heterogeneousMode.Version = STRUCT_VERSION(heterogeneousMode, 1)
 	ret := nvmlDeviceSetVgpuHeterogeneousMode(device, &heterogeneousMode)
 	return ret
 }
@@ -3391,6 +3392,7 @@ func (l *library) DeviceSetClockOffsets(device Device, info ClockOffset) Return 
 }
 
 func (device nvmlDevice) SetClockOffsets(info ClockOffset) Return {
+	info.Version = STRUCT_VERSION(info, 1)
 	return nvmlDeviceSetClockOffsets(device, &info)
 }
 

--- a/pkg/nvml/system.go
+++ b/pkg/nvml/system.go
@@ -136,6 +136,7 @@ func (l *library) SystemGetConfComputeSettings() (SystemConfComputeSettings, Ret
 
 // nvml.SystemSetConfComputeKeyRotationThresholdInfo()
 func (l *library) SystemSetConfComputeKeyRotationThresholdInfo(keyRotationThresholdInfo ConfComputeSetKeyRotationThresholdInfo) Return {
+	keyRotationThresholdInfo.Version = STRUCT_VERSION(keyRotationThresholdInfo, 1)
 	return nvmlSystemSetConfComputeKeyRotationThresholdInfo(&keyRotationThresholdInfo)
 }
 


### PR DESCRIPTION
## Problem

Three by-value `Set` wrappers forward their struct to the versioned NVML C API without stamping the leading `Version` field, unlike every sibling `Get` wrapper (and `DeviceSetRusdSettings_v1`) which do `x.Version = STRUCT_VERSION(x, 1)`:

- `SystemSetConfComputeKeyRotationThresholdInfo` (`pkg/nvml/system.go`)
- `DeviceSetClockOffsets` (`pkg/nvml/device.go`)
- `DeviceSetVgpuHeterogeneousMode` (`pkg/nvml/device.go`)

Each corresponding C struct is versioned (`nvmlConfComputeSetKeyRotationThresholdInfo_v1`, `nvmlClockOffset_v1`, `nvmlVgpuHeterogeneousMode_v1`) and the driver validates the version. An idiomatic freshly-built struct leaves `Version == 0`, so the call is rejected (`ARGUMENT_VERSION_MISMATCH` / `INVALID_ARGUMENT`) and the setter never takes effect. The `Set` struct types differ from their `Get` counterparts (e.g. `ConfComputeSetKeyRotationThresholdInfo{...MaxAttackerAdvantage}` vs `...Get...{...AttackerAdvantage}`), so a version value can never be carried over from a prior `Get` — the wrapper is the correct place to stamp it.

## Fix

Stamp `Version = STRUCT_VERSION(x, 1)` before forwarding, matching the `Get` siblings. This is the same class as the previously-merged version-stamp fix (#189).

## Testing

`go build ./...` and `go vet ./pkg/nvml/` pass. No Confidential-Compute / vGPU / clock-offset-capable hardware on my dev box, so this is a static + build fix; the version-validation contract is standard NVML struct versioning that the sibling `Get` wrappers already follow.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.
