### PR TITLE
[CUDA 13.4] add go-bindings for new NVML methods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,7 @@ clean-bindings:
 	rm -f $(PKG_BINDINGS_DIR)/zz_generated.api.go
 
 # Update nvml.h from the NVIDIA CUDA redistributable JSON
-update-nvml-h: CUDA_VERSION := 13.3.1
+update-nvml-h: CUDA_VERSION := 13.4.1
 update-nvml-h: CUDA_REDIST_BASE_URL := https://developer.download.nvidia.com/compute/cuda/redist
 update-nvml-h: CUDA_REDIST_JSON_URL := $(CUDA_REDIST_BASE_URL)/redistrib_$(CUDA_VERSION).json
 update-nvml-h: NVML_DEV_HEADERS_INFO := $(shell \

--- a/examples/gpm-metrics/main.go
+++ b/examples/gpm-metrics/main.go
@@ -89,7 +89,7 @@ func collectGPMMetrics(i int) error {
 		NumMetrics: 1,
 		Sample1:    sample1,
 		Sample2:    sample2,
-		Metrics: [333]nvml.GpmMetric{
+		Metrics: [477]nvml.GpmMetric{
 			{
 				MetricId: uint32(nvml.GPM_METRIC_GRAPHICS_UTIL),
 			},

--- a/gen/nvml/nvml.h
+++ b/gen/nvml/nvml.h
@@ -1,5 +1,5 @@
-/*** NVML VERSION: 13.3.29 ***/
-/*** From https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvml_dev/linux-x86_64/cuda_nvml_dev-linux-x86_64-13.3.29-archive.tar.xz ***/
+/*** NVML VERSION: 13.4.61 ***/
+/*** From https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvml_dev/linux-x86_64/cuda_nvml_dev-linux-x86_64-13.4.61-archive.tar.xz ***/
 /*
  * Copyright 1993-2026 NVIDIA Corporation.  All rights reserved.
  *
@@ -275,6 +275,59 @@ typedef struct nvmlMemory_v2_st
 } nvmlMemory_v2_t;
 
 #define nvmlMemory_v2 NVML_STRUCT_VERSION(Memory, 2) //!< Version macro for \a nvmlMemory_v2_t
+
+/**
+ * Value for "maximum" memory limit.
+ */
+#define NVML_DEVICE_MEMORY_LIMIT_MAX 0xFFFFFFFFFFFFFFFF
+
+/**
+ * @brief Describes the memory limits that can be set for the device
+ *
+ * This structure holds the necessary information that can be used to set the soft
+ * and hard memory limits of a device.
+ *
+ * The softLimit is the amount of memory that is guaranteed before allocations
+ * may fail due to memory pressure.
+ *
+ * The hardLimit is the maximum amount of memory that can be allocated.
+ *
+ * This should be cross-referenced with \ref nvmlDeviceGetMemoryInfo_v2 while in
+ * that cgroup to see how much memory is actually available to allocate for the device.
+ *
+ * To clear the limits, set softLimit to 0, and hardLimit to \ref NVML_DEVICE_MEMORY_LIMIT_MAX.
+ * Removing the cgroup will also clear any limits.
+ */
+typedef struct
+{
+    const char* nameSpace;         //!<[in] Full path to sysfs cgroup file name
+    unsigned long long softLimit;  //!<[in] Soft memory limit in Bytes.
+    unsigned long long hardLimit;  //!<[in] Hard memory limit in Bytes.
+} nvmlSetMemoryLimits_v1_t;
+
+/**
+ * @brief Describes the current memory limits that are set for the device
+ *
+ * This structure holds the necessary information that can be used to get the
+ * current soft and hard memory limits of a device.
+ *
+ * The softLimit is the amount of memory that is guaranteed before allocations
+ * may fail due to memory pressure.
+ *
+ * The hardLimit is the maximum amount of memory that can be allocated.
+ *
+ * This should be cross-referenced with \ref nvmlDeviceGetMemoryInfo_v2 while in
+ * that cgroup to see how much memory is actually available to allocate for the device.
+ *
+ * No limit is set when softLimit is 0 and hardLimit is \ref NVML_DEVICE_MEMORY_LIMIT_MAX.
+ */
+typedef struct
+{
+    const char* nameSpace;           //!<[in]  Full path to sysfs cgroup file name
+    unsigned long long softLimit;    //!<[out] Currently set soft memory limit in Bytes.
+    unsigned long long hardLimit;    //!<[out] Currently set hard memory limit in Bytes.
+    unsigned long long currentUsed;  //!<[out] Currently used memory in Bytes.
+} nvmlGetMemoryLimits_v1_t;
 
 /**
  * BAR1 Memory allocation Information for a device
@@ -863,6 +916,165 @@ typedef nvmlPdi_v1_t nvmlPdi_t;
 
 #define nvmlPdi_v1 NVML_STRUCT_VERSION(Pdi, 1) //!< Version macro for \a nvmlPdi_v1_t
 
+#define NVML_PERF_METRICS_PWR_MODEL_DLPPM_1X_MAX_CORE_RAILS                                2  //!< Maximum number of core rails for DLPPM 1x power model
+#define NVML_PERF_METRICS_NNE_DESC_INFERENCE_LOOPS_MAX                                     8  //!< Maximum number of NNE descriptor inference loops
+#define NVML_PERF_METRICS_PWR_MODEL_METRICS_DLPPM_1X_OBESRVED_INTIAL_DRAMCLK_ESTIMATES_MAX 3  //!< Maximum number of initial DRAMCLK estimates for DLPPM 1x observed metrics
+#define NVML_PERF_METRICS_CONTROLLER_DLPPC_2X_PWR_POLICY_RELATIONSHIP_SET_LIMITS_MAX       4  //!< Maximum number of power policy relationship set limits for DLPPC 2x controller
+#define NVML_PERF_METRICS_CONTROLLER_STATUS_DLPPC_2X_DRAMCLK_NUM                           3  //!< Number of DRAMCLK frequencies tracked by DLPPC 2x controller status
+#define NVML_PERF_METRICS_CONTROLLER_SAMPLE_CONTROLLER_MAX_NUM                             4  //!< Maximum number of controllers that can be sampled
+#define NVML_PERF_METRICS_SAMPLE_COUNT                                                    13  //!< Total number of performance metrics samples that can be collected
+#define NVML_PERF_METRICS_PWR_MODEL_SCALE_LOOPS_MAX_PFPP_1X                               32  //!< Maximum number of power model scale loops for PFPP 1x
+#define NVML_PERF_METRICS_PWR_MODEL_SCALE_METRICS_INPUT_MAX                               16  //!< Maximum number of power model scale metrics inputs
+#define NVML_PERF_METRICS_CONTROLLER_TYPE_DLPPC_2X                                         0  //!< Controller type identifier for DLPPC 2x
+#define NVML_PERF_METRICS_CONTROLLER_TYPE_PFPP_1X                                          1  //!< Controller type identifier for PFPP 1x
+#define NVML_PERF_METRICS_PWR_MODEL_SCALE_METRICS_PFPP_1X_GPCCLK_IDX                       0  //!< Index for GPCCLK frequency in PFPP 1x scale metrics
+#define NVML_PERF_CF_PM_SENSOR_MAX_SIGNALS                                              1024  //!< Maximum number of BA PM sensor signals
+
+/**
+ * Power tuple containing power consumption in milliwatts.
+ */
+typedef struct
+{
+    unsigned int pwrmW;                                     //!< Power consumption in milliwatts
+} nvmlPmgrPwrTuple_t;
+
+/**
+ * Metrics for a single power rail, including frequency and utilization.
+ */
+typedef struct
+{
+    unsigned int freqkHz;                                   //!< Frequency in kilohertz
+    unsigned long long utilPct;                             //!< Utilization percentage (fixed-point)
+} nvmlRailMetrics_t;
+
+/**
+ * Metrics for all core rails in the system.
+ */
+typedef struct
+{
+    nvmlRailMetrics_t rails[NVML_PERF_METRICS_PWR_MODEL_DLPPM_1X_MAX_CORE_RAILS];  //!< Array of core rail metrics
+} nvmlCoreRailMetrics_t;
+
+/**
+ * Performance metrics for DLPPM 1x power model.
+ */
+typedef struct
+{
+    unsigned int perfms;                                    //!< Performance metric in milliseconds
+} nvmlPwrModelMetricsDlppm1xPerf_t;
+
+/**
+ * Complete power model metrics for DLPPM 1x, including rail metrics and TGP power.
+ */
+typedef struct
+{
+    unsigned char bValid;                                   //!< Validity flag: non-zero if metrics are valid
+    nvmlCoreRailMetrics_t coreRail;                         //!< Core rail metrics
+    nvmlRailMetrics_t fbRail;                               //!< Fb rail metrics
+    nvmlPmgrPwrTuple_t tgpPwrTuple;                         //!< Total Graphics Power (TGP) in milliwatts
+    nvmlPwrModelMetricsDlppm1xPerf_t perfMetrics;           //!< Performance metrics
+} nvmlPwrModelMetricsDlppm1x_t;
+
+/**
+ * DRAMCLK estimates containing multiple estimated metrics for different DRAMCLK frequencies.
+ */
+typedef struct
+{
+    nvmlPwrModelMetricsDlppm1x_t estimatedMetrics[NVML_PERF_METRICS_NNE_DESC_INFERENCE_LOOPS_MAX];  //!< Array of estimated metrics for each inference loop
+    unsigned char numEstimatedMetrics;                                                              //!< Number of valid entries in estimatedMetrics array
+} nvmlPwrModelMetricsDlppm1xDramclkEstimates_t;
+
+/**
+ * Observed metrics from the power model, including initial DRAMCLK estimates and current measurements.
+ */
+typedef struct
+{
+    nvmlPwrModelMetricsDlppm1xDramclkEstimates_t initialDramclkEst[NVML_PERF_METRICS_PWR_MODEL_METRICS_DLPPM_1X_OBESRVED_INTIAL_DRAMCLK_ESTIMATES_MAX];  //!< Initial DRAMCLK estimates for different scenarios
+    unsigned char bValid;                                                                                                                                //!< Validity flag: non-zero if observed metrics are valid
+    nvmlCoreRailMetrics_t coreRail;                                                                                                                      //!< Observed core rail metrics
+    nvmlRailMetrics_t fbRail;                                                                                                                            //!< Observed fb rail metrics
+    nvmlPmgrPwrTuple_t tgpPwrTuple;                                                                                                                      //!< Observed Total Graphics Power (TGP) in milliwatts
+    nvmlPwrModelMetricsDlppm1xPerf_t perfMetrics;                                                                                                        //!< Observed performance metrics
+} nvmlObservedMetrics_t;
+
+/**
+ * Performance metrics sample for DLPPC 2x controller.
+ */
+typedef struct
+{
+    nvmlObservedMetrics_t observedMetrics;                  //!< Observed metrics from the DLPPC 2x controller
+} nvmlPerfMetricsDlppc2xSample_t;
+
+/**
+ * Power model metrics sample for PFPP 1x, containing frequency inputs and estimated TGP.
+ */
+typedef struct
+{
+    unsigned int freqkHz[NVML_PERF_METRICS_PWR_MODEL_SCALE_METRICS_INPUT_MAX];  //!< Array of input frequencies in kilohertz for each domain
+    unsigned int estTgpPwrmW;                                                   //!< Estimated Total Graphics Power in milliwatts
+} nvmlPwrModelMetricsSamplePfpp1x_t;
+
+/**
+ * Operating point for PFPP 1x power model, defining a frequency-power pair.
+ */
+typedef struct
+{
+    unsigned int freqkHz;                                   //!< Operating frequency in kilohertz
+    unsigned int pwrmW;                                     //!< Power consumption at this frequency in milliwatts
+} nvmlPwrModelOperatingPointPfpp1x_t;
+
+/**
+ * Complete power model metrics for PFPP 1x, including estimated metrics and key operating points.
+ */
+typedef struct
+{
+    unsigned char numVfPoints;                                                                                //!< Number of valid vf points
+    nvmlPwrModelMetricsSamplePfpp1x_t estimatedMetrics[NVML_PERF_METRICS_PWR_MODEL_SCALE_LOOPS_MAX_PFPP_1X];  //!< Array of estimated metrics for different operating points
+    unsigned char bValid;                                                                                     //!< Validity flag: non-zero if metrics are valid
+    nvmlPwrModelOperatingPointPfpp1x_t maxPerfPerWattPoint;                                                   //!< Operating point with maximum performance per watt
+    nvmlPwrModelOperatingPointPfpp1x_t fmaxAtVmaxPoint;                                                       //!< Operating point at maximum frequency and voltage
+    unsigned int tgpHeadroommW;                                                                               //!< TGP headroom in milliwatts
+} nvmlPwrModelMetricsPfpp1x_t;
+
+/**
+ * Performance metrics sample for PFPP 1x controller.
+ */
+typedef struct
+{
+    nvmlPwrModelMetricsPfpp1x_t estimatedMetrics;           //!< Estimated metrics from the PFPP 1x controller
+} nvmlPerfMetricsPfpp1xSample_t;
+
+/**
+ * Performance metrics sample from a controller, which can be either DLPPC 2x or PFPP 1x.
+ */
+typedef struct
+{
+    unsigned int controllerType;                            //!< Controller type: NVML_PERF_METRICS_CONTROLLER_TYPE_DLPPC_2X or NVML_PERF_METRICS_CONTROLLER_TYPE_PFPP_1X
+    union{
+        nvmlPerfMetricsDlppc2xSample_t dlppc2x;             //!< DLPPC 2x controller sample data
+        nvmlPerfMetricsPfpp1xSample_t  pfpp1x;              //!< PFPP 1x controller sample data
+    } data;                                                 //!< Union containing controller-specific data
+} nvmlPerfMetricControllerSample_t;
+
+/**
+ * Single performance metrics sample containing data from one or more controllers.
+ */
+typedef struct
+{
+    unsigned char numControllerData;                                                                          //!< Number of valid controller samples in this sample
+    nvmlPerfMetricControllerSample_t controllerData[NVML_PERF_METRICS_CONTROLLER_SAMPLE_CONTROLLER_MAX_NUM];  //!< Array of controller samples
+} nvmlPerfMetricsSample_t;
+
+/**
+ * Collection of performance metrics samples (version 1).
+ * This structure contains multiple samples for performance monitoring and profiling.
+ */
+typedef struct
+{
+    unsigned int numSamples;                                          //!< Number of samples in the samples array
+    nvmlPerfMetricsSample_t samples[NVML_PERF_METRICS_SAMPLE_COUNT];  //!< Array of performance metrics samples
+} nvmlPerfMetricsSamples_v1_t;
+
 /**
  * BBX Time Data
  */
@@ -873,7 +1085,7 @@ typedef nvmlPdi_v1_t nvmlPdi_t;
 /** @} */
 
 /***************************************************************************************************/
-/** @defgroup nvmlDeviceEnumvs Device Enums
+/** @defgroup nvmlDeviceEnums Device Enums
  *  @{
  */
 /***************************************************************************************************/
@@ -927,8 +1139,11 @@ typedef enum nvmlBrandType_enum
     NVML_BRAND_NVIDIA               = 14,
     NVML_BRAND_GEFORCE_RTX          = 15,  // Unused
     NVML_BRAND_TITAN_RTX            = 16,  // Unused
+    NVML_BRAND_NVIDIA_DLA           = 17,  // Deprecated NVIDIA Deep Learning Accelerator
+    NVML_BRAND_NVIDIA_VGAMEDEV      = 18,  // NVIDIA RTX Virtual Game Dev
+    NVML_BRAND_NVIDIA_NPU           = 19,  // NVIDIA NPU
     // Keep this last
-    NVML_BRAND_COUNT                = 18,
+    NVML_BRAND_COUNT                = 20,
 } nvmlBrandType_t;
 
 /**
@@ -936,22 +1151,22 @@ typedef enum nvmlBrandType_enum
  */
 typedef enum nvmlTemperatureThresholds_enum
 {
-    NVML_TEMPERATURE_THRESHOLD_SHUTDOWN      = 0, // Temperature at which the GPU will
-                                                  // shut down for HW protection
-    NVML_TEMPERATURE_THRESHOLD_SLOWDOWN      = 1, // Temperature at which the GPU will
-                                                  // begin HW slowdown
-    NVML_TEMPERATURE_THRESHOLD_MEM_MAX       = 2, // Memory Temperature at which the GPU will
-                                                  // begin SW slowdown
-    NVML_TEMPERATURE_THRESHOLD_GPU_MAX       = 3, // GPU Temperature at which the GPU
-                                                  // can be throttled below base clock
-    NVML_TEMPERATURE_THRESHOLD_ACOUSTIC_MIN  = 4, // Minimum GPU Temperature that can be
-                                                  // set as acoustic threshold
-    NVML_TEMPERATURE_THRESHOLD_ACOUSTIC_CURR = 5, // Current temperature that is set as
-                                                  // acoustic threshold.
-    NVML_TEMPERATURE_THRESHOLD_ACOUSTIC_MAX  = 6, // Maximum GPU temperature that can be
-                                                  // set as acoustic threshold.
-    NVML_TEMPERATURE_THRESHOLD_GPS_CURR      = 7, // Current temperature that is set as
-                                                  // gps threshold.
+    NVML_TEMPERATURE_THRESHOLD_SHUTDOWN       = 0, //!< Temperature at which the GPU will
+                                                   //!< shut down for HW protection
+    NVML_TEMPERATURE_THRESHOLD_SLOWDOWN       = 1, //!< Temperature at which the GPU will
+                                                   //!< begin HW slowdown
+    NVML_TEMPERATURE_THRESHOLD_MEM_MAX        = 2, //!< Memory Temperature at which the GPU will
+                                                   //!< begin SW slowdown
+    NVML_TEMPERATURE_THRESHOLD_GPU_MAX        = 3, //!< GPU Temperature at which the GPU
+                                                   //!< can be throttled below base clock
+    NVML_TEMPERATURE_THRESHOLD_ACOUSTIC_MIN   = 4, //!< Minimum GPU Temperature that can be
+                                                   //!< set as acoustic threshold
+    NVML_TEMPERATURE_THRESHOLD_ACOUSTIC_CURR  = 5, //!< Current temperature that is set as
+                                                   //!< acoustic threshold.
+    NVML_TEMPERATURE_THRESHOLD_ACOUSTIC_MAX   = 6, //!< Maximum GPU temperature that can be
+                                                   //!< set as acoustic threshold.
+    NVML_TEMPERATURE_THRESHOLD_GPS_CURR       = 7, //!< Current temperature that is set as
+                                                   //!< gps threshold.
     // Keep this last
     NVML_TEMPERATURE_THRESHOLD_COUNT
 } nvmlTemperatureThresholds_t;
@@ -962,6 +1177,8 @@ typedef enum nvmlTemperatureThresholds_enum
 typedef enum nvmlTemperatureSensors_enum
 {
     NVML_TEMPERATURE_GPU      = 0,    //!< Temperature sensor for the GPU die
+
+    NVML_TEMPERATURE_GPU_MAX  = 1,    //!< Temperature from the hottest part of the GPU die
 
     // Keep this last
     NVML_TEMPERATURE_COUNT
@@ -1552,7 +1769,12 @@ typedef struct
 
 #define NVML_DEVICE_ARCH_BLACKWELL 10 //!< Devices based on the NVIDIA Blackwell architecture
 
+#define NVML_DEVICE_ARCH_DLA       11 //!< Devices based on the NVIDIA DLA architecture.
+#define NVML_DEVICE_ARCH_DLA2      12 //!< Devices based on the NVIDIA DLA2 architecture.
+
 #define NVML_DEVICE_ARCH_RUBIN     13 //!< Devices based on the NVIDIA Rubin architecture.
+
+#define NVML_DEVICE_ARCH_NPU3      15 //!< Devices based on the NVIDIA NPU3 architecture.
 
 #define NVML_DEVICE_ARCH_UNKNOWN   0xffffffff //!< Anything else, presumably something newer
 
@@ -1667,6 +1889,15 @@ typedef struct
 
 #define nvmlPowerValue_v2 NVML_STRUCT_VERSION(PowerValue, 2) //!< Version macro for \a nvmlPowerValue_v2_t
 
+typedef struct
+{
+    nvmlEnableState_t inBandEnableRequest;    //!< [out] In-band enable requested (NVML_FEATURE_ENABLED) or not requested (NVML_FEATURE_DISABLED)
+    nvmlEnableState_t featureAllowedByAdmin;  //!< [out] Feature allowed by out-of-band/admin (NVML_FEATURE_ENABLED) or not allowed (NVML_FEATURE_DISABLED)
+    nvmlEnableState_t adminOverrideEnabled;   //!< [out] Out-of-band/admin override active (NVML_FEATURE_ENABLED) or inactive (NVML_FEATURE_DISABLED)
+    nvmlEnableState_t enablementStatus;       //!< [out] Enablement after arbitration: active (NVML_FEATURE_ENABLED) or inactive (NVML_FEATURE_DISABLED)
+    unsigned int adjustedLimitMw;             //!< [out] Adjusted TGP limit in milliwatts (valid only when feature is enabled)
+} nvmlAdaptiveTgpModeInfo_v1_t;
+
 /** @} */
 
 /***************************************************************************************************/
@@ -1725,7 +1956,8 @@ typedef enum {
     NVML_GRID_LICENSE_FEATURE_CODE_NVIDIA_RTX   = 2,                                         //!< Nvidia RTX
     NVML_GRID_LICENSE_FEATURE_CODE_VWORKSTATION = NVML_GRID_LICENSE_FEATURE_CODE_NVIDIA_RTX, //!< Deprecated, do not use.
     NVML_GRID_LICENSE_FEATURE_CODE_GAMING       = 3,                                         //!< Gaming
-    NVML_GRID_LICENSE_FEATURE_CODE_COMPUTE      = 4                                          //!< Compute
+    NVML_GRID_LICENSE_FEATURE_CODE_COMPUTE      = 4,                                         //!< Compute
+    NVML_GRID_LICENSE_FEATURE_CODE_VGAMEDEV     = 5                                          //!< vGameDev
 } nvmlGridLicenseFeatureCode_t;
 
 /**
@@ -2198,6 +2430,8 @@ typedef enum nvmlDeviceGpuRecoveryAction_s  {
     NVML_GPU_RECOVERY_ACTION_DRAIN_P2P = 3,           //!< Drain P2P
     NVML_GPU_RECOVERY_ACTION_DRAIN_AND_RESET = 4,     //!< Drain P2P and Reset Gpu
     NVML_GPU_RECOVERY_ACTION_RECOVER_IMEX_DOMAIN = 5, //!< Recover IMEX Domain.
+    NVML_GPU_RECOVERY_ACTION_BUS_RESET = 6,           //!< Reset the GPU's PCIe bus
+    NVML_GPU_RECOVERY_ACTION_SYSTEM_REBOOT = 7,       //!< Reboot the system
 } nvmlDeviceGpuRecoveryAction_t;
 
 /**
@@ -2673,7 +2907,7 @@ typedef struct
  * Link ID needs to be specified in the scopeId field in nvmlFieldValue_t.
  */
 #define NVML_FI_DEV_NVLINK_GET_SPEED                  164 //!< NVLink Speed in MBps
-#define NVML_FI_DEV_NVLINK_GET_STATE                  165 //!< NVLink State - Active,Inactive
+#define NVML_FI_DEV_NVLINK_GET_STATE                  165 //!< NVLink State - one of NVML_NVLINK_STATE_* values
 #define NVML_FI_DEV_NVLINK_GET_VERSION                166 //!< NVLink Version
 
 #define NVML_FI_DEV_NVLINK_GET_POWER_STATE            167 //!< NVLink Power state. 0=HIGH_SPEED 1=LOW_SPEED
@@ -2793,7 +3027,7 @@ typedef struct
 #define NVML_FI_DEV_DRAIN_AND_RESET_STATUS                       227 //!< Deprecated, do not use (use NVML_FI_DEV_GET_GPU_RECOVERY_ACTION instead)
 #define NVML_FI_DEV_PCIE_OUTBOUND_ATOMICS_MASK                   228
 #define NVML_FI_DEV_PCIE_INBOUND_ATOMICS_MASK                    229
-#define NVML_FI_DEV_GET_GPU_RECOVERY_ACTION                      230 //!< GPU Recovery action - None/Reset/Reboot/Drain P2P/Drain and Reset
+#define NVML_FI_DEV_GET_GPU_RECOVERY_ACTION                      230 //!< GPU Recovery action. See \ref nvmlDeviceGpuRecoveryAction_t
 #define NVML_FI_DEV_C2C_LINK_ERROR_INTR                          231 //!< C2C Link CRC Error Counter
 #define NVML_FI_DEV_C2C_LINK_ERROR_REPLAY                        232 //!< C2C Link Replay Error Counter
 #define NVML_FI_DEV_C2C_LINK_ERROR_REPLAY_B2B                    233 //!< C2C Link Back to Back Replay Error Counter
@@ -2952,9 +3186,17 @@ typedef struct
 #define NVML_FI_DEV_MCLK_SWITCH_TYPE                             298 //!< See NVML_MCLK_SWITCH_TYPE_<XYZ> for all enumerations
 #define NVML_FI_DEV_MCLK_MIN_SWITCH_INTERVAL_MILLISECONDS        299 //!< minimum required elapsed time between runtime mclk switches, 0 = no rate limit
 #define NVML_FI_PWR_SMOOTHING_SOC_POWER_SMOOTHING_ENABLED        300 //!< State-Of-Charge Power Smoothing Enabled (0/DISABLED or 1/ENABLED)
+
 #define NVML_FI_DEV_REMAPPED_ROWS_COR_INACTIVE                  301 //!< Number of inactive row remappings due to correctable errors
 #define NVML_FI_DEV_REMAPPED_ROWS_UNC_INACTIVE                  302 //!< Number of inactive row remappings due to uncorrectable errors
-#define NVML_FI_MAX                                             303 //!< One greater than the largest field ID defined above
+
+/* Bank Remapper */
+#define NVML_FI_DEV_ACTIVE_BANK_REMAPPINGS          303 //!< Number of active bank remappings
+#define NVML_FI_DEV_INACTIVE_BANK_REMAPPINGS        304 //!< Number of inactive bank remappings
+#define NVML_FI_DEV_BANK_REMAPPER_HISTOGRAM_MAX     305 //!< Number of groups with full bank remap availability.
+#define NVML_FI_DEV_BANK_REMAPPER_HISTOGRAM_NONE    306 //!< Number of groups with no spare bankremap availability.
+#define NVML_FI_DEV_PENDING_BANK_REMAPPING          307 //!< If any banks are pending remapping. 1=yes 0=no
+#define NVML_FI_MAX                                 308 //!< One greater than the largest field ID defined above
 
 /**
  * NVML_FI_DEV_MCLK_SWITCH_TYPE enumerations
@@ -3237,6 +3479,119 @@ typedef struct nvmlEventData_st
 } nvmlEventData_t;
 
 /**
+ * @brief Log-level values used by GPU Operational Events.
+ *
+ * These values are used both for event reporting in \ref nvmlEventSetWait_v3_t and for subscription
+ * filtering in \ref nvmlGpuOperationalEventConfig_v1_t. Higher numeric values represent more
+ * selective log levels. \c NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_ALL disables log-level filtering
+ * when used as a subscription threshold. Event data may contain newer log-level values that are
+ * not named in this header; clients should handle unrecognized numeric values.
+ */
+typedef enum
+{
+    NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_ALL       = 0,  //!< Matches all GPU Operational Event log levels.
+    NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_TELEMETRY = 10, //!< High-volume telemetry events.
+    NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_DIAG      = 20, //!< Diagnostic events.
+    NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_NOTICE    = 30, //!< Notable operational events.
+    NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_WARNING   = 40, //!< Warning events.
+    NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_ERROR     = 50, //!< Error events.
+} nvmlGpuOperationalEventLogLevel_t;
+
+/**
+ * @brief Severity values used by Operational Events.
+ *
+ * These values are used both for event reporting in \ref nvmlEventSetWait_v3_t and for subscription
+ * filtering in \ref nvmlGpuOperationalEventConfig_v1_t. Higher numeric values represent more
+ * selective severities. \c NVML_OPERATIONAL_EVENT_SEVERITY_ALL disables severity filtering when
+ * used as a subscription threshold. Event data may contain newer severity values that are not
+ * named in this header; clients should handle unrecognized numeric values.
+ */
+typedef enum
+{
+    NVML_OPERATIONAL_EVENT_SEVERITY_ALL           = 0,  //!< Matches all Operational Event severities.
+    NVML_OPERATIONAL_EVENT_SEVERITY_INFORMATIONAL = 10, //!< Informational event.
+    NVML_OPERATIONAL_EVENT_SEVERITY_CORRECTED     = 20, //!< Corrected error event.
+    NVML_OPERATIONAL_EVENT_SEVERITY_RECOVERABLE   = 30, //!< Recoverable error event.
+    NVML_OPERATIONAL_EVENT_SEVERITY_FATAL         = 40, //!< Fatal error event.
+} nvmlOperationalEventSeverity_t;
+
+/**
+ * @brief Event data formats returned by \ref nvmlEventSetWait_v3.
+ */
+typedef enum
+{
+    NVML_EVENT_DATA_TYPE_NVML_EVENT            = 0, //!< NVML event-bit data. \c eventType contains an NVML event bit.
+    NVML_EVENT_DATA_TYPE_GPU_OPERATIONAL_EVENT = 1, //!< Structured GPU Operational Event data.
+} nvmlEventDataType_t;
+
+#define NVML_GPU_INSTANCE_ID_ANY      0xFFFFFFFFU //!< Sentinel value used when no MIG GPU instance ID applies.
+#define NVML_COMPUTE_INSTANCE_ID_ANY  0xFFFFFFFFU //!< Sentinel value used when no MIG compute instance ID applies.
+
+#define NVML_OPERATIONAL_EVENT_ATTR_UNCONTAINED        (1u << 0) //!< Event reports an uncontained condition.
+#define NVML_OPERATIONAL_EVENT_ATTR_LATENT             (1u << 1) //!< Event reports a latent condition.
+#define NVML_OPERATIONAL_EVENT_ATTR_PROPAGATED         (1u << 2) //!< Event was propagated from another source.
+#define NVML_OPERATIONAL_EVENT_ATTR_COMPONENT_RESET    (1u << 3) //!< Event involved a component reset.
+#define NVML_OPERATIONAL_EVENT_ATTR_THRESHOLD_EXCEEDED (1u << 4) //!< Event reports an exceeded threshold.
+#define NVML_OPERATIONAL_EVENT_ATTR_PRIMARY            (1u << 5) //!< Event is the primary event in its group.
+#define NVML_OPERATIONAL_EVENT_ATTR_OVERFLOW           (1u << 6) //!< One or more events or associated payloads were dropped before this event was returned.
+
+#define NVML_OPERATIONAL_EVENT_GROUP_ATTR_RECOVERED    (1u << 0) //!< Event group reports a recovered condition.
+#define NVML_OPERATIONAL_EVENT_GROUP_ATTR_PREVERR      (1u << 1) //!< Event group reports a previous error condition.
+#define NVML_OPERATIONAL_EVENT_GROUP_ATTR_SIMULATED    (1u << 2) //!< Event group was generated by simulation or testing.
+
+/**
+ * @brief NVML-defined GPU Operational Event context classifications.
+ *
+ * These values describe the NVML public interpretation of a context payload. The
+ * original source-defined context type is returned separately in
+ * \ref nvmlEventSetGetContextInfo_v1_t::sourceEventContextType.
+ */
+typedef enum
+{
+    NVML_GPU_OPERATIONAL_EVENT_CONTEXT_TYPE_UNKNOWN    = 0, //!< No NVML public interpretation is defined for this context payload.
+    NVML_GPU_OPERATIONAL_EVENT_CONTEXT_TYPE_LEGACY_XID = 1, //!< Context payload can be decoded with \ref nvmlEventSetGetGpuOperationalEventContextLegacyXid_v1.
+} nvmlGpuOperationalEventContextType_t;
+
+/**
+ * @brief Parameters for retrieving the number of context records associated with the most recent event.
+ */
+typedef struct
+{
+    unsigned int count; //!< [out] Number of context records associated with the most recent event.
+} nvmlEventSetGetContextCount_v1_t;
+
+/**
+ * @brief Parameters for retrieving context metadata associated with the most recent event.
+ */
+typedef struct
+{
+    unsigned int   index;                                //!< [in] Zero-based context index.
+    unsigned int   nvmlGpuOperationalEventContextType;  //!< [out] \ref nvmlGpuOperationalEventContextType_t value describing the NVML public interpretation of the context payload.
+    unsigned int   sourceEventContextType;              //!< [out] Source-defined context payload type identifier carried by the event.
+    unsigned int   dataSize;                            //!< [out] Context payload size in bytes, excluding alignment padding.
+    unsigned short dataFormatVersion;                   //!< [out] Payload format version for \c sourceEventContextType.
+} nvmlEventSetGetContextInfo_v1_t;
+
+/**
+ * @brief Parameters for retrieving raw context data associated with the most recent event.
+ */
+typedef struct
+{
+    void         *data;     //!< [in] Optional caller-owned buffer that receives the raw context payload.
+    unsigned int index;     //!< [in] Zero-based context index.
+    unsigned int dataSize;  //!< [in,out] Size of \c data on input; actual or required size on output.
+} nvmlEventSetGetContextData_v1_t;
+
+/**
+ * @brief Parameters for retrieving decoded GPU legacy-Xid context data.
+ */
+typedef struct
+{
+    unsigned int index;    //!< [in] Zero-based context index.
+    unsigned int xidCode;  //!< [out] Legacy Xid code carried in a GPU Operational Event context.
+} nvmlEventSetGetGpuOperationalEventContextLegacyXid_v1_t;
+
+/**
  * System Event Set
  */
 typedef struct nvmlSystemEventSet_st* nvmlSystemEventSet_t;
@@ -3403,6 +3758,20 @@ typedef nvmlSystemEventSetWaitRequest_v1_t nvmlSystemEventSetWaitRequest_t;
  */
 #define nvmlClocksEventReasonDisplayClockSetting       0x0000000000000100LL //!< Display clock setting limited.
 
+/** Board limit
+ *
+ * The board limit (operating) policy is currently limiting the GPU clocks.
+ *
+ */
+#define nvmlClocksEventReasonBoardLimit                0x0000000000000200LL //!< Board limit policy is limiting clocks.
+
+/** Reliability
+ *
+ * The reliability policy is currently limiting the GPU clocks.
+ *
+ */
+#define nvmlClocksEventReasonReliability              0x0000000000000400LL //!< Reliability policy is limiting clocks.
+
 /** Bit mask representing no clocks throttling
  *
  * Clocks are as high as possible.
@@ -3416,12 +3785,14 @@ typedef nvmlSystemEventSetWaitRequest_v1_t nvmlSystemEventSetWaitRequest_t;
       | nvmlClocksEventReasonGpuIdle                           \
       | nvmlClocksEventReasonApplicationsClocksSetting         \
       | nvmlClocksEventReasonSwPowerCap                        \
-      | nvmlClocksThrottleReasonHwSlowdown                        \
+      | nvmlClocksThrottleReasonHwSlowdown                     \
       | nvmlClocksEventReasonSyncBoost                         \
       | nvmlClocksEventReasonSwThermalSlowdown                 \
-      | nvmlClocksThrottleReasonHwThermalSlowdown                 \
-      | nvmlClocksThrottleReasonHwPowerBrakeSlowdown              \
+      | nvmlClocksThrottleReasonHwThermalSlowdown              \
+      | nvmlClocksThrottleReasonHwPowerBrakeSlowdown           \
       | nvmlClocksEventReasonDisplayClockSetting               \
+      | nvmlClocksEventReasonBoardLimit                        \
+      | nvmlClocksEventReasonReliability                       \
 ) //!< Bitmask of all clock event reasons.
 
 /**
@@ -3885,6 +4256,16 @@ typedef struct
 #define NVML_GPU_FABRIC_HEALTH_MASK_WIDTH_PARTITION_ASSIGNED 0x3       //!< Fabric Health Mask Width for Partition Assigned
 
 /**
+ * Global Fabric Manager State
+ */
+#define NVML_GPU_FABRIC_HEALTH_MASK_GFM_STATE_NOT_SUPPORTED  0 //!< Fabric Health Mask: Global Fabric Manager State not supported
+#define NVML_GPU_FABRIC_HEALTH_MASK_GFM_STATE_CONNECTED      1 //!< Fabric Health Mask: Global Fabric Manager State is Connected
+#define NVML_GPU_FABRIC_HEALTH_MASK_GFM_STATE_DISCONNECTED   2 //!< Fabric Health Mask: Global Fabric Manager State is Disconnected
+
+#define NVML_GPU_FABRIC_HEALTH_MASK_SHIFT_GFM_STATE  14        //!< Fabric Health Mask Bit Shift for Global Fabric Manager State
+#define NVML_GPU_FABRIC_HEALTH_MASK_WIDTH_GFM_STATE  0x3       //!< Fabric Health Mask Width for Global Fabric Manager State
+
+/**
  * Fabric Health
  */
 #define NVML_GPU_FABRIC_HEALTH_SUMMARY_NOT_SUPPORTED 0    //!< Fabric Health Summary: Not supported
@@ -3937,11 +4318,14 @@ typedef struct
 #define nvmlGpuFabricInfo_v2 NVML_STRUCT_VERSION(GpuFabricInfo, 2) //!< Version macro for \a nvmlGpuFabricInfo_v2_t
 
 /**
-* GPU Fabric information (v3).
-*/
+ * GPU Fabric information (v3).
+ *
+ * @deprecated  nvmlGpuFabricInfo_v3_t is deprecated and will be removed in a future release.
+ *              Use nvmlGpuFabricInfo_v4_t instead.
+ */
 typedef struct
 {
-    unsigned int         version;                               //!< Structure version identifier (set to nvmlGpuFabricInfo_v2)
+    unsigned int         version;                               //!< Structure version identifier (set to nvmlGpuFabricInfo_v3)
     unsigned char        clusterUuid[NVML_GPU_FABRIC_UUID_LEN]; //!< Uuid of the cluster to which this GPU belongs
     nvmlReturn_t         status;                                //!< Probe Error status, if any. Must be checked only if Probe state returns "complete".
     unsigned int         cliqueId;                              //!< ID of the fabric clique to which this GPU belongs
@@ -3957,81 +4341,134 @@ typedef nvmlGpuFabricInfo_v3_t nvmlGpuFabricInfoV_t;
 */
 #define nvmlGpuFabricInfo_v3 NVML_STRUCT_VERSION(GpuFabricInfo, 3) //!< Version macro for \a nvmlGpuFabricInfo_v3_t
 
-/** @} */
-
-/***************************************************************************************************/
-/** @defgroup nvmlInitializationAndCleanup Initialization and Cleanup
- * This chapter describes the methods that handle NVML initialization and cleanup.
- * It is the user's responsibility to call \ref nvmlInit_v2() before calling any other methods, and
- * nvmlShutdown() once NVML is no longer being used.
- *  @{
+/**
+ * Maximum number of fabric clique entries.
  */
-/***************************************************************************************************/
+#define NVML_GPU_FABRIC_CLIQUE_MAX       64
 
-#define NVML_INIT_FLAG_NO_GPUS      (1 << 0)   //!< Don't fail nvmlInit() when no GPUs are found
-#define NVML_INIT_FLAG_NO_ATTACH    (1 << 1)   //!< Don't attach GPUs
-#define NVML_INIT_FLAG_FORCE_INIT   (1 << 2)   //!< Force GPU initialization when a previous nvmlInit was called with NO_GPUS and NO_ATTACH flags
+#define NVML_GPU_FABRIC_CLIQUE_TYPE_UNICAST_POINTER                         0 //!< Unicast pointer-based access
+#define NVML_GPU_FABRIC_CLIQUE_TYPE_MULTICAST_POINTER                       1 //!< Multicast pointer-based access
+#define NVML_GPU_FABRIC_CLIQUE_TYPE_UNICAST_LOGICAL_ENDPOINT                2 //!< Unicast logical-endpoint-based access
+#define NVML_GPU_FABRIC_CLIQUE_TYPE_MULTICAST_LOGICAL_ENDPOINT              3 //!< Multicast logical-endpoint-based access
 
 /**
- * Initialize NVML, but don't initialize any GPUs yet.
+ * Fabric clique entry. Each entry represents a single (type, id) pair
+ * describing a clique assignment for a given fabric operation type.
+ */
+typedef struct
+{
+    unsigned char type;  //!< Clique type. See NVML_GPU_FABRIC_CLIQUE_TYPE_*
+    unsigned int  id;    //!< Clique ID assigned by the Fabric Manager
+} nvmlGpuFabricClique_v1_t;
+
+/**
+ * GPU Fabric information (v4).
  *
- * \note nvmlInit_v3 introduces a "flags" argument, that allows passing boolean values
- *       modifying the behaviour of nvmlInit().
- * \note In NVML 5.319 new nvmlInit_v2 has replaced nvmlInit"_v1" (default in NVML 4.304 and older) that
- *       did initialize all GPU devices in the system.
+ * Extends v3 by replacing the single \a cliqueId field with a flat array
+ * of (type, id) clique entries. The legacy v3 \a cliqueId maps to the
+ * \a id of the first \ref NVML_GPU_FABRIC_CLIQUE_TYPE_UNICAST_POINTER entry.
+ */
+typedef struct
+{
+    unsigned char            clusterUuid[NVML_GPU_FABRIC_UUID_LEN]; //!< Uuid of the cluster to which this GPU belongs
+    nvmlReturn_t             status;                               //!< Probe Error status, if any. Must be checked only if state returns "complete".
+    nvmlGpuFabricClique_v1_t cliques[NVML_GPU_FABRIC_CLIQUE_MAX];  //!< Clique entries, sorted by ascending type then ascending id
+    unsigned int             numCliques;                           //!< Number of valid entries in \a cliques[]
+    nvmlGpuFabricState_t     state;                                //!< Current Probe State. See NVML_GPU_FABRIC_STATE_*
+    unsigned int             healthMask;                           //!< GPU Fabric health Status Mask. See NVML_GPU_FABRIC_HEALTH_MASK_*
+    unsigned char            healthSummary;                        //!< GPU Fabric health summary. See NVML_GPU_FABRIC_HEALTH_SUMMARY_*
+} nvmlGpuFabricInfo_v4_t;
+
+/** @} */
+
+/**
+ * @defgroup nvmlInitializationAndCleanup Initialization and Cleanup
+ * @brief NVML Methods that handle the NVML Library initialization and cleanup.
  *
- * This allows NVML to communicate with a GPU
- * when other GPUs in the system are unstable or in a bad state.  When using this API, GPUs are
- * discovered and initialized in nvmlDeviceGetHandleBy* functions instead.
+ * This chapter describes the methods that handle NVML initialization and cleanup.
+ * It is the user's responsibility to call \ref nvmlInit_v2() before calling any
+ * other methods, and \ref nvmlShutdown() once NVML is no longer being used.
+ * @{
+ */
+
+#define NVML_INIT_FLAG_NO_GPUS      (1 << 0)   //!< Initialize the NVML Library even when no devices are found.
+#define NVML_INIT_FLAG_NO_ATTACH    (1 << 1)   //!< Initialize the NVML Library without attaching any discovered devices.
+#define NVML_INIT_FLAG_FORCE_INIT   (1 << 2)   //!< Force device initialization even when a previous nvmlInit was called with the NO_GPUS and NO_ATTACH flags.
+
+/**
+ * @brief Initialize the NVML Library lazily, without allocating any device state.
  *
- * \note To contrast nvmlInit_v2 with nvmlInit"_v1", NVML 4.304 nvmlInit"_v1" will fail when any detected GPU is in
- *       a bad or unstable state.
+ * This will initialize the NVML Library state without enumerating any discovered
+ * devices. This will allow NVML to communicate with a device, even if other devices
+ * are in an unstable or bad state. Enumeration of a device can be done by obtaining
+ * the device handle via the nvmlDeviceGetHandleBy* class of APIs.
+ *
+ * This method needs to be called once before any usage of NVML Library APIs.
  *
  * For all products.
  *
- * This method, should be called once before invoking any other methods in the library.
- * A reference count of the number of initializations is maintained.  Shutdown only occurs
- * when the reference count reaches zero.
- *
  * @return
- *         - \ref NVML_SUCCESS                   if NVML has been properly initialized
- *         - \ref NVML_ERROR_DRIVER_NOT_LOADED   if NVIDIA driver is not running
- *         - \ref NVML_ERROR_NO_PERMISSION       if NVML does not have permission to talk to the driver
- *         - \ref NVML_ERROR_UNKNOWN             on any unexpected error
+ * - \ref NVML_SUCCESS                   if the NVML Library was properly initialized.
+ * - \ref NVML_ERROR_DRIVER_NOT_LOADED   if the NVIDIA driver is not running.
+ * - \ref NVML_ERROR_NO_PERMISSION       if the NVML Library does not have permission to talk to the driver.
+ * - \ref NVML_ERROR_UNKNOWN             if there is an unexpected error.
+ *
+ * @note  A reference count of the number of initializations is maintained, and
+ *        a corresponding call to \ref nvmlShutdown() needs to be issued once usage
+ *        of the NVML Library is complete. Shutdown will only occur after the
+ *        reference count reaches zero.
+ *
+ * @see nvmlShutdown()
  */
 nvmlReturn_t DECLDIR nvmlInit_v2(void);
 
 /**
- * nvmlInitWithFlags is a variant of nvmlInit(), that allows passing a set of boolean values
- *       modifying the behaviour of nvmlInit().
- *       Other than the "flags" parameter it is completely similar to \ref nvmlInit_v2.
+ * @brief Initialize the NVML Library lazily, without allocating any device state, with additional init flags.
+ *
+ * A variant of \ref nvmlInit_v2(), this will initialize the NVML Library state without
+ * enumerating any discovered devices. An option to pass in additional flags
+ * is provided to modify the behavior of NVML Library init. The usage of these
+ * flags can be obtained from NVML_INIT_FLAG_*. These flags can be combined together.
+ *
+ * Other than the "flags" parameter, this method is completely identical to \ref nvmlInit_v2().
  *
  * For all products.
  *
- * @param flags                                 behaviour modifier flags
+ * @param[in]  flags                     NVML_INIT_FLAG_* flags that can modify NVML Init behavior.
  *
  * @return
- *         - \ref NVML_SUCCESS                   if NVML has been properly initialized
- *         - \ref NVML_ERROR_DRIVER_NOT_LOADED   if NVIDIA driver is not running
- *         - \ref NVML_ERROR_NO_PERMISSION       if NVML does not have permission to talk to the driver
- *         - \ref NVML_ERROR_UNKNOWN             on any unexpected error
+ * - \ref NVML_SUCCESS                   if the NVML Library was properly initialized.
+ * - \ref NVML_ERROR_DRIVER_NOT_LOADED   if the NVIDIA driver is not running.
+ * - \ref NVML_ERROR_NO_PERMISSION       if the NVML Library does not have permission to talk to the driver.
+ * - \ref NVML_ERROR_UNKNOWN             if there is an unexpected error.
+ *
+ * @note  A reference count of the number of initializations is maintained, and
+ *        a corresponding call to \ref nvmlShutdown() needs to be issued once usage
+ *        of the NVML Library is complete. Shutdown will only occur after the
+ *        reference count reaches zero.
+ *
+ * @see nvmlShutdown()
  */
 nvmlReturn_t DECLDIR nvmlInitWithFlags(unsigned int flags);
 
 /**
- * Shut down NVML by releasing all GPU resources previously allocated with \ref nvmlInit_v2().
+ * @brief Shut down and cleanup NVML Library state.
+ *
+ * This will shut down and cleanup NVML Library state by releasing all device and
+ * library resources previously allocated with \ref nvmlInit_v2() or \ref nvmlInitWithFlags().
+ * This should be called after all NVML work is done, and once for each call to
+ * \ref nvmlInit_v2() or \ref nvmlInitWithFlags().
+ *
+ * Complete shutdown will only occur when the reference count of all prior NVML
+ * initializations reaches zero. No error will be reported if this is called
+ * more times than \ref nvmlInit_v2() or \ref nvmlInitWithFlags().
  *
  * For all products.
  *
- * This method should be called after NVML work is done, once for each call to \ref nvmlInit_v2()
- * A reference count of the number of initializations is maintained.  Shutdown only occurs
- * when the reference count reaches zero.  For backwards compatibility, no error is reported if
- * nvmlShutdown() is called more times than nvmlInit().
- *
  * @return
- *         - \ref NVML_SUCCESS                 if NVML has been properly shut down
- *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
- *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ * - \ref NVML_SUCCESS                 if the NVML Library was properly shut down.
+ * - \ref NVML_ERROR_UNINITIALIZED     if the NVML Library was not previously initialized.
+ * - \ref NVML_ERROR_UNKNOWN           if there is an unexpected error.
  */
 nvmlReturn_t DECLDIR nvmlShutdown(void);
 
@@ -4115,6 +4552,65 @@ const DECLDIR char* nvmlErrorString(nvmlReturn_t result);
 #define NVML_DEVICE_VBIOS_VERSION_BUFFER_SIZE         32
 
 /** @} */
+
+/**
+ * @brief Configuration for registering structured GPU Operational Events with
+ * \ref nvmlEventSetRegisterGpuOperationalEvents_v1.
+ *
+ * Initialize the structure to zero and then set \c uuid to select the target GPU. Default values
+ * register new device-wide events with log-level and severity filters disabled.
+ */
+typedef struct nvmlGpuOperationalEventConfig_v1_st
+{
+    char                                uuid[NVML_DEVICE_UUID_V2_BUFFER_SIZE]; //!< [in] Target GPU UUID string. Must be a NULL-terminated "GPU-..." UUID.
+    unsigned int                        minLogLevel;                           //!< [in] \ref nvmlGpuOperationalEventLogLevel_t value for the minimum GPU Operational Event log level. \c NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_ALL means no filter.
+    unsigned int                        minSeverity;                           //!< [in] \ref nvmlOperationalEventSeverity_t value for the minimum Operational Event severity threshold. \c NVML_OPERATIONAL_EVENT_SEVERITY_ALL means no filter.
+} nvmlGpuOperationalEventConfig_v1_t;
+
+/**
+ * @brief Parameters for waiting on an event set with \ref nvmlEventSetWait_v3.
+ *
+ * This structure supplies the wait timeout and returns either NVML event-bit or structured event data.
+ * For NVML event-bit data,
+ * \c dataType is \ref NVML_EVENT_DATA_TYPE_NVML_EVENT, \c eventType contains the NVML event bit,
+ * fields such as \c eventData, \c gpuInstanceId, and \c computeInstanceId preserve existing
+ * semantics, and structured-only fields are set to 0 or empty values. For structured GPU Operational
+ * Events, \c dataType is \ref NVML_EVENT_DATA_TYPE_GPU_OPERATIONAL_EVENT, \c eventType is set to
+ * \ref nvmlEventTypeNone, and the structured metadata fields are populated.
+ *
+ * Clients that subscribe to both NVML event-bit and structured formats on the same event set should branch
+ * on \c dataType to determine which format was returned. During the transition period, the
+ * same underlying incident may generate both an NVML event-bit notification and a structured notification.
+ *
+ */
+typedef struct
+{
+    unsigned int        timeoutMs;                             //!< [in] Maximum amount of time to wait, in milliseconds.
+    unsigned int        dataType;                              //!< [out] \ref nvmlEventDataType_t value indicating which event-data format is populated.
+    char                uuid[NVML_DEVICE_UUID_V2_BUFFER_SIZE]; //!< [out] UUID for the GPU where the event occurred. Empty if unavailable.
+    char                sourceModule[16];                      //!< [out] Source module signature for structured events. Not guaranteed to be NULL-terminated. Empty for NVML event-bit events.
+    unsigned long long  eventType;                             //!< [out] NVML event bit for \ref NVML_EVENT_DATA_TYPE_NVML_EVENT events; \ref nvmlEventTypeNone for structured events.
+    unsigned long long  eventData;                             //!< [out] Xid code for \ref nvmlEventTypeXidCriticalError, or 0 when not applicable.
+    unsigned long long  groupCursor;                           //!< [out] Structured event group identifier. 0 for NVML event-bit events.
+    unsigned long long  instanceId;                            //!< [out] Structured event sequence identifier. 0 for NVML event-bit events.
+    unsigned long long  timestampUsec;                         //!< [out] Event timestamp in microseconds. 0 if unavailable.
+    unsigned long long  traceId;                               //!< [out] Structured event trace identifier. 0 for NVML event-bit events.
+    unsigned int        gpuInstanceId;                         //!< [out] MIG GPU instance ID for NVML event-bit data, or \c NVML_GPU_INSTANCE_ID_ANY when not applicable.
+    unsigned int        computeInstanceId;                     //!< [out] MIG compute instance ID for NVML event-bit data, or \c NVML_COMPUTE_INSTANCE_ID_ANY when not applicable.
+    unsigned int        severity;                              //!< [out] \ref nvmlOperationalEventSeverity_t value for structured events. May contain newer severity values not named in this header. \c NVML_OPERATIONAL_EVENT_SEVERITY_ALL for NVML event-bit events.
+    unsigned int        categoryId;                            //!< [out] Source-defined structured event category identifier. 0 for NVML event-bit events.
+    unsigned int        moduleEventCode;                       //!< [out] Source-module-defined event code. Interpret with \c sourceModule. 0 for NVML event-bit events.
+    unsigned int        scope;                                 //!< [out] Structured event scope identifier. 0 for NVML event-bit events.
+    unsigned int        originator;                            //!< [out] Structured event originator identifier. 0 for NVML event-bit events.
+    unsigned int        moduleInstance;                        //!< [out] Structured event module instance identifier. 0 for NVML event-bit events.
+    unsigned int        chipletId;                             //!< [out] Structured event chiplet identifier. 0 for NVML event-bit events.
+    unsigned int        logLevel;                              //!< [out] \ref nvmlGpuOperationalEventLogLevel_t value for structured GPU Operational Events. May contain newer log-level values not named in this header. \c NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_ALL for NVML event-bit events.
+    unsigned int        attributes;                            //!< [out] Bitmask of \c NVML_OPERATIONAL_EVENT_ATTR_* values for structured events. May contain newer bits not named in this header. 0 for NVML event-bit events. May include \c NVML_OPERATIONAL_EVENT_ATTR_OVERFLOW if events or associated payloads were dropped.
+    unsigned int        groupCperSize;                         //!< [out] Associated CPER record size in bytes. 0 when unavailable.
+    unsigned int        groupAttributes;                       //!< [out] Bitmask of \c NVML_OPERATIONAL_EVENT_GROUP_ATTR_* values for structured events. May contain newer bits not named in this header. 0 for NVML event-bit events.
+    unsigned char       groupSize;                             //!< [out] Total number of events in the structured event group. 0 for NVML event-bit events.
+    unsigned char       groupIndex;                            //!< [out] Zero-based index within the structured event group. 0 for NVML event-bit events.
+} nvmlEventSetWait_v3_t;
 
 /***************************************************************************************************/
 /** @defgroup nvmlCPER CPER (Common Platform Error Record)
@@ -6597,7 +7093,6 @@ nvmlReturn_t DECLDIR nvmlDeviceGetPowerMizerMode_v1(nvmlDevice_t device, nvmlDev
 
 nvmlReturn_t DECLDIR nvmlDeviceSetPowerMizerMode_v1(nvmlDevice_t device, nvmlDevicePowerMizerModes_v1_t *powerMizerMode);
 
-
 /**
  * Retrieves total energy consumption for this GPU in millijoules (mJ) since the driver was last reloaded
  *
@@ -6636,6 +7131,58 @@ nvmlReturn_t DECLDIR nvmlDeviceGetTotalEnergyConsumption(nvmlDevice_t device, un
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetEnforcedPowerLimit(nvmlDevice_t device, unsigned int *limit);
+
+/**
+ * Request to enable or disable Adaptive TGP Mode for a GPU.
+ *
+ * %RUBIN_OR_NEWER%
+ * Requires root/admin privileges.
+ *
+ * Adaptive TGP Mode assigns tailored power budgets to two binned GPU parts within the same
+ * module, reducing node-to-node and rack-to-rack performance variation.
+ * An out-of-band administrator policy may override the in-band request;
+ * use \ref nvmlDeviceGetAdaptiveTgpModeInfo_v1 to query the arbitrated state.
+ *
+ * @param device     The identifier of the target device
+ * @param mode       NVML_FEATURE_ENABLED or NVML_FEATURE_DISABLED
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if the request was accepted
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a mode is not a valid \ref nvmlEnableState_t
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support Adaptive TGP Mode
+ *         - \ref NVML_ERROR_NO_PERMISSION     if the caller lacks root/admin privileges
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlDeviceGetAdaptiveTgpModeInfo_v1()
+ */
+nvmlReturn_t DECLDIR nvmlDeviceSetAdaptiveTgpMode_v1(nvmlDevice_t device, nvmlEnableState_t mode);
+
+/**
+ * Retrieves Adaptive TGP Mode state and telemetry for a GPU.
+ *
+ * %RUBIN_OR_NEWER%
+ *
+ * Populates \a info with the in-band request, out-of-band enablement status, out-of-band
+ * override status, arbitrated enablement state, and adjusted base power limit. The adjusted base
+ * power is valid only when feature is enabled.
+ * See \ref nvmlAdaptiveTgpModeInfo_v1_t for field details.
+ *
+ * @param device     The identifier of the target device
+ * @param info       Reference in which to return the Adaptive TGP Mode information
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if \a info has been populated
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a info is NULL
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support Adaptive TGP Mode
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlDeviceSetAdaptiveTgpMode_v1()
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetAdaptiveTgpModeInfo_v1(nvmlDevice_t device, nvmlAdaptiveTgpModeInfo_v1_t *info);
 
 /**
  * Retrieves the current GOM and pending GOM (the one that GPU will switch to after reboot).
@@ -6748,6 +7295,60 @@ nvmlReturn_t DECLDIR nvmlDeviceGetMemoryInfo(nvmlDevice_t device, nvmlMemory_t *
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetMemoryInfo_v2(nvmlDevice_t device, nvmlMemory_v2_t *memory);
+
+/**
+ * @brief Set the memory limits of the device for the cgroup partition.
+ *
+ * This method will set the memory limits of the device for the specified cgroup
+ * partition. The limits will indicate the amount of memory that can be allocated
+ * for the device for use of an application in that cgroup.
+ *
+ * For all products.
+ * For Linux only.
+ * Requires root/admin permissions.
+ *
+ * @param[in] device                               The identifier of the target device
+ * @param[in] limits                               A pointer to \ref nvmlSetMemoryLimits_v1_t where the limits can be set
+ *
+ * @return
+ *  - \ref NVML_SUCCESS                 if the operation was successful
+ *  - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *  - \ref NVML_ERROR_NO_PERMISSION     if the user doesn't have permission to perform this operation
+ *  - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, \a limits is NULL,
+ *                                      the softLimit exceeds the hardLimit, or a limit
+ *                                      exceeds total device memory
+ *  - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support this feature
+ *  - \ref NVML_ERROR_OPERATING_SYSTEM  if the cgroup path cannot be opened
+ *  - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @note MIG handles are not supported
+ */
+nvmlReturn_t DECLDIR nvmlDeviceSetMemoryLimits_v1(nvmlDevice_t device, nvmlSetMemoryLimits_v1_t *limits);
+
+/**
+ * @brief Get the memory limits of the device for the cgroup partition.
+ *
+ * This method will get the current memory limits of the device for the specified
+ * cgroup partition, as well as the current memory used against the limits.
+ *
+ * For all products.
+ * For Linux only.
+ *
+ * @param[in]     device                           The identifier of the target device
+ * @param[in,out] limits                           A pointer to \ref nvmlGetMemoryLimits_v1_t
+ *
+ * @return
+ *  - \ref NVML_SUCCESS                 if the operation was successful
+ *  - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *  - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a limits is NULL
+ *  - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support this feature
+ *  - \ref NVML_ERROR_NOT_FOUND         if the limits were not found for this device and cgroup
+ *  - \ref NVML_ERROR_OPERATING_SYSTEM  if the cgroup path cannot be opened
+ *  - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @note MIG handles are not supported
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetMemoryLimits_v1(nvmlDevice_t device, nvmlGetMemoryLimits_v1_t *limits);
 
 /**
  * Retrieves the current compute mode for the device or MIG device.
@@ -7297,6 +7898,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetFBCSessions(nvmlDevice_t device, unsigned int 
  *
  * On Windows platforms the device driver can run in either WDDM, MCDM or WDM (TCC) modes. If a display is attached
  * to the device it must run in WDDM mode. MCDM mode is preferred if a display is not attached. TCC mode is deprecated.
+ * Driver-model availability is architecture-specific; attempting to set an unsupported driver model returns
+ * NVML_ERROR_NOT_SUPPORTED.
  *
  * See \ref nvmlDriverModel_t for details on available driver models.
  *
@@ -7851,6 +8454,37 @@ DEPRECATED(13.0) nvmlReturn_t DECLDIR nvmlDeviceGetGpuFabricInfo(nvmlDevice_t de
 */
 nvmlReturn_t DECLDIR nvmlDeviceGetGpuFabricInfoV(nvmlDevice_t device,
                                                  nvmlGpuFabricInfoV_t *gpuFabricInfo);
+
+/**
+ * Retrieves GPU fabric information including per-type clique assignments.
+ *
+ * Returns fabric clique data via \ref nvmlGpuFabricInfo_v4_t.
+ * Each entry in the \a cliques array is a (type, id) pair representing a single
+ * clique assignment. The number of valid entries is given by \a numCliques.
+ * Entries are sorted by ascending type (NVML_GPU_FABRIC_CLIQUE_TYPE_*), then by
+ * ascending clique id within each type.
+ *
+ * On Hopper systems, the driver reports Unicast Pointer and Multicast Pointer cliques.
+ * On Blackwell and Rubin, Unicast Logical Endpoint and Multicast Logical Endpoint
+ * are additionally reported.
+ *
+ * \code
+ *     nvmlGpuFabricInfo_v4_t fabricInfo = {0};
+ *     nvmlReturn_t result = nvmlDeviceGetGpuFabricInfo_v4(device, &fabricInfo);
+ * \endcode
+ *
+ * For Hopper &tm; or newer fully supported devices.
+ *
+ * @param device                               The identifier of the target device
+ * @param gpuFabricInfo                        Information about GPU fabric state including per-type cliques
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 Upon success
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     If \a device doesn't support gpu fabric
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  If \a device or \a gpuFabricInfo is invalid
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetGpuFabricInfo_v4(nvmlDevice_t device,
+                                                   nvmlGpuFabricInfo_v4_t *gpuFabricInfo);
 
 /**
  * Get Conf Computing System capabilities.
@@ -8665,6 +9299,20 @@ nvmlReturn_t DECLDIR nvmlDeviceSetHostname_v1(nvmlDevice_t device, nvmlHostname_
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetHostname_v1(nvmlDevice_t device, nvmlHostname_v1_t *hostname);
 
+/**
+    * Get Performance Metric samples
+    *
+    * See \ref nvmlPerfMetricsSamples_v1_t for more information on the struct.
+    *
+    * @param[in] device                            The identifier of the target device
+    * @param[out] samples                          Reference to \a nvmlPerfMetricsSamples_v1_t.
+    *
+    * @return
+    *        - \ref NVML_SUCCESS                         if the query is successful
+    *        - \ref NVML_ERROR_NOT_SUPPORTED             if this query is not supported by the device
+    **/
+nvmlReturn_t DECLDIR nvmlDevicePerfMetricsGetSamples_v1(nvmlDevice_t device, nvmlPerfMetricsSamples_v1_t *samples);
+
 /** @} */
 
 /***************************************************************************************************/
@@ -8860,6 +9508,9 @@ nvmlReturn_t DECLDIR nvmlDeviceClearEccErrorCounts(nvmlDevice_t device, nvmlEccC
  *
  * On Windows platforms the device driver can run in either WDDM or WDM (TCC) mode. If a display is attached
  * to the device it must run in WDDM mode.
+ *
+ * Driver-model availability is architecture-specific; attempting to set an unsupported driver model returns
+ * NVML_ERROR_NOT_SUPPORTED.
  *
  * It is possible to force the change to WDM (TCC) while the display is still attached with a force flag (nvmlFlagForce).
  * This should only be done if the host is subsequently powered down and the display is detached from the device
@@ -9387,9 +10038,10 @@ nvmlReturn_t DECLDIR nvmlDeviceClearAccountingPids(nvmlDevice_t device);
 /*
  * NVML_FI_DEV_NVLINK_GET_STATE state enums
  */
-#define NVML_NVLINK_STATE_INACTIVE 0x0 //!< NVLink is inactive.
-#define NVML_NVLINK_STATE_ACTIVE   0x1 //!< NVLink is active.
-#define NVML_NVLINK_STATE_SLEEP    0x2 //!< NVLink is in sleep state.
+#define NVML_NVLINK_STATE_INACTIVE 0x0          //!< NVLink is inactive.
+#define NVML_NVLINK_STATE_ACTIVE   0x1          //!< NVLink is active.
+#define NVML_NVLINK_STATE_SLEEP    0x2          //!< NVLink is in sleep state.
+#define NVML_NVLINK_STATE_ACTIVE_TRAFFIC_DISABLED 0x3 //!< NVLink is active, but not usable for traffic
 
 /**
  * Represents Nvlink Version
@@ -9435,6 +10087,21 @@ typedef struct
 } nvmlNvlinkSetBwMode_v1_t;
 typedef nvmlNvlinkSetBwMode_v1_t nvmlNvlinkSetBwMode_t;
 #define nvmlNvlinkSetBwMode_v1 NVML_STRUCT_VERSION(NvlinkSetBwMode, 1) //!< Version macro for \a nvmlNvlinkSetBwMode_v1_t
+
+/**
+ * @brief Describes the parameters involved to setting Nvlink RBM mode asynchronously.
+ *
+ * This structure holds the parameters needed to correctly set a Device's Nvlink
+ * Reduced Bandwidth Mode asynchronously. Polling for NVML_GPU_FABRIC_STATE_COMPLETED
+ * from \ref nvmlDeviceGetGpuFabricInfoV() is needed to check if the setting was applied.
+ *
+ */
+typedef struct
+{
+    unsigned int bSetBest;           //!< [in]  - Set to the best available Bandwidth mode
+    unsigned int bwMode;             //!< [in]  - Requested Bandwidth mode to set. Values can be found from \ref nvmlDeviceGetNvlinkSupportedBwModes()
+    unsigned int asyncPollTimeoutMs; //!< [out] - Time in ms to poll to validate bandwidth setting.
+} nvmlNvlinkSetBwModeAsync_v1_t;
 
 /**
  * Struct to represent per device NVLINK information v1
@@ -9838,6 +10505,26 @@ nvmlReturn_t DECLDIR nvmlDeviceSetNvlinkBwMode(nvmlDevice_t device,
                                                nvmlNvlinkSetBwMode_t *setBwMode);
 
 /**
+ * Set the NvLink Reduced Bandwidth Mode asynchronously for the device. Polling should be
+ * done by checking for \a NVML_GPU_FABRIC_STATE_COMPLETED from \ref nvmlDeviceGetGpuFabricInfoV().
+ *
+ * %RUBIN_OR_NEWER%
+ *
+ * @param[in]     device                              The identifier of the target device
+ * @param[in,out] setBwModeAsync                      Reference to \ref nvmlNvlinkSetBwModeAsync_v1_t
+ *
+ * @return
+ *        - \ref NVML_SUCCESS                         if the Bandwidth mode was successfully set
+ *        - \ref NVML_ERROR_INVALID_ARGUMENT          if device or \p setBwModeAsync is invalid
+ *        - \ref NVML_ERROR_NO_PERMISSION             if user does not have permission to change Bandwidth mode
+ *        - \ref NVML_ERROR_NOT_SUPPORTED             if this feature is not supported by the device
+ *
+ * @see nvmlDeviceGetGpuFabricInfoV()
+ *
+ **/
+nvmlReturn_t DECLDIR nvmlDeviceSetNvlinkBwModeAsync_v1(nvmlDevice_t device, nvmlNvlinkSetBwModeAsync_v1_t *setBwModeAsync);
+
+/**
  * Query NVLINK information associated with this device.
  *
  * @param[in]  device                              The identifier of the target device
@@ -9853,6 +10540,66 @@ nvmlReturn_t DECLDIR nvmlDeviceSetNvlinkBwMode(nvmlDevice_t device,
  *         - \ref NVML_ERROR_UNKNOWN                    on any unexpected error
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetNvLinkInfo(nvmlDevice_t device, nvmlNvLinkInfo_t *info);
+
+/**
+ * Per-link NVLink telemetry sample types.
+ */
+typedef enum
+{
+    NVML_NVLINK_TELEMETRY_SAMPLE_TYPE_THROUGHPUT_RAW_TX = 0, //!< Raw TX flit counter for a single link
+    NVML_NVLINK_TELEMETRY_SAMPLE_TYPE_THROUGHPUT_RAW_RX = 1, //!< Raw RX flit counter for a single link
+    NVML_NVLINK_TELEMETRY_SAMPLE_TYPE_COUNT             = 2  //!< Number of valid sample types
+} nvmlNvlinkTelemetrySampleType_t;
+
+/**
+ * Struct representing one (link, metric) telemetry request / response slot.
+ */
+typedef struct
+{
+    unsigned int linkId;         //!<[in] LinkId
+    unsigned int sampleType;     //!<[in] Type of telemetry to sample, specified by `nvmlNvlinkTelemetrySampleType_t`
+    unsigned int sampleCount;    //!<[in,out]: Number of samples users need to allocate. If set to 0, will return max
+                                 //! supported count of samples without touching the `samples` pointer.
+    unsigned long long *samples; //!<[in,out]: Array of samples allocated by the user. Can be set to NULL when getting count
+    nvmlReturn_t nvmlReturn;     //!<[out]: Return code for retrieving this sample. This must be checked by the client
+                                 //! before looking at any output values, as they are invalid if `nvmlReturn != NVML_SUCCESS`.
+} nvmlNvlinkTelemetrySample_v1_t;
+
+/**
+ * Batched NVLink telemetry request.
+ */
+typedef struct
+{
+    unsigned int telemetryCount;                      //!<[in]     Number of valid entries in \a telemetrySamples
+    nvmlNvlinkTelemetrySample_v1_t *telemetrySamples; //!<[in,out] Caller-allocated array of \a telemetryCount request slots
+} nvmlNvlinkTelemetrySamples_v1_t;
+
+/**
+ * \brief Retrieve a batch of historical NVLink per-link telemetry samples.
+ *
+ * Samples are taken at approximately 100 ms intervals.
+ * Intended for use with periodic polling every ~2 seconds.
+ * Longer polling intervals are possible, but can result in dropped samples
+ * if the supported `sampleCount` is too low for the given polling interval.
+ *
+ * %RUBIN_OR_NEWER%
+ *
+ * @param[in]     device  The device handle of the GPU to retrieve samples for
+ * @param[in,out] samples Request/response batch (see \ref nvmlNvlinkTelemetrySamples_v1_t)
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 If the call succeeded.
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  If any required pointer is NULL,
+ *                                             a given enum value is out of range,
+ *                                             a slot's `linkId` is out of range,
+ *                                             a slot's `sampleCount` is non-zero with a NULL `samples` pointer, or
+ *                                             a slot's `sampleCount` is greater than the supported `sampleCount` for the given link.
+ *         - \ref NVML_ERROR_GPU_IS_LOST       If the target GPU has fallen off the bus or is otherwise inaccessible.
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     If the given device does not support this API.
+ *         - \ref NVML_ERROR_UNKNOWN           On any unexpected error.
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetNvLinkTelemetrySamples_v1(nvmlDevice_t device,
+                                                            nvmlNvlinkTelemetrySamples_v1_t *samples);
 
 /** @} */ // @defgroup NvLink NvLink Methods
 
@@ -9968,7 +10715,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetSupportedEventTypes(nvmlDevice_t device, unsig
  * @return
  *         - \ref NVML_SUCCESS                 if the data has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
- *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a data is NULL
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a set or \a data is NULL
  *         - \ref NVML_ERROR_TIMEOUT           if no event arrived in specified timeout or interrupt arrived
  *         - \ref NVML_ERROR_GPU_IS_LOST       if a GPU has fallen off the bus or is otherwise inaccessible
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
@@ -9977,6 +10724,223 @@ nvmlReturn_t DECLDIR nvmlDeviceGetSupportedEventTypes(nvmlDevice_t device, unsig
  * @see nvmlDeviceRegisterEvents
  */
 nvmlReturn_t DECLDIR nvmlEventSetWait_v2(nvmlEventSet_t set, nvmlEventData_t * data, unsigned int timeoutms);
+
+/**
+ * @brief Adds a GPU Operational Event subscription to an event set.
+ *
+ * This API is separate from \ref nvmlDeviceRegisterEvents. Calling this API opts the event set into
+ * the structured GPU Operational Event format for the target GPU UUID. Subscriptions are identified
+ * by \a config; registering the same subscription more than once is treated as success.
+ *
+ * \ref nvmlDeviceRegisterEvents and \ref nvmlEventSetRegisterGpuOperationalEvents_v1 may both be used on the same
+ * event set. In that mixed-subscription model, NVML event-bit subscriptions continue to deliver event
+ * bits such as \ref nvmlEventTypeXidCriticalError, while GPU Operational Event subscriptions deliver
+ * \ref NVML_EVENT_DATA_TYPE_GPU_OPERATIONAL_EVENT records through \ref nvmlEventSetWait_v3 with
+ * \c eventType set to \ref nvmlEventTypeNone. The same underlying incident may generate both an NVML
+ * event-bit notification and a structured notification.
+ *
+ * This API supports GPU UUID subscriptions.
+ *
+ * For Turing &tm; or newer fully supported devices.
+ *
+ * For Linux only.
+ *
+ * @param[in] eventSet                         Event set created by \ref nvmlEventSetCreate
+ * @param[in] config                           GPU Operational Event subscription configuration
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if the GPU Operational Event subscription was registered
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a eventSet or \a config is invalid
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if structured GPU Operational Events are not supported on this platform,
+ *                                             or if the requested subscription is not supported
+ *         - \ref NVML_ERROR_NO_PERMISSION     if the caller lacks permission for the requested scope
+ *         - \ref NVML_ERROR_INSUFFICIENT_RESOURCES
+ *                                             if the event set cannot accept another subscription
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlGpuOperationalEventConfig_v1_t
+ * @see nvmlEventSetWait_v3
+ * @see nvmlEventSetFree
+ */
+nvmlReturn_t DECLDIR nvmlEventSetRegisterGpuOperationalEvents_v1(nvmlEventSet_t eventSet,
+                                                                  const nvmlGpuOperationalEventConfig_v1_t *config);
+
+/**
+ * @brief Waits on an event set and returns the next event in the extended event format.
+ *
+ * This API is the unified wait surface for NVML event-bit subscriptions registered with
+ * \ref nvmlDeviceRegisterEvents and structured GPU Operational Event subscriptions registered with
+ * \ref nvmlEventSetRegisterGpuOperationalEvents_v1.
+ *
+ * The returned format is distinguished by \c dataType in \a params. If \c dataType is
+ * \ref NVML_EVENT_DATA_TYPE_NVML_EVENT, the event came from the \ref nvmlDeviceRegisterEvents path,
+ * \c eventType is an NVML event bit such as \ref nvmlEventTypeXidCriticalError, and the existing
+ * fields preserve their historical semantics. If \c dataType is
+ * \ref NVML_EVENT_DATA_TYPE_GPU_OPERATIONAL_EVENT, the event came from the structured format,
+ * \c eventType is \ref nvmlEventTypeNone, and the structured metadata fields are populated.
+ *
+ * When an event set contains only NVML event-bit subscriptions, this API normalizes those events into
+ * \ref nvmlEventSetWait_v3_t. When an event set contains both NVML event-bit and structured subscriptions,
+ * each successful call returns the next available event from either path. Clients should branch on
+ * \c dataType to determine which format was returned. An event set is not required to have
+ * structured GPU Operational Event subscriptions to be used with this API.
+ *
+ * Context records for the returned event, if any, are made available through
+ * \ref nvmlEventSetGetContextCount_v1, \ref nvmlEventSetGetContextInfo_v1, and
+ * \ref nvmlEventSetGetContextData_v1. Context records remain associated with the event set until the
+ * next successful call to \ref nvmlEventSetWait_v3 on the same event set or until the event set is freed.
+ *
+ * For Turing &tm; or newer fully supported devices.
+ *
+ * For Linux only.
+ *
+ * @param[in] set                              Reference to set of events to wait on
+ * @param[in,out] params                       Wait parameters and returned event data
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if the event data has been set
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a set or \a params is NULL
+ *         - \ref NVML_ERROR_TIMEOUT           if no event arrived in specified timeout or interrupt arrived
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if this API is not available on the platform or driver
+ *         - \ref NVML_ERROR_MEMORY            if system memory is insufficient
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if a GPU has fallen off the bus or is otherwise inaccessible
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlEventSetWait_v3_t
+ * @see nvmlDeviceRegisterEvents
+ * @see nvmlEventSetRegisterGpuOperationalEvents_v1
+ * @see nvmlEventSetGetContextCount_v1
+ */
+nvmlReturn_t DECLDIR nvmlEventSetWait_v3(nvmlEventSet_t set, nvmlEventSetWait_v3_t *params);
+
+/**
+ * @brief Gets the number of context records for the most recent event returned by
+ * \ref nvmlEventSetWait_v3 on this event set.
+ *
+ * This count is tied to the event set, not to a caller-owned copy of \ref nvmlEventSetWait_v3_t. It is
+ * replaced by the next successful call to \ref nvmlEventSetWait_v3 on the same event set.
+ *
+ * For Turing &tm; or newer fully supported devices.
+ *
+ * For Linux only.
+ *
+ * @param[in] set                              Event set previously used with \ref nvmlEventSetWait_v3
+ * @param[out] params                          Parameters in which to return the number of context records
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if \a params has been set
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a set or \a params is NULL
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if this API is not available on the platform or driver
+ *         - \ref NVML_ERROR_NOT_FOUND         if no event has been returned by \ref nvmlEventSetWait_v3
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlEventSetWait_v3
+ * @see nvmlEventSetGetContextInfo_v1
+ * @see nvmlEventSetGetContextData_v1
+ */
+nvmlReturn_t DECLDIR nvmlEventSetGetContextCount_v1(nvmlEventSet_t set,
+                                                     nvmlEventSetGetContextCount_v1_t *params);
+
+/**
+ * @brief Gets metadata for a context record from the most recent event returned by
+ * \ref nvmlEventSetWait_v3.
+ *
+ * The returned metadata identifies the NVML public interpretation, the source-defined context payload
+ * type, payload size, and payload format version. The raw payload for any context record can be
+ * copied with \ref nvmlEventSetGetContextData_v1 and decoded using the public operational event
+ * schema or documentation for
+ * \ref nvmlEventSetGetContextInfo_v1_t::sourceEventContextType. When
+ * \c nvmlGpuOperationalEventContextType names a type-specific accessor, callers may use that
+ * accessor instead. Metadata is replaced by the next successful call to \ref nvmlEventSetWait_v3
+ * on the same event set.
+ *
+ * For Turing &tm; or newer fully supported devices.
+ *
+ * For Linux only.
+ *
+ * @param[in] set                              Event set previously used with \ref nvmlEventSetWait_v3
+ * @param[in,out] params                       Context index and returned context metadata
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if the context metadata has been returned
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if arguments are invalid or \c params->index is out of range
+ *         - \ref NVML_ERROR_NOT_FOUND         if no event has been returned by \ref nvmlEventSetWait_v3
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if this API is not available on the platform or driver
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlEventSetGetContextInfo_v1_t
+ * @see nvmlEventSetGetContextCount_v1
+ * @see nvmlEventSetGetContextData_v1
+ */
+nvmlReturn_t DECLDIR nvmlEventSetGetContextInfo_v1(nvmlEventSet_t set,
+                                                    nvmlEventSetGetContextInfo_v1_t *params);
+
+/**
+ * @brief Copies the raw payload for a context record from the most recent event returned by
+ * \ref nvmlEventSetWait_v3.
+ *
+ * Passing \c params->data as NULL performs a size query. In that case \c params->dataSize is set to the required
+ * payload size and the function returns \ref NVML_ERROR_INSUFFICIENT_SIZE when the payload is
+ * non-empty. If the context payload is empty, \c params->dataSize is set to 0 and the function returns
+ * \ref NVML_SUCCESS.
+ *
+ * For Turing &tm; or newer fully supported devices.
+ *
+ * For Linux only.
+ *
+ * @param[in] set                              Event set previously used with \ref nvmlEventSetWait_v3
+ * @param[in,out] params                       Context index, optional data buffer, and buffer size
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if the raw context payload has been copied
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if arguments are invalid or \c params->index is out of range
+ *         - \ref NVML_ERROR_NOT_FOUND         if no event has been returned by \ref nvmlEventSetWait_v3
+ *         - \ref NVML_ERROR_INSUFFICIENT_SIZE if \c params->data is NULL or too small for a non-empty payload
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if this API is not available on the platform or driver
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlEventSetWait_v3
+ * @see nvmlEventSetGetContextCount_v1
+ * @see nvmlEventSetGetContextInfo_v1
+ */
+nvmlReturn_t DECLDIR nvmlEventSetGetContextData_v1(nvmlEventSet_t set,
+                                                    nvmlEventSetGetContextData_v1_t *params);
+
+/**
+ * @brief Gets decoded GPU legacy-Xid context data for a context record from the most recent event returned
+ * by \ref nvmlEventSetWait_v3.
+ *
+ * This helper succeeds only for context records whose \c nvmlGpuOperationalEventContextType is
+ * \ref NVML_GPU_OPERATIONAL_EVENT_CONTEXT_TYPE_LEGACY_XID. Other context records remain available
+ * through \ref nvmlEventSetGetContextData_v1.
+ *
+ * For Turing &tm; or newer fully supported devices.
+ *
+ * For Linux only.
+ *
+ * @param[in] set                              Event set previously used with \ref nvmlEventSetWait_v3
+ * @param[in,out] params                       Context index and returned legacy-Xid data
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if the GPU legacy-Xid context has been returned
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if arguments are invalid or \c params->index is out of range
+ *         - \ref NVML_ERROR_NOT_FOUND         if no event has been returned or the context is not a GPU legacy-Xid context
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if this API is not available on the platform or driver
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlEventSetGetGpuOperationalEventContextLegacyXid_v1_t
+ * @see nvmlEventSetGetContextInfo_v1
+ * @see nvmlEventSetGetContextData_v1
+ */
+nvmlReturn_t DECLDIR nvmlEventSetGetGpuOperationalEventContextLegacyXid_v1(nvmlEventSet_t set,
+                                                                           nvmlEventSetGetGpuOperationalEventContextLegacyXid_v1_t *params);
 
 /**
  * Releases events in the set
@@ -12383,33 +13347,44 @@ typedef struct
  */
 nvmlReturn_t DECLDIR nvmlDeviceReadWritePRM_v1(nvmlDevice_t device, nvmlPRMTLV_v1_t *buffer);
 
-/** @} */
-
 /**
  * PRM Counter IDs
  */
 typedef enum
 {
-    NVML_PRM_COUNTER_ID_NONE = 0,
+    NVML_PRM_COUNTER_ID_NONE = 0,                                                                       //!< Sentinel
+                                                                                                        //
     /* Physical Layer Counters (PPCNT group 0x12) */
-    NVML_PRM_COUNTER_ID_PPCNT_PHYSICAL_LAYER_CTRS_LINK_DOWN_EVENTS = 1,
-    NVML_PRM_COUNTER_ID_PPCNT_PHYSICAL_LAYER_CTRS_SUCCESSFUL_RECOVERY_EVENTS = 2,
+    NVML_PRM_COUNTER_ID_PPCNT_PHYSICAL_LAYER_CTRS_LINK_DOWN_EVENTS = 1,                                 //!< PPCNT group 0x12, link_down_events
+    NVML_PRM_COUNTER_ID_PPCNT_PHYSICAL_LAYER_CTRS_SUCCESSFUL_RECOVERY_EVENTS = 2,                       //!< PPCNT group 0x12, successful_recovery_events
+
     /* Recovery counters (PPCNT group 0x1A) */
-    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_SUCCESSFUL_RECOVERY_EVENTS = 101,
-    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_SINCE_LAST_RECOVERY = 102,
-    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_BETWEEN_LAST_TWO_RECOVERIES = 103,
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_SUCCESSFUL_RECOVERY_EVENTS = 101,                     //!< PPCNT group 0x1A, total_successful_recovery_events
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_SINCE_LAST_RECOVERY = 102,                             //!< PPCNT group 0x1A, time_since_last_recovery
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_BETWEEN_LAST_TWO_RECOVERIES = 103,                     //!< PPCNT group 0x1A, time_between_last_two_recoveries
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_IN_LAST_HOST_SERDES_FEQ_RECOVERY = 104,                //!< PPCNT group 0x1A, time_in_last_host_serdes_feq_recovery
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_TIME_IN_HOST_SERDES_FEQ_RECOVERY = 105,               //!< PPCNT group 0x1A, total_time_in_host_serdes_feq_recovery
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_HOST_SERDES_FEQ_RECOVERY_COUNT = 106,                 //!< PPCNT group 0x1A, total_host_serdes_feq_recovery_count
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_HOST_SERDES_FEQ_SUCCESSFUL_RECOVERY_COUNT = 107,      //!< PPCNT group 0x1A, total_host_serdes_feq_successful_recovery_count
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_LAST_HOST_SERDES_FEQ_ATTEMPTS_COUNT = 108,                  //!< PPCNT group 0x1A, last_host_serdes_feq_attempts_count
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_LAST_SUCCESSFUL_RECOVERY_STEP_ATTEMPTS = 109,               //!< PPCNT group 0x1A, last_successful_recovery_step_attempts
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_LAST_SUCCESSFUL_RECOVERY_TIME = 110,                        //!< PPCNT group 0x1A, last_successful_recovery_time
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_SUCCESSFUL_RECOVERY_TIME = 111,                       //!< PPCNT group 0x1A, total_successful_recovery_time
+
     /* Infiniband PortCounters Attribute (PPCNT group 0x20) */
-    NVML_PRM_COUNTER_ID_PPCNT_PORTCOUNTERS_PORT_XMIT_WAIT = 201,
+    NVML_PRM_COUNTER_ID_PPCNT_PORTCOUNTERS_PORT_XMIT_WAIT = 201,                                        //!< PPCNT group 0x20, port_xmit_wait
+
     /* PLR counters (PPCNT group 0x22) */
-    NVML_PRM_COUNTER_ID_PPCNT_PLR_RCV_CODES = 301,
-    NVML_PRM_COUNTER_ID_PPCNT_PLR_RCV_CODE_ERR = 302,
-    NVML_PRM_COUNTER_ID_PPCNT_PLR_RCV_UNCORRECTABLE_CODE = 303,
-    NVML_PRM_COUNTER_ID_PPCNT_PLR_XMIT_CODES = 304,
-    NVML_PRM_COUNTER_ID_PPCNT_PLR_XMIT_RETRY_CODES = 305,
-    NVML_PRM_COUNTER_ID_PPCNT_PLR_XMIT_RETRY_EVENTS = 306,
-    NVML_PRM_COUNTER_ID_PPCNT_PLR_SYNC_EVENTS = 307,
+    NVML_PRM_COUNTER_ID_PPCNT_PLR_RCV_CODES = 301,                                                      //!< PPCNT group 0x22, plr_rcv_codes
+    NVML_PRM_COUNTER_ID_PPCNT_PLR_RCV_CODE_ERR = 302,                                                   //!< PPCNT group 0x22, plr_rcv_code_err
+    NVML_PRM_COUNTER_ID_PPCNT_PLR_RCV_UNCORRECTABLE_CODE = 303,                                         //!< PPCNT group 0x22, plr_rcv_uncorrectable_code
+    NVML_PRM_COUNTER_ID_PPCNT_PLR_XMIT_CODES = 304,                                                     //!< PPCNT group 0x22, plr_xmit_codes
+    NVML_PRM_COUNTER_ID_PPCNT_PLR_XMIT_RETRY_CODES = 305,                                               //!< PPCNT group 0x22, plr_xmit_retry_codes
+    NVML_PRM_COUNTER_ID_PPCNT_PLR_XMIT_RETRY_EVENTS = 306,                                              //!< PPCNT group 0x22, plr_xmit_retry_events
+    NVML_PRM_COUNTER_ID_PPCNT_PLR_SYNC_EVENTS = 307,                                                    //!< PPCNT group 0x22, plr_sync_events
+
     /* PPRM counters */
-    NVML_PRM_COUNTER_ID_PPRM_OPER_RECOVERY = 1001,
+    NVML_PRM_COUNTER_ID_PPRM_OPER_RECOVERY = 1001,                                                      //!< PPRM, oper_recovery
 } nvmlPRMCounterId_t;
 
 /**
@@ -12469,6 +13444,7 @@ typedef struct
  *        - \ref NVML_ERROR_UNKNOWN                     on any other error
  */
 nvmlReturn_t DECLDIR nvmlDeviceReadPRMCounters_v1(nvmlDevice_t device, nvmlPRMCounterList_v1_t *counterList);
+/** @} */
 
 /***************************************************************************************************/
 /** @defgroup nvmlMultiInstanceGPU Multi Instance GPU Management
@@ -13550,152 +14526,152 @@ typedef enum
     NVML_GPM_METRIC_NVLINK_L16_TX_PER_SEC       = 95,   //!< NvLink write bandwidth for link 16 in MiB/sec
     NVML_GPM_METRIC_NVLINK_L17_RX_PER_SEC       = 96,   //!< NvLink read bandwidth for link 17 in MiB/sec
     NVML_GPM_METRIC_NVLINK_L17_TX_PER_SEC       = 97,   //!< NvLink write bandwidth for link 17 in MiB/sec
-    NVML_GPM_METRIC_C2C_TOTAL_TX_PER_SEC        = 100,
-    NVML_GPM_METRIC_C2C_TOTAL_RX_PER_SEC        = 101,
-    NVML_GPM_METRIC_C2C_DATA_TX_PER_SEC         = 102,
-    NVML_GPM_METRIC_C2C_DATA_RX_PER_SEC         = 103,
-    NVML_GPM_METRIC_C2C_LINK0_TOTAL_TX_PER_SEC  = 104,
-    NVML_GPM_METRIC_C2C_LINK0_TOTAL_RX_PER_SEC  = 105,
-    NVML_GPM_METRIC_C2C_LINK0_DATA_TX_PER_SEC   = 106,
-    NVML_GPM_METRIC_C2C_LINK0_DATA_RX_PER_SEC   = 107,
-    NVML_GPM_METRIC_C2C_LINK1_TOTAL_TX_PER_SEC  = 108,
-    NVML_GPM_METRIC_C2C_LINK1_TOTAL_RX_PER_SEC  = 109,
-    NVML_GPM_METRIC_C2C_LINK1_DATA_TX_PER_SEC   = 110,
-    NVML_GPM_METRIC_C2C_LINK1_DATA_RX_PER_SEC   = 111,
-    NVML_GPM_METRIC_C2C_LINK2_TOTAL_TX_PER_SEC  = 112,
-    NVML_GPM_METRIC_C2C_LINK2_TOTAL_RX_PER_SEC  = 113,
-    NVML_GPM_METRIC_C2C_LINK2_DATA_TX_PER_SEC   = 114,
-    NVML_GPM_METRIC_C2C_LINK2_DATA_RX_PER_SEC   = 115,
-    NVML_GPM_METRIC_C2C_LINK3_TOTAL_TX_PER_SEC  = 116,
-    NVML_GPM_METRIC_C2C_LINK3_TOTAL_RX_PER_SEC  = 117,
-    NVML_GPM_METRIC_C2C_LINK3_DATA_TX_PER_SEC   = 118,
-    NVML_GPM_METRIC_C2C_LINK3_DATA_RX_PER_SEC   = 119,
-    NVML_GPM_METRIC_C2C_LINK4_TOTAL_TX_PER_SEC  = 120,
-    NVML_GPM_METRIC_C2C_LINK4_TOTAL_RX_PER_SEC  = 121,
-    NVML_GPM_METRIC_C2C_LINK4_DATA_TX_PER_SEC   = 122,
-    NVML_GPM_METRIC_C2C_LINK4_DATA_RX_PER_SEC   = 123,
-    NVML_GPM_METRIC_C2C_LINK5_TOTAL_TX_PER_SEC  = 124,
-    NVML_GPM_METRIC_C2C_LINK5_TOTAL_RX_PER_SEC  = 125,
-    NVML_GPM_METRIC_C2C_LINK5_DATA_TX_PER_SEC   = 126,
-    NVML_GPM_METRIC_C2C_LINK5_DATA_RX_PER_SEC   = 127,
-    NVML_GPM_METRIC_C2C_LINK6_TOTAL_TX_PER_SEC  = 128,
-    NVML_GPM_METRIC_C2C_LINK6_TOTAL_RX_PER_SEC  = 129,
-    NVML_GPM_METRIC_C2C_LINK6_DATA_TX_PER_SEC   = 130,
-    NVML_GPM_METRIC_C2C_LINK6_DATA_RX_PER_SEC   = 131,
-    NVML_GPM_METRIC_C2C_LINK7_TOTAL_TX_PER_SEC  = 132,
-    NVML_GPM_METRIC_C2C_LINK7_TOTAL_RX_PER_SEC  = 133,
-    NVML_GPM_METRIC_C2C_LINK7_DATA_TX_PER_SEC   = 134,
-    NVML_GPM_METRIC_C2C_LINK7_DATA_RX_PER_SEC   = 135,
-    NVML_GPM_METRIC_C2C_LINK8_TOTAL_TX_PER_SEC  = 136,
-    NVML_GPM_METRIC_C2C_LINK8_TOTAL_RX_PER_SEC  = 137,
-    NVML_GPM_METRIC_C2C_LINK8_DATA_TX_PER_SEC   = 138,
-    NVML_GPM_METRIC_C2C_LINK8_DATA_RX_PER_SEC   = 139,
-    NVML_GPM_METRIC_C2C_LINK9_TOTAL_TX_PER_SEC  = 140,
-    NVML_GPM_METRIC_C2C_LINK9_TOTAL_RX_PER_SEC  = 141,
-    NVML_GPM_METRIC_C2C_LINK9_DATA_TX_PER_SEC   = 142,
-    NVML_GPM_METRIC_C2C_LINK9_DATA_RX_PER_SEC   = 143,
-    NVML_GPM_METRIC_C2C_LINK10_TOTAL_TX_PER_SEC = 144,
-    NVML_GPM_METRIC_C2C_LINK10_TOTAL_RX_PER_SEC = 145,
-    NVML_GPM_METRIC_C2C_LINK10_DATA_TX_PER_SEC  = 146,
-    NVML_GPM_METRIC_C2C_LINK10_DATA_RX_PER_SEC  = 147,
-    NVML_GPM_METRIC_C2C_LINK11_TOTAL_TX_PER_SEC = 148,
-    NVML_GPM_METRIC_C2C_LINK11_TOTAL_RX_PER_SEC = 149,
-    NVML_GPM_METRIC_C2C_LINK11_DATA_TX_PER_SEC  = 150,
-    NVML_GPM_METRIC_C2C_LINK11_DATA_RX_PER_SEC  = 151,
-    NVML_GPM_METRIC_C2C_LINK12_TOTAL_TX_PER_SEC = 152,
-    NVML_GPM_METRIC_C2C_LINK12_TOTAL_RX_PER_SEC = 153,
-    NVML_GPM_METRIC_C2C_LINK12_DATA_TX_PER_SEC  = 154,
-    NVML_GPM_METRIC_C2C_LINK12_DATA_RX_PER_SEC  = 155,
-    NVML_GPM_METRIC_C2C_LINK13_TOTAL_TX_PER_SEC = 156,
-    NVML_GPM_METRIC_C2C_LINK13_TOTAL_RX_PER_SEC = 157,
-    NVML_GPM_METRIC_C2C_LINK13_DATA_TX_PER_SEC  = 158,
-    NVML_GPM_METRIC_C2C_LINK13_DATA_RX_PER_SEC  = 159,
-    NVML_GPM_METRIC_HOSTMEM_CACHE_HIT           = 160,
-    NVML_GPM_METRIC_HOSTMEM_CACHE_MISS          = 161,
-    NVML_GPM_METRIC_PEERMEM_CACHE_HIT           = 162,
-    NVML_GPM_METRIC_PEERMEM_CACHE_MISS          = 163,
-    NVML_GPM_METRIC_DRAM_CACHE_HIT              = 164,
-    NVML_GPM_METRIC_DRAM_CACHE_MISS             = 165,
-    NVML_GPM_METRIC_NVENC_0_UTIL                = 166,
-    NVML_GPM_METRIC_NVENC_1_UTIL                = 167,
-    NVML_GPM_METRIC_NVENC_2_UTIL                = 168,
-    NVML_GPM_METRIC_NVENC_3_UTIL                = 169,
-    NVML_GPM_METRIC_GR0_CTXSW_CYCLES_ELAPSED    = 170,
-    NVML_GPM_METRIC_GR0_CTXSW_CYCLES_ACTIVE     = 171,
-    NVML_GPM_METRIC_GR0_CTXSW_REQUESTS          = 172,
-    NVML_GPM_METRIC_GR0_CTXSW_CYCLES_PER_REQ    = 173,
-    NVML_GPM_METRIC_GR0_CTXSW_ACTIVE_PCT        = 174,
-    NVML_GPM_METRIC_GR1_CTXSW_CYCLES_ELAPSED    = 175,
-    NVML_GPM_METRIC_GR1_CTXSW_CYCLES_ACTIVE     = 176,
-    NVML_GPM_METRIC_GR1_CTXSW_REQUESTS          = 177,
-    NVML_GPM_METRIC_GR1_CTXSW_CYCLES_PER_REQ    = 178,
-    NVML_GPM_METRIC_GR1_CTXSW_ACTIVE_PCT        = 179,
-    NVML_GPM_METRIC_GR2_CTXSW_CYCLES_ELAPSED    = 180,
-    NVML_GPM_METRIC_GR2_CTXSW_CYCLES_ACTIVE     = 181,
-    NVML_GPM_METRIC_GR2_CTXSW_REQUESTS          = 182,
-    NVML_GPM_METRIC_GR2_CTXSW_CYCLES_PER_REQ    = 183,
-    NVML_GPM_METRIC_GR2_CTXSW_ACTIVE_PCT        = 184,
-    NVML_GPM_METRIC_GR3_CTXSW_CYCLES_ELAPSED    = 185,
-    NVML_GPM_METRIC_GR3_CTXSW_CYCLES_ACTIVE     = 186,
-    NVML_GPM_METRIC_GR3_CTXSW_REQUESTS          = 187,
-    NVML_GPM_METRIC_GR3_CTXSW_CYCLES_PER_REQ    = 188,
-    NVML_GPM_METRIC_GR3_CTXSW_ACTIVE_PCT        = 189,
-    NVML_GPM_METRIC_GR4_CTXSW_CYCLES_ELAPSED    = 190,
-    NVML_GPM_METRIC_GR4_CTXSW_CYCLES_ACTIVE     = 191,
-    NVML_GPM_METRIC_GR4_CTXSW_REQUESTS          = 192,
-    NVML_GPM_METRIC_GR4_CTXSW_CYCLES_PER_REQ    = 193,
-    NVML_GPM_METRIC_GR4_CTXSW_ACTIVE_PCT        = 194,
-    NVML_GPM_METRIC_GR5_CTXSW_CYCLES_ELAPSED    = 195,
-    NVML_GPM_METRIC_GR5_CTXSW_CYCLES_ACTIVE     = 196,
-    NVML_GPM_METRIC_GR5_CTXSW_REQUESTS          = 197,
-    NVML_GPM_METRIC_GR5_CTXSW_CYCLES_PER_REQ    = 198,
-    NVML_GPM_METRIC_GR5_CTXSW_ACTIVE_PCT        = 199,
-    NVML_GPM_METRIC_GR6_CTXSW_CYCLES_ELAPSED    = 200,
-    NVML_GPM_METRIC_GR6_CTXSW_CYCLES_ACTIVE     = 201,
-    NVML_GPM_METRIC_GR6_CTXSW_REQUESTS          = 202,
-    NVML_GPM_METRIC_GR6_CTXSW_CYCLES_PER_REQ    = 203,
-    NVML_GPM_METRIC_GR6_CTXSW_ACTIVE_PCT        = 204,
-    NVML_GPM_METRIC_GR7_CTXSW_CYCLES_ELAPSED    = 205,
-    NVML_GPM_METRIC_GR7_CTXSW_CYCLES_ACTIVE     = 206,
-    NVML_GPM_METRIC_GR7_CTXSW_REQUESTS          = 207,
-    NVML_GPM_METRIC_GR7_CTXSW_CYCLES_PER_REQ    = 208,
-    NVML_GPM_METRIC_GR7_CTXSW_ACTIVE_PCT        = 209,
-    NVML_GPM_METRIC_NVLINK_L18_RX_PER_SEC       = 212,
-    NVML_GPM_METRIC_NVLINK_L18_TX_PER_SEC       = 213,
-    NVML_GPM_METRIC_NVLINK_L19_RX_PER_SEC       = 214,
-    NVML_GPM_METRIC_NVLINK_L19_TX_PER_SEC       = 215,
-    NVML_GPM_METRIC_NVLINK_L20_RX_PER_SEC       = 216,
-    NVML_GPM_METRIC_NVLINK_L20_TX_PER_SEC       = 217,
-    NVML_GPM_METRIC_NVLINK_L21_RX_PER_SEC       = 218,
-    NVML_GPM_METRIC_NVLINK_L21_TX_PER_SEC       = 219,
-    NVML_GPM_METRIC_NVLINK_L22_RX_PER_SEC       = 220,
-    NVML_GPM_METRIC_NVLINK_L22_TX_PER_SEC       = 221,
-    NVML_GPM_METRIC_NVLINK_L23_RX_PER_SEC       = 222,
-    NVML_GPM_METRIC_NVLINK_L23_TX_PER_SEC       = 223,
-    NVML_GPM_METRIC_NVLINK_L24_RX_PER_SEC       = 224,
-    NVML_GPM_METRIC_NVLINK_L24_TX_PER_SEC       = 225,
-    NVML_GPM_METRIC_NVLINK_L25_RX_PER_SEC       = 226,
-    NVML_GPM_METRIC_NVLINK_L25_TX_PER_SEC       = 227,
-    NVML_GPM_METRIC_NVLINK_L26_RX_PER_SEC       = 228,
-    NVML_GPM_METRIC_NVLINK_L26_TX_PER_SEC       = 229,
-    NVML_GPM_METRIC_NVLINK_L27_RX_PER_SEC       = 230,
-    NVML_GPM_METRIC_NVLINK_L27_TX_PER_SEC       = 231,
-    NVML_GPM_METRIC_NVLINK_L28_RX_PER_SEC       = 232,
-    NVML_GPM_METRIC_NVLINK_L28_TX_PER_SEC       = 233,
-    NVML_GPM_METRIC_NVLINK_L29_RX_PER_SEC       = 234,
-    NVML_GPM_METRIC_NVLINK_L29_TX_PER_SEC       = 235,
-    NVML_GPM_METRIC_NVLINK_L30_RX_PER_SEC       = 236,
-    NVML_GPM_METRIC_NVLINK_L30_TX_PER_SEC       = 237,
-    NVML_GPM_METRIC_NVLINK_L31_RX_PER_SEC       = 238,
-    NVML_GPM_METRIC_NVLINK_L31_TX_PER_SEC       = 239,
-    NVML_GPM_METRIC_NVLINK_L32_RX_PER_SEC       = 240,
-    NVML_GPM_METRIC_NVLINK_L32_TX_PER_SEC       = 241,
-    NVML_GPM_METRIC_NVLINK_L33_RX_PER_SEC       = 242,
-    NVML_GPM_METRIC_NVLINK_L33_TX_PER_SEC       = 243,
-    NVML_GPM_METRIC_NVLINK_L34_RX_PER_SEC       = 244,
-    NVML_GPM_METRIC_NVLINK_L34_TX_PER_SEC       = 245,
-    NVML_GPM_METRIC_NVLINK_L35_RX_PER_SEC       = 246,
-    NVML_GPM_METRIC_NVLINK_L35_TX_PER_SEC       = 247,
+    NVML_GPM_METRIC_C2C_TOTAL_TX_PER_SEC        = 100,  //!< C2C total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_TOTAL_RX_PER_SEC        = 101,  //!< C2C total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_DATA_TX_PER_SEC         = 102,  //!< C2C data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_DATA_RX_PER_SEC         = 103,  //!< C2C data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK0_TOTAL_TX_PER_SEC  = 104,  //!< C2C link 0 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK0_TOTAL_RX_PER_SEC  = 105,  //!< C2C link 0 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK0_DATA_TX_PER_SEC   = 106,  //!< C2C link 0 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK0_DATA_RX_PER_SEC   = 107,  //!< C2C link 0 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK1_TOTAL_TX_PER_SEC  = 108,  //!< C2C link 1 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK1_TOTAL_RX_PER_SEC  = 109,  //!< C2C link 1 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK1_DATA_TX_PER_SEC   = 110,  //!< C2C link 1 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK1_DATA_RX_PER_SEC   = 111,  //!< C2C link 1 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK2_TOTAL_TX_PER_SEC  = 112,  //!< C2C link 2 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK2_TOTAL_RX_PER_SEC  = 113,  //!< C2C link 2 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK2_DATA_TX_PER_SEC   = 114,  //!< C2C link 2 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK2_DATA_RX_PER_SEC   = 115,  //!< C2C link 2 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK3_TOTAL_TX_PER_SEC  = 116,  //!< C2C link 3 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK3_TOTAL_RX_PER_SEC  = 117,  //!< C2C link 3 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK3_DATA_TX_PER_SEC   = 118,  //!< C2C link 3 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK3_DATA_RX_PER_SEC   = 119,  //!< C2C link 3 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK4_TOTAL_TX_PER_SEC  = 120,  //!< C2C link 4 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK4_TOTAL_RX_PER_SEC  = 121,  //!< C2C link 4 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK4_DATA_TX_PER_SEC   = 122,  //!< C2C link 4 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK4_DATA_RX_PER_SEC   = 123,  //!< C2C link 4 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK5_TOTAL_TX_PER_SEC  = 124,  //!< C2C link 5 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK5_TOTAL_RX_PER_SEC  = 125,  //!< C2C link 5 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK5_DATA_TX_PER_SEC   = 126,  //!< C2C link 5 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK5_DATA_RX_PER_SEC   = 127,  //!< C2C link 5 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK6_TOTAL_TX_PER_SEC  = 128,  //!< C2C link 6 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK6_TOTAL_RX_PER_SEC  = 129,  //!< C2C link 6 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK6_DATA_TX_PER_SEC   = 130,  //!< C2C link 6 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK6_DATA_RX_PER_SEC   = 131,  //!< C2C link 6 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK7_TOTAL_TX_PER_SEC  = 132,  //!< C2C link 7 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK7_TOTAL_RX_PER_SEC  = 133,  //!< C2C link 7 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK7_DATA_TX_PER_SEC   = 134,  //!< C2C link 7 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK7_DATA_RX_PER_SEC   = 135,  //!< C2C link 7 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK8_TOTAL_TX_PER_SEC  = 136,  //!< C2C link 8 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK8_TOTAL_RX_PER_SEC  = 137,  //!< C2C link 8 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK8_DATA_TX_PER_SEC   = 138,  //!< C2C link 8 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK8_DATA_RX_PER_SEC   = 139,  //!< C2C link 8 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK9_TOTAL_TX_PER_SEC  = 140,  //!< C2C link 9 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK9_TOTAL_RX_PER_SEC  = 141,  //!< C2C link 9 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK9_DATA_TX_PER_SEC   = 142,  //!< C2C link 9 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK9_DATA_RX_PER_SEC   = 143,  //!< C2C link 9 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK10_TOTAL_TX_PER_SEC = 144,  //!< C2C link 10 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK10_TOTAL_RX_PER_SEC = 145,  //!< C2C link 10 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK10_DATA_TX_PER_SEC  = 146,  //!< C2C link 10 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK10_DATA_RX_PER_SEC  = 147,  //!< C2C link 10 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK11_TOTAL_TX_PER_SEC = 148,  //!< C2C link 11 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK11_TOTAL_RX_PER_SEC = 149,  //!< C2C link 11 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK11_DATA_TX_PER_SEC  = 150,  //!< C2C link 11 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK11_DATA_RX_PER_SEC  = 151,  //!< C2C link 11 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK12_TOTAL_TX_PER_SEC = 152,  //!< C2C link 12 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK12_TOTAL_RX_PER_SEC = 153,  //!< C2C link 12 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK12_DATA_TX_PER_SEC  = 154,  //!< C2C link 12 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK12_DATA_RX_PER_SEC  = 155,  //!< C2C link 12 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK13_TOTAL_TX_PER_SEC = 156,  //!< C2C link 13 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK13_TOTAL_RX_PER_SEC = 157,  //!< C2C link 13 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK13_DATA_TX_PER_SEC  = 158,  //!< C2C link 13 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK13_DATA_RX_PER_SEC  = 159,  //!< C2C link 13 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_HOSTMEM_CACHE_HIT           = 160,  //!< Percentage of host memory cache hits. 0.0 - 100.0
+    NVML_GPM_METRIC_HOSTMEM_CACHE_MISS          = 161,  //!< Percentage of host memory cache misses. 0.0 - 100.0
+    NVML_GPM_METRIC_PEERMEM_CACHE_HIT           = 162,  //!< Percentage of peer memory cache hits. 0.0 - 100.0
+    NVML_GPM_METRIC_PEERMEM_CACHE_MISS          = 163,  //!< Percentage of peer memory cache misses. 0.0 - 100.0
+    NVML_GPM_METRIC_DRAM_CACHE_HIT              = 164,  //!< Percentage of DRAM cache hits. 0.0 - 100.0
+    NVML_GPM_METRIC_DRAM_CACHE_MISS             = 165,  //!< Percentage of DRAM cache misses. 0.0 - 100.0
+    NVML_GPM_METRIC_NVENC_0_UTIL                = 166,  //!< Percent utilization of NVENC 0. 0.0 - 100.0
+    NVML_GPM_METRIC_NVENC_1_UTIL                = 167,  //!< Percent utilization of NVENC 1. 0.0 - 100.0
+    NVML_GPM_METRIC_NVENC_2_UTIL                = 168,  //!< Percent utilization of NVENC 2. 0.0 - 100.0
+    NVML_GPM_METRIC_NVENC_3_UTIL                = 169,  //!< Percent utilization of NVENC 3. 0.0 - 100.0
+    NVML_GPM_METRIC_GR0_CTXSW_CYCLES_ELAPSED    = 170,  //!< Total context switch cycles elapsed for GR engine 0
+    NVML_GPM_METRIC_GR0_CTXSW_CYCLES_ACTIVE     = 171,  //!< Active context switch cycles for GR engine 0
+    NVML_GPM_METRIC_GR0_CTXSW_REQUESTS          = 172,  //!< Number of context switch requests for GR engine 0
+    NVML_GPM_METRIC_GR0_CTXSW_CYCLES_PER_REQ    = 173,  //!< Average context switch cycles per request for GR engine 0
+    NVML_GPM_METRIC_GR0_CTXSW_ACTIVE_PCT        = 174,  //!< Percentage of time GR engine 0 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_GR1_CTXSW_CYCLES_ELAPSED    = 175,  //!< Total context switch cycles elapsed for GR engine 1
+    NVML_GPM_METRIC_GR1_CTXSW_CYCLES_ACTIVE     = 176,  //!< Active context switch cycles for GR engine 1
+    NVML_GPM_METRIC_GR1_CTXSW_REQUESTS          = 177,  //!< Number of context switch requests for GR engine 1
+    NVML_GPM_METRIC_GR1_CTXSW_CYCLES_PER_REQ    = 178,  //!< Average context switch cycles per request for GR engine 1
+    NVML_GPM_METRIC_GR1_CTXSW_ACTIVE_PCT        = 179,  //!< Percentage of time GR engine 1 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_GR2_CTXSW_CYCLES_ELAPSED    = 180,  //!< Total context switch cycles elapsed for GR engine 2
+    NVML_GPM_METRIC_GR2_CTXSW_CYCLES_ACTIVE     = 181,  //!< Active context switch cycles for GR engine 2
+    NVML_GPM_METRIC_GR2_CTXSW_REQUESTS          = 182,  //!< Number of context switch requests for GR engine 2
+    NVML_GPM_METRIC_GR2_CTXSW_CYCLES_PER_REQ    = 183,  //!< Average context switch cycles per request for GR engine 2
+    NVML_GPM_METRIC_GR2_CTXSW_ACTIVE_PCT        = 184,  //!< Percentage of time GR engine 2 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_GR3_CTXSW_CYCLES_ELAPSED    = 185,  //!< Total context switch cycles elapsed for GR engine 3
+    NVML_GPM_METRIC_GR3_CTXSW_CYCLES_ACTIVE     = 186,  //!< Active context switch cycles for GR engine 3
+    NVML_GPM_METRIC_GR3_CTXSW_REQUESTS          = 187,  //!< Number of context switch requests for GR engine 3
+    NVML_GPM_METRIC_GR3_CTXSW_CYCLES_PER_REQ    = 188,  //!< Average context switch cycles per request for GR engine 3
+    NVML_GPM_METRIC_GR3_CTXSW_ACTIVE_PCT        = 189,  //!< Percentage of time GR engine 3 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_GR4_CTXSW_CYCLES_ELAPSED    = 190,  //!< Total context switch cycles elapsed for GR engine 4
+    NVML_GPM_METRIC_GR4_CTXSW_CYCLES_ACTIVE     = 191,  //!< Active context switch cycles for GR engine 4
+    NVML_GPM_METRIC_GR4_CTXSW_REQUESTS          = 192,  //!< Number of context switch requests for GR engine 4
+    NVML_GPM_METRIC_GR4_CTXSW_CYCLES_PER_REQ    = 193,  //!< Average context switch cycles per request for GR engine 4
+    NVML_GPM_METRIC_GR4_CTXSW_ACTIVE_PCT        = 194,  //!< Percentage of time GR engine 4 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_GR5_CTXSW_CYCLES_ELAPSED    = 195,  //!< Total context switch cycles elapsed for GR engine 5
+    NVML_GPM_METRIC_GR5_CTXSW_CYCLES_ACTIVE     = 196,  //!< Active context switch cycles for GR engine 5
+    NVML_GPM_METRIC_GR5_CTXSW_REQUESTS          = 197,  //!< Number of context switch requests for GR engine 5
+    NVML_GPM_METRIC_GR5_CTXSW_CYCLES_PER_REQ    = 198,  //!< Average context switch cycles per request for GR engine 5
+    NVML_GPM_METRIC_GR5_CTXSW_ACTIVE_PCT        = 199,  //!< Percentage of time GR engine 5 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_GR6_CTXSW_CYCLES_ELAPSED    = 200,  //!< Total context switch cycles elapsed for GR engine 6
+    NVML_GPM_METRIC_GR6_CTXSW_CYCLES_ACTIVE     = 201,  //!< Active context switch cycles for GR engine 6
+    NVML_GPM_METRIC_GR6_CTXSW_REQUESTS          = 202,  //!< Number of context switch requests for GR engine 6
+    NVML_GPM_METRIC_GR6_CTXSW_CYCLES_PER_REQ    = 203,  //!< Average context switch cycles per request for GR engine 6
+    NVML_GPM_METRIC_GR6_CTXSW_ACTIVE_PCT        = 204,  //!< Percentage of time GR engine 6 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_GR7_CTXSW_CYCLES_ELAPSED    = 205,  //!< Total context switch cycles elapsed for GR engine 7
+    NVML_GPM_METRIC_GR7_CTXSW_CYCLES_ACTIVE     = 206,  //!< Active context switch cycles for GR engine 7
+    NVML_GPM_METRIC_GR7_CTXSW_REQUESTS          = 207,  //!< Number of context switch requests for GR engine 7
+    NVML_GPM_METRIC_GR7_CTXSW_CYCLES_PER_REQ    = 208,  //!< Average context switch cycles per request for GR engine 7
+    NVML_GPM_METRIC_GR7_CTXSW_ACTIVE_PCT        = 209,  //!< Percentage of time GR engine 7 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_NVLINK_L18_RX_PER_SEC       = 212,  //!< NvLink read bandwidth for link 18 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L18_TX_PER_SEC       = 213,  //!< NvLink write bandwidth for link 18 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L19_RX_PER_SEC       = 214,  //!< NvLink read bandwidth for link 19 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L19_TX_PER_SEC       = 215,  //!< NvLink write bandwidth for link 19 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L20_RX_PER_SEC       = 216,  //!< NvLink read bandwidth for link 20 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L20_TX_PER_SEC       = 217,  //!< NvLink write bandwidth for link 20 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L21_RX_PER_SEC       = 218,  //!< NvLink read bandwidth for link 21 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L21_TX_PER_SEC       = 219,  //!< NvLink write bandwidth for link 21 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L22_RX_PER_SEC       = 220,  //!< NvLink read bandwidth for link 22 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L22_TX_PER_SEC       = 221,  //!< NvLink write bandwidth for link 22 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L23_RX_PER_SEC       = 222,  //!< NvLink read bandwidth for link 23 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L23_TX_PER_SEC       = 223,  //!< NvLink write bandwidth for link 23 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L24_RX_PER_SEC       = 224,  //!< NvLink read bandwidth for link 24 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L24_TX_PER_SEC       = 225,  //!< NvLink write bandwidth for link 24 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L25_RX_PER_SEC       = 226,  //!< NvLink read bandwidth for link 25 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L25_TX_PER_SEC       = 227,  //!< NvLink write bandwidth for link 25 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L26_RX_PER_SEC       = 228,  //!< NvLink read bandwidth for link 26 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L26_TX_PER_SEC       = 229,  //!< NvLink write bandwidth for link 26 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L27_RX_PER_SEC       = 230,  //!< NvLink read bandwidth for link 27 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L27_TX_PER_SEC       = 231,  //!< NvLink write bandwidth for link 27 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L28_RX_PER_SEC       = 232,  //!< NvLink read bandwidth for link 28 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L28_TX_PER_SEC       = 233,  //!< NvLink write bandwidth for link 28 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L29_RX_PER_SEC       = 234,  //!< NvLink read bandwidth for link 29 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L29_TX_PER_SEC       = 235,  //!< NvLink write bandwidth for link 29 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L30_RX_PER_SEC       = 236,  //!< NvLink read bandwidth for link 30 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L30_TX_PER_SEC       = 237,  //!< NvLink write bandwidth for link 30 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L31_RX_PER_SEC       = 238,  //!< NvLink read bandwidth for link 31 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L31_TX_PER_SEC       = 239,  //!< NvLink write bandwidth for link 31 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L32_RX_PER_SEC       = 240,  //!< NvLink read bandwidth for link 32 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L32_TX_PER_SEC       = 241,  //!< NvLink write bandwidth for link 32 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L33_RX_PER_SEC       = 242,  //!< NvLink read bandwidth for link 33 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L33_TX_PER_SEC       = 243,  //!< NvLink write bandwidth for link 33 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L34_RX_PER_SEC       = 244,  //!< NvLink read bandwidth for link 34 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L34_TX_PER_SEC       = 245,  //!< NvLink write bandwidth for link 34 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L35_RX_PER_SEC       = 246,  //!< NvLink read bandwidth for link 35 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L35_TX_PER_SEC       = 247,  //!< NvLink write bandwidth for link 35 in MiB/sec
     NVML_GPM_METRIC_SM_CYCLES_ELAPSED           = 248,  //!< The GPU's SM cycles elapsed since reboot
     NVML_GPM_METRIC_SM_CYCLES_ACTIVE            = 249,  //!< The GPU's SM activity since reboot
     NVML_GPM_METRIC_MMA_CYCLES_ACTIVE           = 250,  //!< The GPU's SM MMA tensor activity since reboot
@@ -13707,8 +14683,8 @@ typedef enum
     NVML_GPM_METRIC_PCIE_RX                     = 256,  //!< The PCIe RX traffic since reboot
     NVML_GPM_METRIC_INTEGER_CYCLES_ACTIVE       = 257,  //!< The GPU's SM integer activity since reboot
     NVML_GPM_METRIC_FP64_CYCLES_ACTIVE          = 258,  //!< The GPU's SM FP64 activity since reboot
-    NVML_GPM_METRIC_FP32_CYCLES_ACTIVE          = 259,  //!< The GPU's SM FP64 activity since reboot
-    NVML_GPM_METRIC_FP16_CYCLES_ACTIVE          = 260,  //!< The GPU's SM FP64 activity since reboot
+    NVML_GPM_METRIC_FP32_CYCLES_ACTIVE          = 259,  //!< The GPU's SM FP32 activity since reboot
+    NVML_GPM_METRIC_FP16_CYCLES_ACTIVE          = 260,  //!< The GPU's SM FP16 activity since reboot
     NVML_GPM_METRIC_NVLINK_L0_RX                = 261,  //!< NvLink read for link 0 in bytes since reboot
     NVML_GPM_METRIC_NVLINK_L0_TX                = 262,  //!< NvLink write for link 0 in bytes since reboot
     NVML_GPM_METRIC_NVLINK_L1_RX                = 263,  //!< NvLink read for link 1 in bytes since reboot
@@ -13781,7 +14757,151 @@ typedef enum
     NVML_GPM_METRIC_NVLINK_L34_TX               = 330,  //!< NvLink write for link 34 in bytes since reboot
     NVML_GPM_METRIC_NVLINK_L35_RX               = 331,  //!< NvLink read for link 35 in bytes since reboot
     NVML_GPM_METRIC_NVLINK_L35_TX               = 332,  //!< NvLink write for link 35 in bytes since reboot
-    NVML_GPM_METRIC_MAX                         = 333,  //!< Maximum value above +1
+    NVML_GPM_METRIC_NVLINK_L36_RX               = 333,  //!< NvLink read for link 36 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L36_TX               = 334,  //!< NvLink write for link 36 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L37_RX               = 335,  //!< NvLink read for link 37 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L37_TX               = 336,  //!< NvLink write for link 37 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L38_RX               = 337,  //!< NvLink read for link 38 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L38_TX               = 338,  //!< NvLink write for link 38 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L39_RX               = 339,  //!< NvLink read for link 39 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L39_TX               = 340,  //!< NvLink write for link 39 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L40_RX               = 341,  //!< NvLink read for link 40 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L40_TX               = 342,  //!< NvLink write for link 40 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L41_RX               = 343,  //!< NvLink read for link 41 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L41_TX               = 344,  //!< NvLink write for link 41 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L42_RX               = 345,  //!< NvLink read for link 42 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L42_TX               = 346,  //!< NvLink write for link 42 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L43_RX               = 347,  //!< NvLink read for link 43 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L43_TX               = 348,  //!< NvLink write for link 43 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L44_RX               = 349,  //!< NvLink read for link 44 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L44_TX               = 350,  //!< NvLink write for link 44 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L45_RX               = 351,  //!< NvLink read for link 45 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L45_TX               = 352,  //!< NvLink write for link 45 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L46_RX               = 353,  //!< NvLink read for link 46 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L46_TX               = 354,  //!< NvLink write for link 46 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L47_RX               = 355,  //!< NvLink read for link 47 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L47_TX               = 356,  //!< NvLink write for link 47 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L48_RX               = 357,  //!< NvLink read for link 48 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L48_TX               = 358,  //!< NvLink write for link 48 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L49_RX               = 359,  //!< NvLink read for link 49 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L49_TX               = 360,  //!< NvLink write for link 49 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L50_RX               = 361,  //!< NvLink read for link 50 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L50_TX               = 362,  //!< NvLink write for link 50 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L51_RX               = 363,  //!< NvLink read for link 51 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L51_TX               = 364,  //!< NvLink write for link 51 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L52_RX               = 365,  //!< NvLink read for link 52 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L52_TX               = 366,  //!< NvLink write for link 52 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L53_RX               = 367,  //!< NvLink read for link 53 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L53_TX               = 368,  //!< NvLink write for link 53 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L54_RX               = 369,  //!< NvLink read for link 54 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L54_TX               = 370,  //!< NvLink write for link 54 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L55_RX               = 371,  //!< NvLink read for link 55 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L55_TX               = 372,  //!< NvLink write for link 55 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L56_RX               = 373,  //!< NvLink read for link 56 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L56_TX               = 374,  //!< NvLink write for link 56 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L57_RX               = 375,  //!< NvLink read for link 57 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L57_TX               = 376,  //!< NvLink write for link 57 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L58_RX               = 377,  //!< NvLink read for link 58 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L58_TX               = 378,  //!< NvLink write for link 58 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L59_RX               = 379,  //!< NvLink read for link 59 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L59_TX               = 380,  //!< NvLink write for link 59 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L60_RX               = 381,  //!< NvLink read for link 60 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L60_TX               = 382,  //!< NvLink write for link 60 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L61_RX               = 383,  //!< NvLink read for link 61 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L61_TX               = 384,  //!< NvLink write for link 61 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L62_RX               = 385,  //!< NvLink read for link 62 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L62_TX               = 386,  //!< NvLink write for link 62 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L63_RX               = 387,  //!< NvLink read for link 63 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L63_TX               = 388,  //!< NvLink write for link 63 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L64_RX               = 389,  //!< NvLink read for link 64 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L64_TX               = 390,  //!< NvLink write for link 64 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L65_RX               = 391,  //!< NvLink read for link 65 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L65_TX               = 392,  //!< NvLink write for link 65 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L66_RX               = 393,  //!< NvLink read for link 66 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L66_TX               = 394,  //!< NvLink write for link 66 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L67_RX               = 395,  //!< NvLink read for link 67 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L67_TX               = 396,  //!< NvLink write for link 67 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L68_RX               = 397,  //!< NvLink read for link 68 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L68_TX               = 398,  //!< NvLink write for link 68 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L69_RX               = 399,  //!< NvLink read for link 69 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L69_TX               = 400,  //!< NvLink write for link 69 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L70_RX               = 401,  //!< NvLink read for link 70 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L70_TX               = 402,  //!< NvLink write for link 70 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L71_RX               = 403,  //!< NvLink read for link 71 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L71_TX               = 404,  //!< NvLink write for link 71 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L36_RX_PER_SEC       = 405,  //!< NvLink read bandwidth for link 36 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L36_TX_PER_SEC       = 406,  //!< NvLink write bandwidth for link 36 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L37_RX_PER_SEC       = 407,  //!< NvLink read bandwidth for link 37 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L37_TX_PER_SEC       = 408,  //!< NvLink write bandwidth for link 37 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L38_RX_PER_SEC       = 409,  //!< NvLink read bandwidth for link 38 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L38_TX_PER_SEC       = 410,  //!< NvLink write bandwidth for link 38 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L39_RX_PER_SEC       = 411,  //!< NvLink read bandwidth for link 39 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L39_TX_PER_SEC       = 412,  //!< NvLink write bandwidth for link 39 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L40_RX_PER_SEC       = 413,  //!< NvLink read bandwidth for link 40 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L40_TX_PER_SEC       = 414,  //!< NvLink write bandwidth for link 40 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L41_RX_PER_SEC       = 415,  //!< NvLink read bandwidth for link 41 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L41_TX_PER_SEC       = 416,  //!< NvLink write bandwidth for link 41 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L42_RX_PER_SEC       = 417,  //!< NvLink read bandwidth for link 42 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L42_TX_PER_SEC       = 418,  //!< NvLink write bandwidth for link 42 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L43_RX_PER_SEC       = 419,  //!< NvLink read bandwidth for link 43 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L43_TX_PER_SEC       = 420,  //!< NvLink write bandwidth for link 43 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L44_RX_PER_SEC       = 421,  //!< NvLink read bandwidth for link 44 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L44_TX_PER_SEC       = 422,  //!< NvLink write bandwidth for link 44 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L45_RX_PER_SEC       = 423,  //!< NvLink read bandwidth for link 45 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L45_TX_PER_SEC       = 424,  //!< NvLink write bandwidth for link 45 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L46_RX_PER_SEC       = 425,  //!< NvLink read bandwidth for link 46 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L46_TX_PER_SEC       = 426,  //!< NvLink write bandwidth for link 46 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L47_RX_PER_SEC       = 427,  //!< NvLink read bandwidth for link 47 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L47_TX_PER_SEC       = 428,  //!< NvLink write bandwidth for link 47 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L48_RX_PER_SEC       = 429,  //!< NvLink read bandwidth for link 48 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L48_TX_PER_SEC       = 430,  //!< NvLink write bandwidth for link 48 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L49_RX_PER_SEC       = 431,  //!< NvLink read bandwidth for link 49 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L49_TX_PER_SEC       = 432,  //!< NvLink write bandwidth for link 49 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L50_RX_PER_SEC       = 433,  //!< NvLink read bandwidth for link 50 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L50_TX_PER_SEC       = 434,  //!< NvLink write bandwidth for link 50 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L51_RX_PER_SEC       = 435,  //!< NvLink read bandwidth for link 51 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L51_TX_PER_SEC       = 436,  //!< NvLink write bandwidth for link 51 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L52_RX_PER_SEC       = 437,  //!< NvLink read bandwidth for link 52 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L52_TX_PER_SEC       = 438,  //!< NvLink write bandwidth for link 52 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L53_RX_PER_SEC       = 439,  //!< NvLink read bandwidth for link 53 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L53_TX_PER_SEC       = 440,  //!< NvLink write bandwidth for link 53 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L54_RX_PER_SEC       = 441,  //!< NvLink read bandwidth for link 54 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L54_TX_PER_SEC       = 442,  //!< NvLink write bandwidth for link 54 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L55_RX_PER_SEC       = 443,  //!< NvLink read bandwidth for link 55 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L55_TX_PER_SEC       = 444,  //!< NvLink write bandwidth for link 55 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L56_RX_PER_SEC       = 445,  //!< NvLink read bandwidth for link 56 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L56_TX_PER_SEC       = 446,  //!< NvLink write bandwidth for link 56 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L57_RX_PER_SEC       = 447,  //!< NvLink read bandwidth for link 57 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L57_TX_PER_SEC       = 448,  //!< NvLink write bandwidth for link 57 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L58_RX_PER_SEC       = 449,  //!< NvLink read bandwidth for link 58 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L58_TX_PER_SEC       = 450,  //!< NvLink write bandwidth for link 58 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L59_RX_PER_SEC       = 451,  //!< NvLink read bandwidth for link 59 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L59_TX_PER_SEC       = 452,  //!< NvLink write bandwidth for link 59 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L60_RX_PER_SEC       = 453,  //!< NvLink read bandwidth for link 60 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L60_TX_PER_SEC       = 454,  //!< NvLink write bandwidth for link 60 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L61_RX_PER_SEC       = 455,  //!< NvLink read bandwidth for link 61 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L61_TX_PER_SEC       = 456,  //!< NvLink write bandwidth for link 61 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L62_RX_PER_SEC       = 457,  //!< NvLink read bandwidth for link 62 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L62_TX_PER_SEC       = 458,  //!< NvLink write bandwidth for link 62 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L63_RX_PER_SEC       = 459,  //!< NvLink read bandwidth for link 63 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L63_TX_PER_SEC       = 460,  //!< NvLink write bandwidth for link 63 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L64_RX_PER_SEC       = 461,  //!< NvLink read bandwidth for link 64 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L64_TX_PER_SEC       = 462,  //!< NvLink write bandwidth for link 64 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L65_RX_PER_SEC       = 463,  //!< NvLink read bandwidth for link 65 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L65_TX_PER_SEC       = 464,  //!< NvLink write bandwidth for link 65 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L66_RX_PER_SEC       = 465,  //!< NvLink read bandwidth for link 66 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L66_TX_PER_SEC       = 466,  //!< NvLink write bandwidth for link 66 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L67_RX_PER_SEC       = 467,  //!< NvLink read bandwidth for link 67 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L67_TX_PER_SEC       = 468,  //!< NvLink write bandwidth for link 67 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L68_RX_PER_SEC       = 469,  //!< NvLink read bandwidth for link 68 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L68_TX_PER_SEC       = 470,  //!< NvLink write bandwidth for link 68 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L69_RX_PER_SEC       = 471,  //!< NvLink read bandwidth for link 69 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L69_TX_PER_SEC       = 472,  //!< NvLink write bandwidth for link 69 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L70_RX_PER_SEC       = 473,  //!< NvLink read bandwidth for link 70 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L70_TX_PER_SEC       = 474,  //!< NvLink write bandwidth for link 70 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L71_RX_PER_SEC       = 475,  //!< NvLink read bandwidth for link 71 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L71_TX_PER_SEC       = 476,  //!< NvLink write bandwidth for link 71 in MiB/sec
+    NVML_GPM_METRIC_MAX                         = 477,  //!< Maximum value above +1
 } nvmlGpmMetricId_t;
 
 /** @} */ // @defgroup nvmlGpmEnums
@@ -14062,23 +15182,33 @@ typedef struct
 #define NVML_WORKLOAD_POWER_MAX_PROFILES        (255)
 typedef enum
 {
-    NVML_POWER_PROFILE_MAX_P            = 0,
-    NVML_POWER_PROFILE_MAX_Q            = 1,
-    NVML_POWER_PROFILE_COMPUTE          = 2,
-    NVML_POWER_PROFILE_MEMORY_BOUND     = 3,
-    NVML_POWER_PROFILE_NETWORK          = 4,
-    NVML_POWER_PROFILE_BALANCED         = 5,
-    NVML_POWER_PROFILE_LLM_INFERENCE    = 6,
-    NVML_POWER_PROFILE_LLM_TRAINING     = 7,
-    NVML_POWER_PROFILE_RBM              = 8,
-    NVML_POWER_PROFILE_DCPCIE           = 9,
-    NVML_POWER_PROFILE_HMMA_SPARSE      = 10,
-    NVML_POWER_PROFILE_HMMA_DENSE       = 11,
-    NVML_POWER_PROFILE_SYNC_BALANCED    = 12,
-    NVML_POWER_PROFILE_HPC              = 13,
-    NVML_POWER_PROFILE_MIG              = 14,
+    NVML_POWER_PROFILE_MAX_P                       = 0,
+    NVML_POWER_PROFILE_MAX_Q                       = 1,
+    NVML_POWER_PROFILE_COMPUTE                     = 2,
+    NVML_POWER_PROFILE_MEMORY_BOUND                = 3,
+    NVML_POWER_PROFILE_NETWORK                     = 4,
+    NVML_POWER_PROFILE_BALANCED                    = 5,
+    NVML_POWER_PROFILE_LLM_INFERENCE               = 6,
+    NVML_POWER_PROFILE_LLM_TRAINING                = 7,
+    NVML_POWER_PROFILE_RBM                         = 8,
+    NVML_POWER_PROFILE_DCPCIE                      = 9,
+    NVML_POWER_PROFILE_HMMA_SPARSE                 = 10,
+    NVML_POWER_PROFILE_HMMA_DENSE                  = 11,
+    NVML_POWER_PROFILE_SYNC_BALANCED               = 12,
+    NVML_POWER_PROFILE_HPC                         = 13,
+    NVML_POWER_PROFILE_MIG                         = 14,
+    NVML_POWER_PROFILE_MAX_Q_1                     = 15,
+    NVML_POWER_PROFILE_NETWORK_BOUND               = 16,
+    NVML_POWER_PROFILE_HIGH_THROUGHPUT_INFERENCE   = 17,
+    NVML_POWER_PROFILE_MEDIUM_THROUGHPUT_INFERENCE = 18,
+    NVML_POWER_PROFILE_LOW_LATENCY_INFERENCE       = 19,
+    NVML_POWER_PROFILE_TRAINING                    = 20,
+    NVML_POWER_PROFILE_INFERENCE                   = 21,
+    NVML_POWER_PROFILE_MAX_Q_2                     = 22,
+    NVML_POWER_PROFILE_MAX_Q_3                     = 23,
+    NVML_POWER_PROFILE_LOW_PRIORITY_BACKGROUND     = 24,
 
-    NVML_POWER_PROFILE_MAX              = 15,
+    NVML_POWER_PROFILE_MAX                         = 25,
 } nvmlPowerProfileType_t;
 
 /**
@@ -14209,7 +15339,7 @@ nvmlReturn_t DECLDIR nvmlDeviceWorkloadPowerProfileGetCurrentProfiles(nvmlDevice
  *
  * For Blackwell &tm; or newer fully supported devices.
  * See \ref nvmlWorkloadPowerProfileRequestedProfiles_v1_t for more information on the struct.
- * Reuqest one or more performance profiles be activated using the input bitmask
+ * Request one or more performance profiles be activated using the input bitmask
  * \a requestedProfilesMask, where each bit set corresponds to a supported bit from
  * the \a perfProfilesMask. These profiles will be added to existing list of
  * currently requested profiles.
@@ -14265,7 +15395,7 @@ DEPRECATED(13.1) nvmlReturn_t DECLDIR nvmlDeviceWorkloadPowerProfileClearRequest
  * \a updateProfilesMask, where each bit set corresponds to a supported bit from
  * the \a perfProfilesMask.
  * The \a operation parameter specifies the operation to perform, see \ref nvmlPowerProfileOperation_t for more information.
- * Requires root/admin permissions.
+ * Requires root/admin permissions or access to the NVIDIA WPPS capability.
  *
  * @param device                The identifier of the target device
  * @param updateProfiles        Reference to struct \a nvmlWorkloadPowerProfileUpdateProfiles_v1_t
@@ -14482,6 +15612,45 @@ nvmlReturn_t DECLDIR nvmlDeviceGetRemappedRows_v2(nvmlDevice_t device, nvmlRemap
  *
  **/
 nvmlReturn_t DECLDIR nvmlDeviceSetRusdSettings_v1(nvmlDevice_t device, nvmlRusdSettings_v1_t *settings);
+
+/**
+ * Structure to store bank remapper histogram
+ */
+typedef struct
+{
+    unsigned int maxSpareGroupCount;    //!< Number of groups that have maximum spare.
+    unsigned int noSpareGroupCount;     //!< Number of groups that have not spare.
+} nvmlEccBankRemapperHistogram_v1_t;
+
+/**
+ * Structure to store bank remapper status
+ */
+typedef struct
+{
+    unsigned int activeRemappings;                      //!< Number of active remappings
+    unsigned int inactiveRemappings;                    //!< Number of inactive remappings
+    unsigned int bPending;                              //!< Whether there exists any pending bank remapping. 0 for no pending remapping, 1 for pending remapping.
+    nvmlEccBankRemapperHistogram_v1_t histogram;        //!< Bank remapper histogram
+} nvmlEccBankRemapperStatus_v1_t;
+
+/**
+ * Get bank remapper status.
+ *
+ * %RUBIN_OR_NEWER%
+ *
+ * @param device                 The identifier of the target device
+ * @param pBankRemapperStatus    Reference to \a nvmlEccBankRemapperStatus_t
+ *
+ * @return
+ * - \ref NVML_SUCCESS if \a pBankRemapperStatus was populated
+ * - \ref NVML_ERROR_UNINITIALIZED if the library has not been successfully initialized
+ * - \ref NVML_ERROR_INVALID_ARGUMENT if \a device is invalid or \a pBankRemapperStatus is NULL
+ * - \ref NVML_ERROR_NOT_SUPPORTED if the device doesn't support this feature
+ * - \ref NVML_ERROR_GPU_IS_LOST if the target GPU has fallen off the bus or is otherwise inaccessible
+ * - \ref NVML_ERROR_UNKNOWN on any unexpected error
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetBankRemapperStatus_v1(nvmlDevice_t device,
+                                                        nvmlEccBankRemapperStatus_v1_t *pBankRemapperStatus);
 
 /**
  * NVML API versioning support

--- a/gen/nvml/nvml.yml
+++ b/gen/nvml/nvml.yml
@@ -81,6 +81,11 @@ TRANSLATOR:
       - {action: replace, from: "^VgpuMetadata", to: "nvmlVgpuMetadata"}
       - {action: replace, from: "^VgpuPgpuMetadata", to: "nvmlVgpuPgpuMetadata"}
       - {action: replace, from: "^GpmMetricsGet", to: "nvmlGpmMetricsGetType"}
+      - {action: replace, from: "^EventSetWait_v3$", to: "EventSetWaitData_v3"}
+      - {action: replace, from: "^EventSetGetContextCount_v1$", to: "GetContextCount_v1"}
+      - {action: replace, from: "^EventSetGetContextInfo_v1$", to: "GetContextInfo_v1"}
+      - {action: replace, from: "^EventSetGetContextData_v1$", to: "GetContextData_v1"}
+      - {action: replace, from: "^EventSetGetGpuOperationalEventContextLegacyXid_v1$", to: "GetGpuOperationalEventContextLegacyXid_v1"}
     function:
       - {action: accept, from: "^nvml"}
       - {action: replace, from: "^nvmlInit$", to: "nvmlInit_v1"}

--- a/pkg/nvml/cgo_helpers_static.go
+++ b/pkg/nvml/cgo_helpers_static.go
@@ -121,3 +121,14 @@ func stringToInt8Slice(s string, out []int8) {
 		out[i] = 0
 	}
 }
+
+func int8PtrToString(p *int8) string {
+	goString := C.GoString((*C.char)(unsafe.Pointer(p)))
+	return goString
+}
+
+func stringToCPtr(s string) unsafe.Pointer {
+	cstr := C.CString(s)
+	p := unsafe.Pointer(cstr)
+	return p
+}

--- a/pkg/nvml/const.go
+++ b/pkg/nvml/const.go
@@ -44,6 +44,8 @@ const (
 	DEVICE_PCI_BUS_ID_LEGACY_FMT = "%04X:%02X:%02X.0"
 	// DEVICE_PCI_BUS_ID_FMT as defined in nvml/nvml.h
 	DEVICE_PCI_BUS_ID_FMT = "%08X:%02X:%02X.0"
+	// DEVICE_MEMORY_LIMIT_MAX as defined in nvml/nvml.h
+	DEVICE_MEMORY_LIMIT_MAX = 18446744073709551615
 	// NVLINK_MAX_LINKS as defined in nvml/nvml.h
 	NVLINK_MAX_LINKS = 36
 	// TOPOLOGY_CPU as defined in nvml/nvml.h
@@ -56,6 +58,32 @@ const (
 	DEVICE_UUID_ASCII_LEN = 41
 	// DEVICE_UUID_BINARY_LEN as defined in nvml/nvml.h
 	DEVICE_UUID_BINARY_LEN = 16
+	// PERF_METRICS_PWR_MODEL_DLPPM_1X_MAX_CORE_RAILS as defined in nvml/nvml.h
+	PERF_METRICS_PWR_MODEL_DLPPM_1X_MAX_CORE_RAILS = 2
+	// PERF_METRICS_NNE_DESC_INFERENCE_LOOPS_MAX as defined in nvml/nvml.h
+	PERF_METRICS_NNE_DESC_INFERENCE_LOOPS_MAX = 8
+	// PERF_METRICS_PWR_MODEL_METRICS_DLPPM_1X_OBESRVED_INTIAL_DRAMCLK_ESTIMATES_MAX as defined in nvml/nvml.h
+	PERF_METRICS_PWR_MODEL_METRICS_DLPPM_1X_OBESRVED_INTIAL_DRAMCLK_ESTIMATES_MAX = 3
+	// PERF_METRICS_CONTROLLER_DLPPC_2X_PWR_POLICY_RELATIONSHIP_SET_LIMITS_MAX as defined in nvml/nvml.h
+	PERF_METRICS_CONTROLLER_DLPPC_2X_PWR_POLICY_RELATIONSHIP_SET_LIMITS_MAX = 4
+	// PERF_METRICS_CONTROLLER_STATUS_DLPPC_2X_DRAMCLK_NUM as defined in nvml/nvml.h
+	PERF_METRICS_CONTROLLER_STATUS_DLPPC_2X_DRAMCLK_NUM = 3
+	// PERF_METRICS_CONTROLLER_SAMPLE_CONTROLLER_MAX_NUM as defined in nvml/nvml.h
+	PERF_METRICS_CONTROLLER_SAMPLE_CONTROLLER_MAX_NUM = 4
+	// PERF_METRICS_SAMPLE_COUNT as defined in nvml/nvml.h
+	PERF_METRICS_SAMPLE_COUNT = 13
+	// PERF_METRICS_PWR_MODEL_SCALE_LOOPS_MAX_PFPP_1X as defined in nvml/nvml.h
+	PERF_METRICS_PWR_MODEL_SCALE_LOOPS_MAX_PFPP_1X = 32
+	// PERF_METRICS_PWR_MODEL_SCALE_METRICS_INPUT_MAX as defined in nvml/nvml.h
+	PERF_METRICS_PWR_MODEL_SCALE_METRICS_INPUT_MAX = 16
+	// PERF_METRICS_CONTROLLER_TYPE_DLPPC_2X as defined in nvml/nvml.h
+	PERF_METRICS_CONTROLLER_TYPE_DLPPC_2X = 0
+	// PERF_METRICS_CONTROLLER_TYPE_PFPP_1X as defined in nvml/nvml.h
+	PERF_METRICS_CONTROLLER_TYPE_PFPP_1X = 1
+	// PERF_METRICS_PWR_MODEL_SCALE_METRICS_PFPP_1X_GPCCLK_IDX as defined in nvml/nvml.h
+	PERF_METRICS_PWR_MODEL_SCALE_METRICS_PFPP_1X_GPCCLK_IDX = 0
+	// PERF_CF_PM_SENSOR_MAX_SIGNALS as defined in nvml/nvml.h
+	PERF_CF_PM_SENSOR_MAX_SIGNALS = 1024
 	// FlagDefault as defined in nvml/nvml.h
 	FlagDefault = 0
 	// FlagForce as defined in nvml/nvml.h
@@ -118,8 +146,14 @@ const (
 	DEVICE_ARCH_HOPPER = 9
 	// DEVICE_ARCH_BLACKWELL as defined in nvml/nvml.h
 	DEVICE_ARCH_BLACKWELL = 10
+	// DEVICE_ARCH_DLA as defined in nvml/nvml.h
+	DEVICE_ARCH_DLA = 11
+	// DEVICE_ARCH_DLA2 as defined in nvml/nvml.h
+	DEVICE_ARCH_DLA2 = 12
 	// DEVICE_ARCH_RUBIN as defined in nvml/nvml.h
 	DEVICE_ARCH_RUBIN = 13
+	// DEVICE_ARCH_NPU3 as defined in nvml/nvml.h
+	DEVICE_ARCH_NPU3 = 15
 	// DEVICE_ARCH_UNKNOWN as defined in nvml/nvml.h
 	DEVICE_ARCH_UNKNOWN = 4294967295
 	// BUS_TYPE_UNKNOWN as defined in nvml/nvml.h
@@ -854,8 +888,18 @@ const (
 	FI_DEV_REMAPPED_ROWS_COR_INACTIVE = 301
 	// FI_DEV_REMAPPED_ROWS_UNC_INACTIVE as defined in nvml/nvml.h
 	FI_DEV_REMAPPED_ROWS_UNC_INACTIVE = 302
+	// FI_DEV_ACTIVE_BANK_REMAPPINGS as defined in nvml/nvml.h
+	FI_DEV_ACTIVE_BANK_REMAPPINGS = 303
+	// FI_DEV_INACTIVE_BANK_REMAPPINGS as defined in nvml/nvml.h
+	FI_DEV_INACTIVE_BANK_REMAPPINGS = 304
+	// FI_DEV_BANK_REMAPPER_HISTOGRAM_MAX as defined in nvml/nvml.h
+	FI_DEV_BANK_REMAPPER_HISTOGRAM_MAX = 305
+	// FI_DEV_BANK_REMAPPER_HISTOGRAM_NONE as defined in nvml/nvml.h
+	FI_DEV_BANK_REMAPPER_HISTOGRAM_NONE = 306
+	// FI_DEV_PENDING_BANK_REMAPPING as defined in nvml/nvml.h
+	FI_DEV_PENDING_BANK_REMAPPING = 307
 	// FI_MAX as defined in nvml/nvml.h
-	FI_MAX = 303
+	FI_MAX = 308
 	// MCLK_SWITCH_TYPE_NOT_SUPPORTED as defined in nvml/nvml.h
 	MCLK_SWITCH_TYPE_NOT_SUPPORTED = 0
 	// MCLK_SWITCH_TYPE_DEFERRED as defined in nvml/nvml.h
@@ -914,6 +958,30 @@ const (
 	EventTypeGpuRecoveryAction = 32768
 	// EventTypeAll as defined in nvml/nvml.h
 	EventTypeAll = 65439
+	// GPU_INSTANCE_ID_ANY as defined in nvml/nvml.h
+	GPU_INSTANCE_ID_ANY = 4294967295
+	// COMPUTE_INSTANCE_ID_ANY as defined in nvml/nvml.h
+	COMPUTE_INSTANCE_ID_ANY = 4294967295
+	// OPERATIONAL_EVENT_ATTR_UNCONTAINED as defined in nvml/nvml.h
+	OPERATIONAL_EVENT_ATTR_UNCONTAINED = 1
+	// OPERATIONAL_EVENT_ATTR_LATENT as defined in nvml/nvml.h
+	OPERATIONAL_EVENT_ATTR_LATENT = 2
+	// OPERATIONAL_EVENT_ATTR_PROPAGATED as defined in nvml/nvml.h
+	OPERATIONAL_EVENT_ATTR_PROPAGATED = 4
+	// OPERATIONAL_EVENT_ATTR_COMPONENT_RESET as defined in nvml/nvml.h
+	OPERATIONAL_EVENT_ATTR_COMPONENT_RESET = 8
+	// OPERATIONAL_EVENT_ATTR_THRESHOLD_EXCEEDED as defined in nvml/nvml.h
+	OPERATIONAL_EVENT_ATTR_THRESHOLD_EXCEEDED = 16
+	// OPERATIONAL_EVENT_ATTR_PRIMARY as defined in nvml/nvml.h
+	OPERATIONAL_EVENT_ATTR_PRIMARY = 32
+	// OPERATIONAL_EVENT_ATTR_OVERFLOW as defined in nvml/nvml.h
+	OPERATIONAL_EVENT_ATTR_OVERFLOW = 64
+	// OPERATIONAL_EVENT_GROUP_ATTR_RECOVERED as defined in nvml/nvml.h
+	OPERATIONAL_EVENT_GROUP_ATTR_RECOVERED = 1
+	// OPERATIONAL_EVENT_GROUP_ATTR_PREVERR as defined in nvml/nvml.h
+	OPERATIONAL_EVENT_GROUP_ATTR_PREVERR = 2
+	// OPERATIONAL_EVENT_GROUP_ATTR_SIMULATED as defined in nvml/nvml.h
+	OPERATIONAL_EVENT_GROUP_ATTR_SIMULATED = 4
 	// SystemEventTypeGpuDriverUnbind as defined in nvml/nvml.h
 	SystemEventTypeGpuDriverUnbind = 1
 	// SystemEventTypeGpuDriverBind as defined in nvml/nvml.h
@@ -940,10 +1008,14 @@ const (
 	ClocksThrottleReasonHwPowerBrakeSlowdown = 128
 	// ClocksEventReasonDisplayClockSetting as defined in nvml/nvml.h
 	ClocksEventReasonDisplayClockSetting = 256
+	// ClocksEventReasonBoardLimit as defined in nvml/nvml.h
+	ClocksEventReasonBoardLimit = 512
+	// ClocksEventReasonReliability as defined in nvml/nvml.h
+	ClocksEventReasonReliability = 1024
 	// ClocksEventReasonNone as defined in nvml/nvml.h
 	ClocksEventReasonNone = 0
 	// ClocksEventReasonAll as defined in nvml/nvml.h
-	ClocksEventReasonAll = 511
+	ClocksEventReasonAll = 2047
 	// ClocksThrottleReasonGpuIdle as defined in nvml/nvml.h
 	ClocksThrottleReasonGpuIdle = 1
 	// ClocksThrottleReasonApplicationsClocksSetting as defined in nvml/nvml.h
@@ -959,7 +1031,7 @@ const (
 	// ClocksThrottleReasonNone as defined in nvml/nvml.h
 	ClocksThrottleReasonNone = 0
 	// ClocksThrottleReasonAll as defined in nvml/nvml.h
-	ClocksThrottleReasonAll = 511
+	ClocksThrottleReasonAll = 2047
 	// NVFBC_SESSION_FLAG_DIFFMAP_ENABLED as defined in nvml/nvml.h
 	NVFBC_SESSION_FLAG_DIFFMAP_ENABLED = 1
 	// NVFBC_SESSION_FLAG_CLASSIFICATIONMAP_ENABLED as defined in nvml/nvml.h
@@ -1108,6 +1180,16 @@ const (
 	GPU_FABRIC_HEALTH_MASK_SHIFT_PARTITION_ASSIGNED = 12
 	// GPU_FABRIC_HEALTH_MASK_WIDTH_PARTITION_ASSIGNED as defined in nvml/nvml.h
 	GPU_FABRIC_HEALTH_MASK_WIDTH_PARTITION_ASSIGNED = 3
+	// GPU_FABRIC_HEALTH_MASK_GFM_STATE_NOT_SUPPORTED as defined in nvml/nvml.h
+	GPU_FABRIC_HEALTH_MASK_GFM_STATE_NOT_SUPPORTED = 0
+	// GPU_FABRIC_HEALTH_MASK_GFM_STATE_CONNECTED as defined in nvml/nvml.h
+	GPU_FABRIC_HEALTH_MASK_GFM_STATE_CONNECTED = 1
+	// GPU_FABRIC_HEALTH_MASK_GFM_STATE_DISCONNECTED as defined in nvml/nvml.h
+	GPU_FABRIC_HEALTH_MASK_GFM_STATE_DISCONNECTED = 2
+	// GPU_FABRIC_HEALTH_MASK_SHIFT_GFM_STATE as defined in nvml/nvml.h
+	GPU_FABRIC_HEALTH_MASK_SHIFT_GFM_STATE = 14
+	// GPU_FABRIC_HEALTH_MASK_WIDTH_GFM_STATE as defined in nvml/nvml.h
+	GPU_FABRIC_HEALTH_MASK_WIDTH_GFM_STATE = 3
 	// GPU_FABRIC_HEALTH_SUMMARY_NOT_SUPPORTED as defined in nvml/nvml.h
 	GPU_FABRIC_HEALTH_SUMMARY_NOT_SUPPORTED = 0
 	// GPU_FABRIC_HEALTH_SUMMARY_HEALTHY as defined in nvml/nvml.h
@@ -1116,6 +1198,16 @@ const (
 	GPU_FABRIC_HEALTH_SUMMARY_UNHEALTHY = 2
 	// GPU_FABRIC_HEALTH_SUMMARY_LIMITED_CAPACITY as defined in nvml/nvml.h
 	GPU_FABRIC_HEALTH_SUMMARY_LIMITED_CAPACITY = 3
+	// GPU_FABRIC_CLIQUE_MAX as defined in nvml/nvml.h
+	GPU_FABRIC_CLIQUE_MAX = 64
+	// GPU_FABRIC_CLIQUE_TYPE_UNICAST_POINTER as defined in nvml/nvml.h
+	GPU_FABRIC_CLIQUE_TYPE_UNICAST_POINTER = 0
+	// GPU_FABRIC_CLIQUE_TYPE_MULTICAST_POINTER as defined in nvml/nvml.h
+	GPU_FABRIC_CLIQUE_TYPE_MULTICAST_POINTER = 1
+	// GPU_FABRIC_CLIQUE_TYPE_UNICAST_LOGICAL_ENDPOINT as defined in nvml/nvml.h
+	GPU_FABRIC_CLIQUE_TYPE_UNICAST_LOGICAL_ENDPOINT = 2
+	// GPU_FABRIC_CLIQUE_TYPE_MULTICAST_LOGICAL_ENDPOINT as defined in nvml/nvml.h
+	GPU_FABRIC_CLIQUE_TYPE_MULTICAST_LOGICAL_ENDPOINT = 3
 	// INIT_FLAG_NO_GPUS as defined in nvml/nvml.h
 	INIT_FLAG_NO_GPUS = 1
 	// INIT_FLAG_NO_ATTACH as defined in nvml/nvml.h
@@ -1162,6 +1254,8 @@ const (
 	NVLINK_STATE_ACTIVE = 1
 	// NVLINK_STATE_SLEEP as defined in nvml/nvml.h
 	NVLINK_STATE_SLEEP = 2
+	// NVLINK_STATE_ACTIVE_TRAFFIC_DISABLED as defined in nvml/nvml.h
+	NVLINK_STATE_ACTIVE_TRAFFIC_DISABLED = 3
 	// NVLINK_TOTAL_SUPPORTED_BW_MODES as defined in nvml/nvml.h
 	NVLINK_TOTAL_SUPPORTED_BW_MODES = 23
 	// NVLINK_FIRMWARE_UCODE_TYPE_MSE as defined in nvml/nvml.h
@@ -1527,7 +1621,10 @@ const (
 	BRAND_NVIDIA              BrandType = 14
 	BRAND_GEFORCE_RTX         BrandType = 15
 	BRAND_TITAN_RTX           BrandType = 16
-	BRAND_COUNT               BrandType = 18
+	BRAND_NVIDIA_DLA          BrandType = 17
+	BRAND_NVIDIA_VGAMEDEV     BrandType = 18
+	BRAND_NVIDIA_NPU          BrandType = 19
+	BRAND_COUNT               BrandType = 20
 )
 
 // TemperatureThresholds as declared in nvml/nvml.h
@@ -1551,8 +1648,9 @@ type TemperatureSensors int32
 
 // TemperatureSensors enumeration from nvml/nvml.h
 const (
-	TEMPERATURE_GPU   TemperatureSensors = iota
-	TEMPERATURE_COUNT TemperatureSensors = 1
+	TEMPERATURE_GPU     TemperatureSensors = iota
+	TEMPERATURE_GPU_MAX TemperatureSensors = 1
+	TEMPERATURE_COUNT   TemperatureSensors = 2
 )
 
 // ComputeMode as declared in nvml/nvml.h
@@ -1847,6 +1945,8 @@ const (
 	GPU_RECOVERY_ACTION_DRAIN_P2P           DeviceGpuRecoveryAction = 3
 	GPU_RECOVERY_ACTION_DRAIN_AND_RESET     DeviceGpuRecoveryAction = 4
 	GPU_RECOVERY_ACTION_RECOVER_IMEX_DOMAIN DeviceGpuRecoveryAction = 5
+	GPU_RECOVERY_ACTION_BUS_RESET           DeviceGpuRecoveryAction = 6
+	GPU_RECOVERY_ACTION_SYSTEM_REBOOT       DeviceGpuRecoveryAction = 7
 )
 
 // FanState as declared in nvml/nvml.h
@@ -2032,6 +2132,50 @@ const (
 	GRID_LICENSE_FEATURE_CODE_VWORKSTATION GridLicenseFeatureCode = 2
 	GRID_LICENSE_FEATURE_CODE_GAMING       GridLicenseFeatureCode = 3
 	GRID_LICENSE_FEATURE_CODE_COMPUTE      GridLicenseFeatureCode = 4
+	GRID_LICENSE_FEATURE_CODE_VGAMEDEV     GridLicenseFeatureCode = 5
+)
+
+// GpuOperationalEventLogLevel as declared in nvml/nvml.h
+type GpuOperationalEventLogLevel int32
+
+// GpuOperationalEventLogLevel enumeration from nvml/nvml.h
+const (
+	GPU_OPERATIONAL_EVENT_LOG_LEVEL_ALL       GpuOperationalEventLogLevel = iota
+	GPU_OPERATIONAL_EVENT_LOG_LEVEL_TELEMETRY GpuOperationalEventLogLevel = 10
+	GPU_OPERATIONAL_EVENT_LOG_LEVEL_DIAG      GpuOperationalEventLogLevel = 20
+	GPU_OPERATIONAL_EVENT_LOG_LEVEL_NOTICE    GpuOperationalEventLogLevel = 30
+	GPU_OPERATIONAL_EVENT_LOG_LEVEL_WARNING   GpuOperationalEventLogLevel = 40
+	GPU_OPERATIONAL_EVENT_LOG_LEVEL_ERROR     GpuOperationalEventLogLevel = 50
+)
+
+// OperationalEventSeverity as declared in nvml/nvml.h
+type OperationalEventSeverity int32
+
+// OperationalEventSeverity enumeration from nvml/nvml.h
+const (
+	OPERATIONAL_EVENT_SEVERITY_ALL           OperationalEventSeverity = iota
+	OPERATIONAL_EVENT_SEVERITY_INFORMATIONAL OperationalEventSeverity = 10
+	OPERATIONAL_EVENT_SEVERITY_CORRECTED     OperationalEventSeverity = 20
+	OPERATIONAL_EVENT_SEVERITY_RECOVERABLE   OperationalEventSeverity = 30
+	OPERATIONAL_EVENT_SEVERITY_FATAL         OperationalEventSeverity = 40
+)
+
+// EventDataType as declared in nvml/nvml.h
+type EventDataType int32
+
+// EventDataType enumeration from nvml/nvml.h
+const (
+	EVENT_DATA_TYPE_NVML_EVENT            EventDataType = iota
+	EVENT_DATA_TYPE_GPU_OPERATIONAL_EVENT EventDataType = 1
+)
+
+// GpuOperationalEventContextType as declared in nvml/nvml.h
+type GpuOperationalEventContextType int32
+
+// GpuOperationalEventContextType enumeration from nvml/nvml.h
+const (
+	GPU_OPERATIONAL_EVENT_CONTEXT_TYPE_UNKNOWN    GpuOperationalEventContextType = iota
+	GPU_OPERATIONAL_EVENT_CONTEXT_TYPE_LEGACY_XID GpuOperationalEventContextType = 1
 )
 
 // CPERType as declared in nvml/nvml.h
@@ -2042,26 +2186,44 @@ const (
 	CPER_ACCESS_TYPE_GPU CPERType = 1
 )
 
+// NvlinkTelemetrySampleType as declared in nvml/nvml.h
+type NvlinkTelemetrySampleType int32
+
+// NvlinkTelemetrySampleType enumeration from nvml/nvml.h
+const (
+	NVLINK_TELEMETRY_SAMPLE_TYPE_THROUGHPUT_RAW_TX NvlinkTelemetrySampleType = iota
+	NVLINK_TELEMETRY_SAMPLE_TYPE_THROUGHPUT_RAW_RX NvlinkTelemetrySampleType = 1
+	NVLINK_TELEMETRY_SAMPLE_TYPE_COUNT             NvlinkTelemetrySampleType = 2
+)
+
 // PRMCounterId as declared in nvml/nvml.h
 type PRMCounterId int32
 
 // PRMCounterId enumeration from nvml/nvml.h
 const (
-	PRM_COUNTER_ID_NONE                                                 PRMCounterId = iota
-	PRM_COUNTER_ID_PPCNT_PHYSICAL_LAYER_CTRS_LINK_DOWN_EVENTS           PRMCounterId = 1
-	PRM_COUNTER_ID_PPCNT_PHYSICAL_LAYER_CTRS_SUCCESSFUL_RECOVERY_EVENTS PRMCounterId = 2
-	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_SUCCESSFUL_RECOVERY_EVENTS PRMCounterId = 101
-	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_SINCE_LAST_RECOVERY         PRMCounterId = 102
-	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_BETWEEN_LAST_TWO_RECOVERIES PRMCounterId = 103
-	PRM_COUNTER_ID_PPCNT_PORTCOUNTERS_PORT_XMIT_WAIT                    PRMCounterId = 201
-	PRM_COUNTER_ID_PPCNT_PLR_RCV_CODES                                  PRMCounterId = 301
-	PRM_COUNTER_ID_PPCNT_PLR_RCV_CODE_ERR                               PRMCounterId = 302
-	PRM_COUNTER_ID_PPCNT_PLR_RCV_UNCORRECTABLE_CODE                     PRMCounterId = 303
-	PRM_COUNTER_ID_PPCNT_PLR_XMIT_CODES                                 PRMCounterId = 304
-	PRM_COUNTER_ID_PPCNT_PLR_XMIT_RETRY_CODES                           PRMCounterId = 305
-	PRM_COUNTER_ID_PPCNT_PLR_XMIT_RETRY_EVENTS                          PRMCounterId = 306
-	PRM_COUNTER_ID_PPCNT_PLR_SYNC_EVENTS                                PRMCounterId = 307
-	PRM_COUNTER_ID_PPRM_OPER_RECOVERY                                   PRMCounterId = 1001
+	PRM_COUNTER_ID_NONE                                                                PRMCounterId = iota
+	PRM_COUNTER_ID_PPCNT_PHYSICAL_LAYER_CTRS_LINK_DOWN_EVENTS                          PRMCounterId = 1
+	PRM_COUNTER_ID_PPCNT_PHYSICAL_LAYER_CTRS_SUCCESSFUL_RECOVERY_EVENTS                PRMCounterId = 2
+	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_SUCCESSFUL_RECOVERY_EVENTS                PRMCounterId = 101
+	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_SINCE_LAST_RECOVERY                        PRMCounterId = 102
+	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_BETWEEN_LAST_TWO_RECOVERIES                PRMCounterId = 103
+	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_IN_LAST_HOST_SERDES_FEQ_RECOVERY           PRMCounterId = 104
+	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_TIME_IN_HOST_SERDES_FEQ_RECOVERY          PRMCounterId = 105
+	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_HOST_SERDES_FEQ_RECOVERY_COUNT            PRMCounterId = 106
+	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_HOST_SERDES_FEQ_SUCCESSFUL_RECOVERY_COUNT PRMCounterId = 107
+	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_LAST_HOST_SERDES_FEQ_ATTEMPTS_COUNT             PRMCounterId = 108
+	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_LAST_SUCCESSFUL_RECOVERY_STEP_ATTEMPTS          PRMCounterId = 109
+	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_LAST_SUCCESSFUL_RECOVERY_TIME                   PRMCounterId = 110
+	PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_SUCCESSFUL_RECOVERY_TIME                  PRMCounterId = 111
+	PRM_COUNTER_ID_PPCNT_PORTCOUNTERS_PORT_XMIT_WAIT                                   PRMCounterId = 201
+	PRM_COUNTER_ID_PPCNT_PLR_RCV_CODES                                                 PRMCounterId = 301
+	PRM_COUNTER_ID_PPCNT_PLR_RCV_CODE_ERR                                              PRMCounterId = 302
+	PRM_COUNTER_ID_PPCNT_PLR_RCV_UNCORRECTABLE_CODE                                    PRMCounterId = 303
+	PRM_COUNTER_ID_PPCNT_PLR_XMIT_CODES                                                PRMCounterId = 304
+	PRM_COUNTER_ID_PPCNT_PLR_XMIT_RETRY_CODES                                          PRMCounterId = 305
+	PRM_COUNTER_ID_PPCNT_PLR_XMIT_RETRY_EVENTS                                         PRMCounterId = 306
+	PRM_COUNTER_ID_PPCNT_PLR_SYNC_EVENTS                                               PRMCounterId = 307
+	PRM_COUNTER_ID_PPRM_OPER_RECOVERY                                                  PRMCounterId = 1001
 )
 
 // GpmMetricId as declared in nvml/nvml.h
@@ -2371,7 +2533,151 @@ const (
 	GPM_METRIC_NVLINK_L34_TX               GpmMetricId = 330
 	GPM_METRIC_NVLINK_L35_RX               GpmMetricId = 331
 	GPM_METRIC_NVLINK_L35_TX               GpmMetricId = 332
-	GPM_METRIC_MAX                         GpmMetricId = 333
+	GPM_METRIC_NVLINK_L36_RX               GpmMetricId = 333
+	GPM_METRIC_NVLINK_L36_TX               GpmMetricId = 334
+	GPM_METRIC_NVLINK_L37_RX               GpmMetricId = 335
+	GPM_METRIC_NVLINK_L37_TX               GpmMetricId = 336
+	GPM_METRIC_NVLINK_L38_RX               GpmMetricId = 337
+	GPM_METRIC_NVLINK_L38_TX               GpmMetricId = 338
+	GPM_METRIC_NVLINK_L39_RX               GpmMetricId = 339
+	GPM_METRIC_NVLINK_L39_TX               GpmMetricId = 340
+	GPM_METRIC_NVLINK_L40_RX               GpmMetricId = 341
+	GPM_METRIC_NVLINK_L40_TX               GpmMetricId = 342
+	GPM_METRIC_NVLINK_L41_RX               GpmMetricId = 343
+	GPM_METRIC_NVLINK_L41_TX               GpmMetricId = 344
+	GPM_METRIC_NVLINK_L42_RX               GpmMetricId = 345
+	GPM_METRIC_NVLINK_L42_TX               GpmMetricId = 346
+	GPM_METRIC_NVLINK_L43_RX               GpmMetricId = 347
+	GPM_METRIC_NVLINK_L43_TX               GpmMetricId = 348
+	GPM_METRIC_NVLINK_L44_RX               GpmMetricId = 349
+	GPM_METRIC_NVLINK_L44_TX               GpmMetricId = 350
+	GPM_METRIC_NVLINK_L45_RX               GpmMetricId = 351
+	GPM_METRIC_NVLINK_L45_TX               GpmMetricId = 352
+	GPM_METRIC_NVLINK_L46_RX               GpmMetricId = 353
+	GPM_METRIC_NVLINK_L46_TX               GpmMetricId = 354
+	GPM_METRIC_NVLINK_L47_RX               GpmMetricId = 355
+	GPM_METRIC_NVLINK_L47_TX               GpmMetricId = 356
+	GPM_METRIC_NVLINK_L48_RX               GpmMetricId = 357
+	GPM_METRIC_NVLINK_L48_TX               GpmMetricId = 358
+	GPM_METRIC_NVLINK_L49_RX               GpmMetricId = 359
+	GPM_METRIC_NVLINK_L49_TX               GpmMetricId = 360
+	GPM_METRIC_NVLINK_L50_RX               GpmMetricId = 361
+	GPM_METRIC_NVLINK_L50_TX               GpmMetricId = 362
+	GPM_METRIC_NVLINK_L51_RX               GpmMetricId = 363
+	GPM_METRIC_NVLINK_L51_TX               GpmMetricId = 364
+	GPM_METRIC_NVLINK_L52_RX               GpmMetricId = 365
+	GPM_METRIC_NVLINK_L52_TX               GpmMetricId = 366
+	GPM_METRIC_NVLINK_L53_RX               GpmMetricId = 367
+	GPM_METRIC_NVLINK_L53_TX               GpmMetricId = 368
+	GPM_METRIC_NVLINK_L54_RX               GpmMetricId = 369
+	GPM_METRIC_NVLINK_L54_TX               GpmMetricId = 370
+	GPM_METRIC_NVLINK_L55_RX               GpmMetricId = 371
+	GPM_METRIC_NVLINK_L55_TX               GpmMetricId = 372
+	GPM_METRIC_NVLINK_L56_RX               GpmMetricId = 373
+	GPM_METRIC_NVLINK_L56_TX               GpmMetricId = 374
+	GPM_METRIC_NVLINK_L57_RX               GpmMetricId = 375
+	GPM_METRIC_NVLINK_L57_TX               GpmMetricId = 376
+	GPM_METRIC_NVLINK_L58_RX               GpmMetricId = 377
+	GPM_METRIC_NVLINK_L58_TX               GpmMetricId = 378
+	GPM_METRIC_NVLINK_L59_RX               GpmMetricId = 379
+	GPM_METRIC_NVLINK_L59_TX               GpmMetricId = 380
+	GPM_METRIC_NVLINK_L60_RX               GpmMetricId = 381
+	GPM_METRIC_NVLINK_L60_TX               GpmMetricId = 382
+	GPM_METRIC_NVLINK_L61_RX               GpmMetricId = 383
+	GPM_METRIC_NVLINK_L61_TX               GpmMetricId = 384
+	GPM_METRIC_NVLINK_L62_RX               GpmMetricId = 385
+	GPM_METRIC_NVLINK_L62_TX               GpmMetricId = 386
+	GPM_METRIC_NVLINK_L63_RX               GpmMetricId = 387
+	GPM_METRIC_NVLINK_L63_TX               GpmMetricId = 388
+	GPM_METRIC_NVLINK_L64_RX               GpmMetricId = 389
+	GPM_METRIC_NVLINK_L64_TX               GpmMetricId = 390
+	GPM_METRIC_NVLINK_L65_RX               GpmMetricId = 391
+	GPM_METRIC_NVLINK_L65_TX               GpmMetricId = 392
+	GPM_METRIC_NVLINK_L66_RX               GpmMetricId = 393
+	GPM_METRIC_NVLINK_L66_TX               GpmMetricId = 394
+	GPM_METRIC_NVLINK_L67_RX               GpmMetricId = 395
+	GPM_METRIC_NVLINK_L67_TX               GpmMetricId = 396
+	GPM_METRIC_NVLINK_L68_RX               GpmMetricId = 397
+	GPM_METRIC_NVLINK_L68_TX               GpmMetricId = 398
+	GPM_METRIC_NVLINK_L69_RX               GpmMetricId = 399
+	GPM_METRIC_NVLINK_L69_TX               GpmMetricId = 400
+	GPM_METRIC_NVLINK_L70_RX               GpmMetricId = 401
+	GPM_METRIC_NVLINK_L70_TX               GpmMetricId = 402
+	GPM_METRIC_NVLINK_L71_RX               GpmMetricId = 403
+	GPM_METRIC_NVLINK_L71_TX               GpmMetricId = 404
+	GPM_METRIC_NVLINK_L36_RX_PER_SEC       GpmMetricId = 405
+	GPM_METRIC_NVLINK_L36_TX_PER_SEC       GpmMetricId = 406
+	GPM_METRIC_NVLINK_L37_RX_PER_SEC       GpmMetricId = 407
+	GPM_METRIC_NVLINK_L37_TX_PER_SEC       GpmMetricId = 408
+	GPM_METRIC_NVLINK_L38_RX_PER_SEC       GpmMetricId = 409
+	GPM_METRIC_NVLINK_L38_TX_PER_SEC       GpmMetricId = 410
+	GPM_METRIC_NVLINK_L39_RX_PER_SEC       GpmMetricId = 411
+	GPM_METRIC_NVLINK_L39_TX_PER_SEC       GpmMetricId = 412
+	GPM_METRIC_NVLINK_L40_RX_PER_SEC       GpmMetricId = 413
+	GPM_METRIC_NVLINK_L40_TX_PER_SEC       GpmMetricId = 414
+	GPM_METRIC_NVLINK_L41_RX_PER_SEC       GpmMetricId = 415
+	GPM_METRIC_NVLINK_L41_TX_PER_SEC       GpmMetricId = 416
+	GPM_METRIC_NVLINK_L42_RX_PER_SEC       GpmMetricId = 417
+	GPM_METRIC_NVLINK_L42_TX_PER_SEC       GpmMetricId = 418
+	GPM_METRIC_NVLINK_L43_RX_PER_SEC       GpmMetricId = 419
+	GPM_METRIC_NVLINK_L43_TX_PER_SEC       GpmMetricId = 420
+	GPM_METRIC_NVLINK_L44_RX_PER_SEC       GpmMetricId = 421
+	GPM_METRIC_NVLINK_L44_TX_PER_SEC       GpmMetricId = 422
+	GPM_METRIC_NVLINK_L45_RX_PER_SEC       GpmMetricId = 423
+	GPM_METRIC_NVLINK_L45_TX_PER_SEC       GpmMetricId = 424
+	GPM_METRIC_NVLINK_L46_RX_PER_SEC       GpmMetricId = 425
+	GPM_METRIC_NVLINK_L46_TX_PER_SEC       GpmMetricId = 426
+	GPM_METRIC_NVLINK_L47_RX_PER_SEC       GpmMetricId = 427
+	GPM_METRIC_NVLINK_L47_TX_PER_SEC       GpmMetricId = 428
+	GPM_METRIC_NVLINK_L48_RX_PER_SEC       GpmMetricId = 429
+	GPM_METRIC_NVLINK_L48_TX_PER_SEC       GpmMetricId = 430
+	GPM_METRIC_NVLINK_L49_RX_PER_SEC       GpmMetricId = 431
+	GPM_METRIC_NVLINK_L49_TX_PER_SEC       GpmMetricId = 432
+	GPM_METRIC_NVLINK_L50_RX_PER_SEC       GpmMetricId = 433
+	GPM_METRIC_NVLINK_L50_TX_PER_SEC       GpmMetricId = 434
+	GPM_METRIC_NVLINK_L51_RX_PER_SEC       GpmMetricId = 435
+	GPM_METRIC_NVLINK_L51_TX_PER_SEC       GpmMetricId = 436
+	GPM_METRIC_NVLINK_L52_RX_PER_SEC       GpmMetricId = 437
+	GPM_METRIC_NVLINK_L52_TX_PER_SEC       GpmMetricId = 438
+	GPM_METRIC_NVLINK_L53_RX_PER_SEC       GpmMetricId = 439
+	GPM_METRIC_NVLINK_L53_TX_PER_SEC       GpmMetricId = 440
+	GPM_METRIC_NVLINK_L54_RX_PER_SEC       GpmMetricId = 441
+	GPM_METRIC_NVLINK_L54_TX_PER_SEC       GpmMetricId = 442
+	GPM_METRIC_NVLINK_L55_RX_PER_SEC       GpmMetricId = 443
+	GPM_METRIC_NVLINK_L55_TX_PER_SEC       GpmMetricId = 444
+	GPM_METRIC_NVLINK_L56_RX_PER_SEC       GpmMetricId = 445
+	GPM_METRIC_NVLINK_L56_TX_PER_SEC       GpmMetricId = 446
+	GPM_METRIC_NVLINK_L57_RX_PER_SEC       GpmMetricId = 447
+	GPM_METRIC_NVLINK_L57_TX_PER_SEC       GpmMetricId = 448
+	GPM_METRIC_NVLINK_L58_RX_PER_SEC       GpmMetricId = 449
+	GPM_METRIC_NVLINK_L58_TX_PER_SEC       GpmMetricId = 450
+	GPM_METRIC_NVLINK_L59_RX_PER_SEC       GpmMetricId = 451
+	GPM_METRIC_NVLINK_L59_TX_PER_SEC       GpmMetricId = 452
+	GPM_METRIC_NVLINK_L60_RX_PER_SEC       GpmMetricId = 453
+	GPM_METRIC_NVLINK_L60_TX_PER_SEC       GpmMetricId = 454
+	GPM_METRIC_NVLINK_L61_RX_PER_SEC       GpmMetricId = 455
+	GPM_METRIC_NVLINK_L61_TX_PER_SEC       GpmMetricId = 456
+	GPM_METRIC_NVLINK_L62_RX_PER_SEC       GpmMetricId = 457
+	GPM_METRIC_NVLINK_L62_TX_PER_SEC       GpmMetricId = 458
+	GPM_METRIC_NVLINK_L63_RX_PER_SEC       GpmMetricId = 459
+	GPM_METRIC_NVLINK_L63_TX_PER_SEC       GpmMetricId = 460
+	GPM_METRIC_NVLINK_L64_RX_PER_SEC       GpmMetricId = 461
+	GPM_METRIC_NVLINK_L64_TX_PER_SEC       GpmMetricId = 462
+	GPM_METRIC_NVLINK_L65_RX_PER_SEC       GpmMetricId = 463
+	GPM_METRIC_NVLINK_L65_TX_PER_SEC       GpmMetricId = 464
+	GPM_METRIC_NVLINK_L66_RX_PER_SEC       GpmMetricId = 465
+	GPM_METRIC_NVLINK_L66_TX_PER_SEC       GpmMetricId = 466
+	GPM_METRIC_NVLINK_L67_RX_PER_SEC       GpmMetricId = 467
+	GPM_METRIC_NVLINK_L67_TX_PER_SEC       GpmMetricId = 468
+	GPM_METRIC_NVLINK_L68_RX_PER_SEC       GpmMetricId = 469
+	GPM_METRIC_NVLINK_L68_TX_PER_SEC       GpmMetricId = 470
+	GPM_METRIC_NVLINK_L69_RX_PER_SEC       GpmMetricId = 471
+	GPM_METRIC_NVLINK_L69_TX_PER_SEC       GpmMetricId = 472
+	GPM_METRIC_NVLINK_L70_RX_PER_SEC       GpmMetricId = 473
+	GPM_METRIC_NVLINK_L70_TX_PER_SEC       GpmMetricId = 474
+	GPM_METRIC_NVLINK_L71_RX_PER_SEC       GpmMetricId = 475
+	GPM_METRIC_NVLINK_L71_TX_PER_SEC       GpmMetricId = 476
+	GPM_METRIC_MAX                         GpmMetricId = 477
 )
 
 // PowerProfileType as declared in nvml/nvml.h
@@ -2379,22 +2685,32 @@ type PowerProfileType int32
 
 // PowerProfileType enumeration from nvml/nvml.h
 const (
-	POWER_PROFILE_MAX_P         PowerProfileType = iota
-	POWER_PROFILE_MAX_Q         PowerProfileType = 1
-	POWER_PROFILE_COMPUTE       PowerProfileType = 2
-	POWER_PROFILE_MEMORY_BOUND  PowerProfileType = 3
-	POWER_PROFILE_NETWORK       PowerProfileType = 4
-	POWER_PROFILE_BALANCED      PowerProfileType = 5
-	POWER_PROFILE_LLM_INFERENCE PowerProfileType = 6
-	POWER_PROFILE_LLM_TRAINING  PowerProfileType = 7
-	POWER_PROFILE_RBM           PowerProfileType = 8
-	POWER_PROFILE_DCPCIE        PowerProfileType = 9
-	POWER_PROFILE_HMMA_SPARSE   PowerProfileType = 10
-	POWER_PROFILE_HMMA_DENSE    PowerProfileType = 11
-	POWER_PROFILE_SYNC_BALANCED PowerProfileType = 12
-	POWER_PROFILE_HPC           PowerProfileType = 13
-	POWER_PROFILE_MIG           PowerProfileType = 14
-	POWER_PROFILE_MAX           PowerProfileType = 15
+	POWER_PROFILE_MAX_P                       PowerProfileType = iota
+	POWER_PROFILE_MAX_Q                       PowerProfileType = 1
+	POWER_PROFILE_COMPUTE                     PowerProfileType = 2
+	POWER_PROFILE_MEMORY_BOUND                PowerProfileType = 3
+	POWER_PROFILE_NETWORK                     PowerProfileType = 4
+	POWER_PROFILE_BALANCED                    PowerProfileType = 5
+	POWER_PROFILE_LLM_INFERENCE               PowerProfileType = 6
+	POWER_PROFILE_LLM_TRAINING                PowerProfileType = 7
+	POWER_PROFILE_RBM                         PowerProfileType = 8
+	POWER_PROFILE_DCPCIE                      PowerProfileType = 9
+	POWER_PROFILE_HMMA_SPARSE                 PowerProfileType = 10
+	POWER_PROFILE_HMMA_DENSE                  PowerProfileType = 11
+	POWER_PROFILE_SYNC_BALANCED               PowerProfileType = 12
+	POWER_PROFILE_HPC                         PowerProfileType = 13
+	POWER_PROFILE_MIG                         PowerProfileType = 14
+	POWER_PROFILE_MAX_Q_1                     PowerProfileType = 15
+	POWER_PROFILE_NETWORK_BOUND               PowerProfileType = 16
+	POWER_PROFILE_HIGH_THROUGHPUT_INFERENCE   PowerProfileType = 17
+	POWER_PROFILE_MEDIUM_THROUGHPUT_INFERENCE PowerProfileType = 18
+	POWER_PROFILE_LOW_LATENCY_INFERENCE       PowerProfileType = 19
+	POWER_PROFILE_TRAINING                    PowerProfileType = 20
+	POWER_PROFILE_INFERENCE                   PowerProfileType = 21
+	POWER_PROFILE_MAX_Q_2                     PowerProfileType = 22
+	POWER_PROFILE_MAX_Q_3                     PowerProfileType = 23
+	POWER_PROFILE_LOW_PRIORITY_BACKGROUND     PowerProfileType = 24
+	POWER_PROFILE_MAX                         PowerProfileType = 25
 )
 
 // PowerProfileOperation as declared in nvml/nvml.h

--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -817,6 +817,60 @@ func (device nvmlDevice) GetEnforcedPowerLimit() (uint32, Return) {
 	return limit, ret
 }
 
+func (l *library) DeviceSetMemoryLimits_v1(device Device, namespace string, requests uint64, limits uint64) Return {
+	return device.SetMemoryLimits_v1(namespace, requests, limits)
+}
+
+func (device nvmlDevice) SetMemoryLimits_v1(namespace string, requests uint64, limits uint64) Return {
+	d := &SetMemoryLimits_v1{}
+	cptr := stringToCPtr(namespace)
+	defer free(cptr)
+	d.NameSpace = (*int8)(cptr)
+	d.SoftLimit = requests
+	d.HardLimit = limits
+	return nvmlDeviceSetMemoryLimits_v1(device, d)
+}
+
+// nvml.DeviceGetMemoryLimits_v1()
+func (l *library) DeviceGetMemoryLimits_v1(device Device, namespace string) (MemoryLimits_v1, Return) {
+	return device.GetMemoryLimits_v1(namespace)
+}
+
+func (device nvmlDevice) GetMemoryLimits_v1(namespace string) (MemoryLimits_v1, Return) {
+	d := &GetMemoryLimits_v1{}
+	cptr := stringToCPtr(namespace)
+	defer free(cptr)
+	d.NameSpace = (*int8)(cptr)
+	ret := nvmlDeviceGetMemoryLimits_v1(device, d)
+	resp := MemoryLimits_v1{
+		NameSpace:   int8PtrToString(d.NameSpace),
+		SoftLimit:   d.SoftLimit,
+		HardLimit:   d.HardLimit,
+		CurrentUsed: d.CurrentUsed,
+	}
+	return resp, ret
+}
+
+// nvml.DeviceSetAdaptiveTgpMode_v1()
+func (l *library) DeviceSetAdaptiveTgpMode_v1(device Device, mode EnableState) Return {
+	return device.SetAdaptiveTgpMode_v1(mode)
+}
+
+func (device nvmlDevice) SetAdaptiveTgpMode_v1(mode EnableState) Return {
+	return nvmlDeviceSetAdaptiveTgpMode_v1(device, mode)
+}
+
+// nvml.DeviceGetAdaptiveTgpModeInfo_v1()
+func (l *library) DeviceGetAdaptiveTgpModeInfo_v1(device Device) (AdaptiveTgpModeInfo_v1, Return) {
+	return device.GetAdaptiveTgpModeInfo_v1()
+}
+
+func (device nvmlDevice) GetAdaptiveTgpModeInfo_v1() (AdaptiveTgpModeInfo_v1, Return) {
+	var info AdaptiveTgpModeInfo_v1
+	ret := nvmlDeviceGetAdaptiveTgpModeInfo_v1(device, &info)
+	return info, ret
+}
+
 // nvml.DeviceGetGpuOperationMode()
 func (l *library) DeviceGetGpuOperationMode(device Device) (GpuOperationMode, GpuOperationMode, Return) {
 	return device.GetGpuOperationMode()
@@ -1416,6 +1470,16 @@ func (device nvmlDevice) GetHostname_v1() (string, Return) {
 	var hostName Hostname_v1
 	ret := nvmlDeviceGetHostname_v1(device, &hostName)
 	return int8SliceToString(hostName.Value[:]), ret
+}
+
+func (l *library) DevicePerfMetricsGetSamples_v1(device Device) (PerfMetricsSamples_v1, Return) {
+	return device.PerfMetricsGetSamples_v1()
+}
+
+func (device nvmlDevice) PerfMetricsGetSamples_v1() (PerfMetricsSamples_v1, Return) {
+	var samples PerfMetricsSamples_v1
+	ret := nvmlDevicePerfMetricsGetSamples_v1(device, &samples)
+	return samples, ret
 }
 
 // nvml.DeviceGetAccountingStats()
@@ -3267,6 +3331,16 @@ func (device nvmlDevice) GetGpuFabricInfoV() GpuFabricInfoHandler {
 	return GpuFabricInfoHandler{device}
 }
 
+func (l *library) DeviceGetGpuFabricInfo_v4(device Device) (GpuFabricInfo_v4, Return) {
+	return device.GetGpuFabricInfo_v4()
+}
+
+func (device nvmlDevice) GetGpuFabricInfo_v4() (GpuFabricInfo_v4, Return) {
+	var info GpuFabricInfo_v4
+	ret := nvmlDeviceGetGpuFabricInfo_v4(device, &info)
+	return info, ret
+}
+
 // nvml.DeviceGetProcessesUtilizationInfo()
 func (l *library) DeviceGetProcessesUtilizationInfo(device Device) (ProcessesUtilizationInfo, Return) {
 	return device.GetProcessesUtilizationInfo()
@@ -3572,6 +3646,14 @@ func (device nvmlDevice) SetNvlinkBwMode(setBwMode *NvlinkSetBwMode) Return {
 	return nvmlDeviceSetNvlinkBwMode(device, setBwMode)
 }
 
+func (l *library) DeviceSetNvlinkBwModeAsync_v1(device Device, setBwMode *NvlinkSetBwModeAsync_v1) Return {
+	return device.SetNvlinkBwModeAsync_v1(setBwMode)
+}
+
+func (device nvmlDevice) SetNvlinkBwModeAsync_v1(setBwMode *NvlinkSetBwModeAsync_v1) Return {
+	return nvmlDeviceSetNvlinkBwModeAsync_v1(device, setBwMode)
+}
+
 func (l *library) DeviceGetNvLinkInfo(device Device) NvLinkInfoHandler {
 	return device.GetNvLinkInfo()
 }
@@ -3598,6 +3680,28 @@ func (handler NvLinkInfoHandler) V2() (NvLinkInfo_v2, Return) {
 	ret := nvmlDeviceGetNvLinkInfo(handler.device, (*NvLinkInfo)(unsafe.Pointer(&info)))
 
 	return info, ret
+}
+
+// nvml.DeviceGetNvLinkTelemetrySamples_v1()
+func (l *library) DeviceGetNvLinkTelemetrySamples_v1(device Device, samples NvlinkTelemetrySamples_v1) (NvlinkTelemetrySamples_v1, Return) {
+	return device.GetNvLinkTelemetrySamples_v1(samples)
+}
+
+func (device nvmlDevice) GetNvLinkTelemetrySamples_v1(samples NvlinkTelemetrySamples_v1) (NvlinkTelemetrySamples_v1, Return) {
+	var pinner runtime.Pinner
+	defer pinner.Unpin()
+
+	if samples.TelemetrySamples != nil && samples.TelemetryCount > 0 {
+		pinner.Pin(samples.TelemetrySamples)
+		entries := unsafe.Slice(samples.TelemetrySamples, samples.TelemetryCount)
+		for _, entry := range entries {
+			if entry.Samples != nil && entry.SampleCount > 0 {
+				pinner.Pin(entry.Samples)
+			}
+		}
+	}
+	ret := nvmlDeviceGetNvLinkTelemetrySamples_v1(device, &samples)
+	return samples, ret
 }
 
 // nvml.DeviceWorkloadPowerProfileGetProfilesInfo()
@@ -3700,9 +3804,21 @@ func (device nvmlDevice) GetSramUniqueUncorrectedEccErrorCounts(errorCounts *Ecc
 func (l *library) DeviceSetRusdSettings_v1(device Device, settings RusdSettings_v1) Return {
 	return device.SetRusdSettings_v1(settings)
 }
+
 func (device nvmlDevice) SetRusdSettings_v1(settings RusdSettings_v1) Return {
 	settings.Version = STRUCT_VERSION(settings, 1)
 	return nvmlDeviceSetRusdSettings_v1(device, &settings)
+}
+
+// nvml.DeviceGetBankRemapperStatus_v1()
+func (l *library) DeviceGetBankRemapperStatus_v1(device Device) (EccBankRemapperStatus_v1, Return) {
+	return device.GetBankRemapperStatus_v1()
+}
+
+func (device nvmlDevice) GetBankRemapperStatus_v1() (EccBankRemapperStatus_v1, Return) {
+	var status EccBankRemapperStatus_v1
+	ret := nvmlDeviceGetBankRemapperStatus_v1(device, &status)
+	return status, ret
 }
 
 func (l *library) DeviceGetRemappedRows_v2(device Device) (RemappedRowsInfo_v2, Return) {

--- a/pkg/nvml/event_set.go
+++ b/pkg/nvml/event_set.go
@@ -14,6 +14,8 @@
 
 package nvml
 
+import "runtime"
+
 // EventData includes an interface type for Device instead of nvmlDevice
 type EventData struct {
 	Device            Device
@@ -50,6 +52,72 @@ func (set nvmlEventSet) Wait(timeoutms uint32) (EventData, Return) {
 	var data nvmlEventData
 	ret := nvmlEventSetWait(set, &data, timeoutms)
 	return data.convert(), ret
+}
+
+func (l *library) EventSetRegisterGpuOperationalEvents_v1(set EventSet, config *GpuOperationalEventConfig_v1) Return {
+	return set.RegisterGpuOperationalEvents_v1(config)
+}
+
+func (set nvmlEventSet) RegisterGpuOperationalEvents_v1(config *GpuOperationalEventConfig_v1) Return {
+	return nvmlEventSetRegisterGpuOperationalEvents_v1(set, config)
+}
+
+func (l *library) EventSetWait_v3(set EventSet, timeoutms uint32) (EventSetWaitData_v3, Return) {
+	return set.Wait_v3(timeoutms)
+}
+
+func (set nvmlEventSet) Wait_v3(timeoutms uint32) (EventSetWaitData_v3, Return) {
+	var data EventSetWaitData_v3
+	data.TimeoutMs = timeoutms
+	ret := nvmlEventSetWait_v3(set, &data)
+	return data, ret
+}
+
+func (l *library) EventSetGetContextCount_v1(set EventSet) (GetContextCount_v1, Return) {
+	return set.GetContextCount_v1()
+}
+
+func (set nvmlEventSet) GetContextCount_v1() (GetContextCount_v1, Return) {
+	var count GetContextCount_v1
+	ret := nvmlEventSetGetContextCount_v1(set, &count)
+	return count, ret
+}
+
+func (l *library) EventSetGetContextInfo_v1(set EventSet, index uint32) (GetContextInfo_v1, Return) {
+	return set.GetContextInfo_v1(index)
+}
+
+func (set nvmlEventSet) GetContextInfo_v1(index uint32) (GetContextInfo_v1, Return) {
+	var info GetContextInfo_v1
+	info.Index = index
+	ret := nvmlEventSetGetContextInfo_v1(set, &info)
+	return info, ret
+}
+
+func (l *library) EventSetGetContextData_v1(set EventSet, data GetContextData_v1) (GetContextData_v1, Return) {
+	return set.GetContextData_v1(data)
+}
+
+func (set nvmlEventSet) GetContextData_v1(data GetContextData_v1) (GetContextData_v1, Return) {
+	var pinner runtime.Pinner
+	defer pinner.Unpin()
+
+	if data.Data != nil && data.DataSize > 0 {
+		pinner.Pin(data.Data)
+	}
+	ret := nvmlEventSetGetContextData_v1(set, &data)
+	return data, ret
+}
+
+func (l *library) EventSetGetGpuOperationalEventContextLegacyXid_v1(set EventSet, index uint32) (uint32, Return) {
+	return set.GetGpuOperationalEventContextLegacyXid_v1(index)
+}
+
+func (set nvmlEventSet) GetGpuOperationalEventContextLegacyXid_v1(index uint32) (uint32, Return) {
+	var params GetGpuOperationalEventContextLegacyXid_v1
+	params.Index = index
+	ret := nvmlEventSetGetGpuOperationalEventContextLegacyXid_v1(set, &params)
+	return params.XidCode, ret
 }
 
 // nvml.EventSetFree()

--- a/pkg/nvml/gpm.go
+++ b/pkg/nvml/gpm.go
@@ -20,7 +20,7 @@ type GpmMetricsGetType struct {
 	NumMetrics uint32
 	Sample1    GpmSample
 	Sample2    GpmSample
-	Metrics    [333]GpmMetric
+	Metrics    [477]GpmMetric
 }
 
 func (g *GpmMetricsGetType) convert() *nvmlGpmMetricsGetType {

--- a/pkg/nvml/gpm_test.go
+++ b/pkg/nvml/gpm_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestGpmMetricsGet(t *testing.T) {
-	overrideMetrics := [333]GpmMetric{
+	overrideMetrics := [477]GpmMetric{
 		{
 			Value: 99,
 		},
@@ -46,7 +46,7 @@ func TestGpmMetricsGet(t *testing.T) {
 }
 
 func TestGpmMetricsGetV(t *testing.T) {
-	overrideMetrics := [333]GpmMetric{
+	overrideMetrics := [477]GpmMetric{
 		{
 			Value: 99,
 		},

--- a/pkg/nvml/memory_limits.go
+++ b/pkg/nvml/memory_limits.go
@@ -1,0 +1,23 @@
+// Copyright (c) NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package nvml
+
+// MemoryLimits_v1 is the go-friendly wrapper struct of GetMemoryLimits_v1
+type MemoryLimits_v1 struct {
+	NameSpace   string
+	SoftLimit   uint64
+	HardLimit   uint64
+	CurrentUsed uint64
+}

--- a/pkg/nvml/mock/device.go
+++ b/pkg/nvml/mock/device.go
@@ -63,6 +63,9 @@ var _ nvml.Device = &Device{}
 //			GetAdaptiveClockInfoStatusFunc: func() (uint32, nvml.Return) {
 //				panic("mock out the GetAdaptiveClockInfoStatus method")
 //			},
+//			GetAdaptiveTgpModeInfo_v1Func: func() (nvml.AdaptiveTgpModeInfo_v1, nvml.Return) {
+//				panic("mock out the GetAdaptiveTgpModeInfo_v1 method")
+//			},
 //			GetAddressingModeFunc: func() (nvml.DeviceAddressingMode, nvml.Return) {
 //				panic("mock out the GetAddressingMode method")
 //			},
@@ -83,6 +86,9 @@ var _ nvml.Device = &Device{}
 //			},
 //			GetBBXTimeData_v1Func: func() (nvml.BBXTimeData_v1, nvml.Return) {
 //				panic("mock out the GetBBXTimeData_v1 method")
+//			},
+//			GetBankRemapperStatus_v1Func: func() (nvml.EccBankRemapperStatus_v1, nvml.Return) {
+//				panic("mock out the GetBankRemapperStatus_v1 method")
 //			},
 //			GetBoardIdFunc: func() (uint32, nvml.Return) {
 //				panic("mock out the GetBoardId method")
@@ -252,6 +258,9 @@ var _ nvml.Device = &Device{}
 //			GetGpuFabricInfoVFunc: func() nvml.GpuFabricInfoHandler {
 //				panic("mock out the GetGpuFabricInfoV method")
 //			},
+//			GetGpuFabricInfo_v4Func: func() (nvml.GpuFabricInfo_v4, nvml.Return) {
+//				panic("mock out the GetGpuFabricInfo_v4 method")
+//			},
 //			GetGpuInstanceByIdFunc: func(n int) (nvml.GpuInstance, nvml.Return) {
 //				panic("mock out the GetGpuInstanceById method")
 //			},
@@ -363,6 +372,9 @@ var _ nvml.Device = &Device{}
 //			GetMemoryInfo_v2Func: func() (nvml.Memory_v2, nvml.Return) {
 //				panic("mock out the GetMemoryInfo_v2 method")
 //			},
+//			GetMemoryLimits_v1Func: func(s string) (nvml.MemoryLimits_v1, nvml.Return) {
+//				panic("mock out the GetMemoryLimits_v1 method")
+//			},
 //			GetMigDeviceHandleByIndexFunc: func(n int) (nvml.Device, nvml.Return) {
 //				panic("mock out the GetMigDeviceHandleByIndex method")
 //			},
@@ -413,6 +425,9 @@ var _ nvml.Device = &Device{}
 //			},
 //			GetNvLinkStateFunc: func(n int) (nvml.EnableState, nvml.Return) {
 //				panic("mock out the GetNvLinkState method")
+//			},
+//			GetNvLinkTelemetrySamples_v1Func: func(nvlinkTelemetrySamples_v1 nvml.NvlinkTelemetrySamples_v1) (nvml.NvlinkTelemetrySamples_v1, nvml.Return) {
+//				panic("mock out the GetNvLinkTelemetrySamples_v1 method")
 //			},
 //			GetNvLinkUtilizationControlFunc: func(n1 int, n2 int) (nvml.NvLinkUtilizationControl, nvml.Return) {
 //				panic("mock out the GetNvLinkUtilizationControl method")
@@ -669,6 +684,9 @@ var _ nvml.Device = &Device{}
 //			OnSameBoardFunc: func(device nvml.Device) (int, nvml.Return) {
 //				panic("mock out the OnSameBoard method")
 //			},
+//			PerfMetricsGetSamples_v1Func: func() (nvml.PerfMetricsSamples_v1, nvml.Return) {
+//				panic("mock out the PerfMetricsGetSamples_v1 method")
+//			},
 //			PowerSmoothingActivatePresetProfileFunc: func(powerSmoothingProfile *nvml.PowerSmoothingProfile) nvml.Return {
 //				panic("mock out the PowerSmoothingActivatePresetProfile method")
 //			},
@@ -707,6 +725,9 @@ var _ nvml.Device = &Device{}
 //			},
 //			SetAccountingModeFunc: func(enableState nvml.EnableState) nvml.Return {
 //				panic("mock out the SetAccountingMode method")
+//			},
+//			SetAdaptiveTgpMode_v1Func: func(enableState nvml.EnableState) nvml.Return {
+//				panic("mock out the SetAdaptiveTgpMode_v1 method")
 //			},
 //			SetApplicationsClocksFunc: func(v1 uint32, v2 uint32) nvml.Return {
 //				panic("mock out the SetApplicationsClocks method")
@@ -762,6 +783,9 @@ var _ nvml.Device = &Device{}
 //			SetMemClkVfOffsetFunc: func(n int) nvml.Return {
 //				panic("mock out the SetMemClkVfOffset method")
 //			},
+//			SetMemoryLimits_v1Func: func(s string, v1 uint64, v2 uint64) nvml.Return {
+//				panic("mock out the SetMemoryLimits_v1 method")
+//			},
 //			SetMemoryLockedClocksFunc: func(v1 uint32, v2 uint32) nvml.Return {
 //				panic("mock out the SetMemoryLockedClocks method")
 //			},
@@ -776,6 +800,9 @@ var _ nvml.Device = &Device{}
 //			},
 //			SetNvlinkBwModeFunc: func(nvlinkSetBwMode *nvml.NvlinkSetBwMode) nvml.Return {
 //				panic("mock out the SetNvlinkBwMode method")
+//			},
+//			SetNvlinkBwModeAsync_v1Func: func(nvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1) nvml.Return {
+//				panic("mock out the SetNvlinkBwModeAsync_v1 method")
 //			},
 //			SetPersistenceModeFunc: func(enableState nvml.EnableState) nvml.Return {
 //				panic("mock out the SetPersistenceMode method")
@@ -883,6 +910,9 @@ type Device struct {
 	// GetAdaptiveClockInfoStatusFunc mocks the GetAdaptiveClockInfoStatus method.
 	GetAdaptiveClockInfoStatusFunc func() (uint32, nvml.Return)
 
+	// GetAdaptiveTgpModeInfo_v1Func mocks the GetAdaptiveTgpModeInfo_v1 method.
+	GetAdaptiveTgpModeInfo_v1Func func() (nvml.AdaptiveTgpModeInfo_v1, nvml.Return)
+
 	// GetAddressingModeFunc mocks the GetAddressingMode method.
 	GetAddressingModeFunc func() (nvml.DeviceAddressingMode, nvml.Return)
 
@@ -903,6 +933,9 @@ type Device struct {
 
 	// GetBBXTimeData_v1Func mocks the GetBBXTimeData_v1 method.
 	GetBBXTimeData_v1Func func() (nvml.BBXTimeData_v1, nvml.Return)
+
+	// GetBankRemapperStatus_v1Func mocks the GetBankRemapperStatus_v1 method.
+	GetBankRemapperStatus_v1Func func() (nvml.EccBankRemapperStatus_v1, nvml.Return)
 
 	// GetBoardIdFunc mocks the GetBoardId method.
 	GetBoardIdFunc func() (uint32, nvml.Return)
@@ -1072,6 +1105,9 @@ type Device struct {
 	// GetGpuFabricInfoVFunc mocks the GetGpuFabricInfoV method.
 	GetGpuFabricInfoVFunc func() nvml.GpuFabricInfoHandler
 
+	// GetGpuFabricInfo_v4Func mocks the GetGpuFabricInfo_v4 method.
+	GetGpuFabricInfo_v4Func func() (nvml.GpuFabricInfo_v4, nvml.Return)
+
 	// GetGpuInstanceByIdFunc mocks the GetGpuInstanceById method.
 	GetGpuInstanceByIdFunc func(n int) (nvml.GpuInstance, nvml.Return)
 
@@ -1183,6 +1219,9 @@ type Device struct {
 	// GetMemoryInfo_v2Func mocks the GetMemoryInfo_v2 method.
 	GetMemoryInfo_v2Func func() (nvml.Memory_v2, nvml.Return)
 
+	// GetMemoryLimits_v1Func mocks the GetMemoryLimits_v1 method.
+	GetMemoryLimits_v1Func func(s string) (nvml.MemoryLimits_v1, nvml.Return)
+
 	// GetMigDeviceHandleByIndexFunc mocks the GetMigDeviceHandleByIndex method.
 	GetMigDeviceHandleByIndexFunc func(n int) (nvml.Device, nvml.Return)
 
@@ -1233,6 +1272,9 @@ type Device struct {
 
 	// GetNvLinkStateFunc mocks the GetNvLinkState method.
 	GetNvLinkStateFunc func(n int) (nvml.EnableState, nvml.Return)
+
+	// GetNvLinkTelemetrySamples_v1Func mocks the GetNvLinkTelemetrySamples_v1 method.
+	GetNvLinkTelemetrySamples_v1Func func(nvlinkTelemetrySamples_v1 nvml.NvlinkTelemetrySamples_v1) (nvml.NvlinkTelemetrySamples_v1, nvml.Return)
 
 	// GetNvLinkUtilizationControlFunc mocks the GetNvLinkUtilizationControl method.
 	GetNvLinkUtilizationControlFunc func(n1 int, n2 int) (nvml.NvLinkUtilizationControl, nvml.Return)
@@ -1489,6 +1531,9 @@ type Device struct {
 	// OnSameBoardFunc mocks the OnSameBoard method.
 	OnSameBoardFunc func(device nvml.Device) (int, nvml.Return)
 
+	// PerfMetricsGetSamples_v1Func mocks the PerfMetricsGetSamples_v1 method.
+	PerfMetricsGetSamples_v1Func func() (nvml.PerfMetricsSamples_v1, nvml.Return)
+
 	// PowerSmoothingActivatePresetProfileFunc mocks the PowerSmoothingActivatePresetProfile method.
 	PowerSmoothingActivatePresetProfileFunc func(powerSmoothingProfile *nvml.PowerSmoothingProfile) nvml.Return
 
@@ -1527,6 +1572,9 @@ type Device struct {
 
 	// SetAccountingModeFunc mocks the SetAccountingMode method.
 	SetAccountingModeFunc func(enableState nvml.EnableState) nvml.Return
+
+	// SetAdaptiveTgpMode_v1Func mocks the SetAdaptiveTgpMode_v1 method.
+	SetAdaptiveTgpMode_v1Func func(enableState nvml.EnableState) nvml.Return
 
 	// SetApplicationsClocksFunc mocks the SetApplicationsClocks method.
 	SetApplicationsClocksFunc func(v1 uint32, v2 uint32) nvml.Return
@@ -1582,6 +1630,9 @@ type Device struct {
 	// SetMemClkVfOffsetFunc mocks the SetMemClkVfOffset method.
 	SetMemClkVfOffsetFunc func(n int) nvml.Return
 
+	// SetMemoryLimits_v1Func mocks the SetMemoryLimits_v1 method.
+	SetMemoryLimits_v1Func func(s string, v1 uint64, v2 uint64) nvml.Return
+
 	// SetMemoryLockedClocksFunc mocks the SetMemoryLockedClocks method.
 	SetMemoryLockedClocksFunc func(v1 uint32, v2 uint32) nvml.Return
 
@@ -1596,6 +1647,9 @@ type Device struct {
 
 	// SetNvlinkBwModeFunc mocks the SetNvlinkBwMode method.
 	SetNvlinkBwModeFunc func(nvlinkSetBwMode *nvml.NvlinkSetBwMode) nvml.Return
+
+	// SetNvlinkBwModeAsync_v1Func mocks the SetNvlinkBwModeAsync_v1 method.
+	SetNvlinkBwModeAsync_v1Func func(nvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1) nvml.Return
 
 	// SetPersistenceModeFunc mocks the SetPersistenceMode method.
 	SetPersistenceModeFunc func(enableState nvml.EnableState) nvml.Return
@@ -1720,6 +1774,9 @@ type Device struct {
 		// GetAdaptiveClockInfoStatus holds details about calls to the GetAdaptiveClockInfoStatus method.
 		GetAdaptiveClockInfoStatus []struct {
 		}
+		// GetAdaptiveTgpModeInfo_v1 holds details about calls to the GetAdaptiveTgpModeInfo_v1 method.
+		GetAdaptiveTgpModeInfo_v1 []struct {
+		}
 		// GetAddressingMode holds details about calls to the GetAddressingMode method.
 		GetAddressingMode []struct {
 		}
@@ -1742,6 +1799,9 @@ type Device struct {
 		}
 		// GetBBXTimeData_v1 holds details about calls to the GetBBXTimeData_v1 method.
 		GetBBXTimeData_v1 []struct {
+		}
+		// GetBankRemapperStatus_v1 holds details about calls to the GetBankRemapperStatus_v1 method.
+		GetBankRemapperStatus_v1 []struct {
 		}
 		// GetBoardId holds details about calls to the GetBoardId method.
 		GetBoardId []struct {
@@ -1939,6 +1999,9 @@ type Device struct {
 		// GetGpuFabricInfoV holds details about calls to the GetGpuFabricInfoV method.
 		GetGpuFabricInfoV []struct {
 		}
+		// GetGpuFabricInfo_v4 holds details about calls to the GetGpuFabricInfo_v4 method.
+		GetGpuFabricInfo_v4 []struct {
+		}
 		// GetGpuInstanceById holds details about calls to the GetGpuInstanceById method.
 		GetGpuInstanceById []struct {
 			// N is the n argument value.
@@ -2080,6 +2143,11 @@ type Device struct {
 		// GetMemoryInfo_v2 holds details about calls to the GetMemoryInfo_v2 method.
 		GetMemoryInfo_v2 []struct {
 		}
+		// GetMemoryLimits_v1 holds details about calls to the GetMemoryLimits_v1 method.
+		GetMemoryLimits_v1 []struct {
+			// S is the s argument value.
+			S string
+		}
 		// GetMigDeviceHandleByIndex holds details about calls to the GetMigDeviceHandleByIndex method.
 		GetMigDeviceHandleByIndex []struct {
 			// N is the n argument value.
@@ -2150,6 +2218,11 @@ type Device struct {
 		GetNvLinkState []struct {
 			// N is the n argument value.
 			N int
+		}
+		// GetNvLinkTelemetrySamples_v1 holds details about calls to the GetNvLinkTelemetrySamples_v1 method.
+		GetNvLinkTelemetrySamples_v1 []struct {
+			// NvlinkTelemetrySamples_v1 is the nvlinkTelemetrySamples_v1 argument value.
+			NvlinkTelemetrySamples_v1 nvml.NvlinkTelemetrySamples_v1
 		}
 		// GetNvLinkUtilizationControl holds details about calls to the GetNvLinkUtilizationControl method.
 		GetNvLinkUtilizationControl []struct {
@@ -2478,6 +2551,9 @@ type Device struct {
 			// Device is the device argument value.
 			Device nvml.Device
 		}
+		// PerfMetricsGetSamples_v1 holds details about calls to the PerfMetricsGetSamples_v1 method.
+		PerfMetricsGetSamples_v1 []struct {
+		}
 		// PowerSmoothingActivatePresetProfile holds details about calls to the PowerSmoothingActivatePresetProfile method.
 		PowerSmoothingActivatePresetProfile []struct {
 			// PowerSmoothingProfile is the powerSmoothingProfile argument value.
@@ -2542,6 +2618,11 @@ type Device struct {
 		}
 		// SetAccountingMode holds details about calls to the SetAccountingMode method.
 		SetAccountingMode []struct {
+			// EnableState is the enableState argument value.
+			EnableState nvml.EnableState
+		}
+		// SetAdaptiveTgpMode_v1 holds details about calls to the SetAdaptiveTgpMode_v1 method.
+		SetAdaptiveTgpMode_v1 []struct {
 			// EnableState is the enableState argument value.
 			EnableState nvml.EnableState
 		}
@@ -2645,6 +2726,15 @@ type Device struct {
 			// N is the n argument value.
 			N int
 		}
+		// SetMemoryLimits_v1 holds details about calls to the SetMemoryLimits_v1 method.
+		SetMemoryLimits_v1 []struct {
+			// S is the s argument value.
+			S string
+			// V1 is the v1 argument value.
+			V1 uint64
+			// V2 is the v2 argument value.
+			V2 uint64
+		}
 		// SetMemoryLockedClocks holds details about calls to the SetMemoryLockedClocks method.
 		SetMemoryLockedClocks []struct {
 			// V1 is the v1 argument value.
@@ -2677,6 +2767,11 @@ type Device struct {
 		SetNvlinkBwMode []struct {
 			// NvlinkSetBwMode is the nvlinkSetBwMode argument value.
 			NvlinkSetBwMode *nvml.NvlinkSetBwMode
+		}
+		// SetNvlinkBwModeAsync_v1 holds details about calls to the SetNvlinkBwModeAsync_v1 method.
+		SetNvlinkBwModeAsync_v1 []struct {
+			// NvlinkSetBwModeAsync_v1 is the nvlinkSetBwModeAsync_v1 argument value.
+			NvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1
 		}
 		// SetPersistenceMode holds details about calls to the SetPersistenceMode method.
 		SetPersistenceMode []struct {
@@ -2782,6 +2877,7 @@ type Device struct {
 	lockGetAccountingStats_v2                      sync.RWMutex
 	lockGetActiveVgpus                             sync.RWMutex
 	lockGetAdaptiveClockInfoStatus                 sync.RWMutex
+	lockGetAdaptiveTgpModeInfo_v1                  sync.RWMutex
 	lockGetAddressingMode                          sync.RWMutex
 	lockGetApplicationsClock                       sync.RWMutex
 	lockGetArchitecture                            sync.RWMutex
@@ -2789,6 +2885,7 @@ type Device struct {
 	lockGetAutoBoostedClocksEnabled                sync.RWMutex
 	lockGetBAR1MemoryInfo                          sync.RWMutex
 	lockGetBBXTimeData_v1                          sync.RWMutex
+	lockGetBankRemapperStatus_v1                   sync.RWMutex
 	lockGetBoardId                                 sync.RWMutex
 	lockGetBoardPartNumber                         sync.RWMutex
 	lockGetBrand                                   sync.RWMutex
@@ -2845,6 +2942,7 @@ type Device struct {
 	lockGetGpcClkVfOffset                          sync.RWMutex
 	lockGetGpuFabricInfo                           sync.RWMutex
 	lockGetGpuFabricInfoV                          sync.RWMutex
+	lockGetGpuFabricInfo_v4                        sync.RWMutex
 	lockGetGpuInstanceById                         sync.RWMutex
 	lockGetGpuInstanceId                           sync.RWMutex
 	lockGetGpuInstancePossiblePlacements           sync.RWMutex
@@ -2882,6 +2980,7 @@ type Device struct {
 	lockGetMemoryErrorCounter                      sync.RWMutex
 	lockGetMemoryInfo                              sync.RWMutex
 	lockGetMemoryInfo_v2                           sync.RWMutex
+	lockGetMemoryLimits_v1                         sync.RWMutex
 	lockGetMigDeviceHandleByIndex                  sync.RWMutex
 	lockGetMigMode                                 sync.RWMutex
 	lockGetMinMaxClockOfPState                     sync.RWMutex
@@ -2899,6 +2998,7 @@ type Device struct {
 	lockGetNvLinkRemoteDeviceType                  sync.RWMutex
 	lockGetNvLinkRemotePciInfo                     sync.RWMutex
 	lockGetNvLinkState                             sync.RWMutex
+	lockGetNvLinkTelemetrySamples_v1               sync.RWMutex
 	lockGetNvLinkUtilizationControl                sync.RWMutex
 	lockGetNvLinkUtilizationCounter                sync.RWMutex
 	lockGetNvLinkVersion                           sync.RWMutex
@@ -2984,6 +3084,7 @@ type Device struct {
 	lockGpmSetStreamingEnabled                     sync.RWMutex
 	lockIsMigDeviceHandle                          sync.RWMutex
 	lockOnSameBoard                                sync.RWMutex
+	lockPerfMetricsGetSamples_v1                   sync.RWMutex
 	lockPowerSmoothingActivatePresetProfile        sync.RWMutex
 	lockPowerSmoothingSetState                     sync.RWMutex
 	lockPowerSmoothingUpdatePresetProfileParam     sync.RWMutex
@@ -2997,6 +3098,7 @@ type Device struct {
 	lockResetNvLinkUtilizationCounter              sync.RWMutex
 	lockSetAPIRestriction                          sync.RWMutex
 	lockSetAccountingMode                          sync.RWMutex
+	lockSetAdaptiveTgpMode_v1                      sync.RWMutex
 	lockSetApplicationsClocks                      sync.RWMutex
 	lockSetAutoBoostedClocksEnabled                sync.RWMutex
 	lockSetClockOffsets                            sync.RWMutex
@@ -3015,11 +3117,13 @@ type Device struct {
 	lockSetGpuOperationMode                        sync.RWMutex
 	lockSetHostname_v1                             sync.RWMutex
 	lockSetMemClkVfOffset                          sync.RWMutex
+	lockSetMemoryLimits_v1                         sync.RWMutex
 	lockSetMemoryLockedClocks                      sync.RWMutex
 	lockSetMigMode                                 sync.RWMutex
 	lockSetNvLinkDeviceLowPowerThreshold           sync.RWMutex
 	lockSetNvLinkUtilizationControl                sync.RWMutex
 	lockSetNvlinkBwMode                            sync.RWMutex
+	lockSetNvlinkBwModeAsync_v1                    sync.RWMutex
 	lockSetPersistenceMode                         sync.RWMutex
 	lockSetPowerManagementLimit                    sync.RWMutex
 	lockSetPowerManagementLimit_v2                 sync.RWMutex
@@ -3497,6 +3601,33 @@ func (mock *Device) GetAdaptiveClockInfoStatusCalls() []struct {
 	return calls
 }
 
+// GetAdaptiveTgpModeInfo_v1 calls GetAdaptiveTgpModeInfo_v1Func.
+func (mock *Device) GetAdaptiveTgpModeInfo_v1() (nvml.AdaptiveTgpModeInfo_v1, nvml.Return) {
+	if mock.GetAdaptiveTgpModeInfo_v1Func == nil {
+		panic("Device.GetAdaptiveTgpModeInfo_v1Func: method is nil but Device.GetAdaptiveTgpModeInfo_v1 was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockGetAdaptiveTgpModeInfo_v1.Lock()
+	mock.calls.GetAdaptiveTgpModeInfo_v1 = append(mock.calls.GetAdaptiveTgpModeInfo_v1, callInfo)
+	mock.lockGetAdaptiveTgpModeInfo_v1.Unlock()
+	return mock.GetAdaptiveTgpModeInfo_v1Func()
+}
+
+// GetAdaptiveTgpModeInfo_v1Calls gets all the calls that were made to GetAdaptiveTgpModeInfo_v1.
+// Check the length with:
+//
+//	len(mockedDevice.GetAdaptiveTgpModeInfo_v1Calls())
+func (mock *Device) GetAdaptiveTgpModeInfo_v1Calls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockGetAdaptiveTgpModeInfo_v1.RLock()
+	calls = mock.calls.GetAdaptiveTgpModeInfo_v1
+	mock.lockGetAdaptiveTgpModeInfo_v1.RUnlock()
+	return calls
+}
+
 // GetAddressingMode calls GetAddressingModeFunc.
 func (mock *Device) GetAddressingMode() (nvml.DeviceAddressingMode, nvml.Return) {
 	if mock.GetAddressingModeFunc == nil {
@@ -3688,6 +3819,33 @@ func (mock *Device) GetBBXTimeData_v1Calls() []struct {
 	mock.lockGetBBXTimeData_v1.RLock()
 	calls = mock.calls.GetBBXTimeData_v1
 	mock.lockGetBBXTimeData_v1.RUnlock()
+	return calls
+}
+
+// GetBankRemapperStatus_v1 calls GetBankRemapperStatus_v1Func.
+func (mock *Device) GetBankRemapperStatus_v1() (nvml.EccBankRemapperStatus_v1, nvml.Return) {
+	if mock.GetBankRemapperStatus_v1Func == nil {
+		panic("Device.GetBankRemapperStatus_v1Func: method is nil but Device.GetBankRemapperStatus_v1 was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockGetBankRemapperStatus_v1.Lock()
+	mock.calls.GetBankRemapperStatus_v1 = append(mock.calls.GetBankRemapperStatus_v1, callInfo)
+	mock.lockGetBankRemapperStatus_v1.Unlock()
+	return mock.GetBankRemapperStatus_v1Func()
+}
+
+// GetBankRemapperStatus_v1Calls gets all the calls that were made to GetBankRemapperStatus_v1.
+// Check the length with:
+//
+//	len(mockedDevice.GetBankRemapperStatus_v1Calls())
+func (mock *Device) GetBankRemapperStatus_v1Calls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockGetBankRemapperStatus_v1.RLock()
+	calls = mock.calls.GetBankRemapperStatus_v1
+	mock.lockGetBankRemapperStatus_v1.RUnlock()
 	return calls
 }
 
@@ -5270,6 +5428,33 @@ func (mock *Device) GetGpuFabricInfoVCalls() []struct {
 	return calls
 }
 
+// GetGpuFabricInfo_v4 calls GetGpuFabricInfo_v4Func.
+func (mock *Device) GetGpuFabricInfo_v4() (nvml.GpuFabricInfo_v4, nvml.Return) {
+	if mock.GetGpuFabricInfo_v4Func == nil {
+		panic("Device.GetGpuFabricInfo_v4Func: method is nil but Device.GetGpuFabricInfo_v4 was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockGetGpuFabricInfo_v4.Lock()
+	mock.calls.GetGpuFabricInfo_v4 = append(mock.calls.GetGpuFabricInfo_v4, callInfo)
+	mock.lockGetGpuFabricInfo_v4.Unlock()
+	return mock.GetGpuFabricInfo_v4Func()
+}
+
+// GetGpuFabricInfo_v4Calls gets all the calls that were made to GetGpuFabricInfo_v4.
+// Check the length with:
+//
+//	len(mockedDevice.GetGpuFabricInfo_v4Calls())
+func (mock *Device) GetGpuFabricInfo_v4Calls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockGetGpuFabricInfo_v4.RLock()
+	calls = mock.calls.GetGpuFabricInfo_v4
+	mock.lockGetGpuFabricInfo_v4.RUnlock()
+	return calls
+}
+
 // GetGpuInstanceById calls GetGpuInstanceByIdFunc.
 func (mock *Device) GetGpuInstanceById(n int) (nvml.GpuInstance, nvml.Return) {
 	if mock.GetGpuInstanceByIdFunc == nil {
@@ -6341,6 +6526,38 @@ func (mock *Device) GetMemoryInfo_v2Calls() []struct {
 	return calls
 }
 
+// GetMemoryLimits_v1 calls GetMemoryLimits_v1Func.
+func (mock *Device) GetMemoryLimits_v1(s string) (nvml.MemoryLimits_v1, nvml.Return) {
+	if mock.GetMemoryLimits_v1Func == nil {
+		panic("Device.GetMemoryLimits_v1Func: method is nil but Device.GetMemoryLimits_v1 was just called")
+	}
+	callInfo := struct {
+		S string
+	}{
+		S: s,
+	}
+	mock.lockGetMemoryLimits_v1.Lock()
+	mock.calls.GetMemoryLimits_v1 = append(mock.calls.GetMemoryLimits_v1, callInfo)
+	mock.lockGetMemoryLimits_v1.Unlock()
+	return mock.GetMemoryLimits_v1Func(s)
+}
+
+// GetMemoryLimits_v1Calls gets all the calls that were made to GetMemoryLimits_v1.
+// Check the length with:
+//
+//	len(mockedDevice.GetMemoryLimits_v1Calls())
+func (mock *Device) GetMemoryLimits_v1Calls() []struct {
+	S string
+} {
+	var calls []struct {
+		S string
+	}
+	mock.lockGetMemoryLimits_v1.RLock()
+	calls = mock.calls.GetMemoryLimits_v1
+	mock.lockGetMemoryLimits_v1.RUnlock()
+	return calls
+}
+
 // GetMigDeviceHandleByIndex calls GetMigDeviceHandleByIndexFunc.
 func (mock *Device) GetMigDeviceHandleByIndex(n int) (nvml.Device, nvml.Return) {
 	if mock.GetMigDeviceHandleByIndexFunc == nil {
@@ -6844,6 +7061,38 @@ func (mock *Device) GetNvLinkStateCalls() []struct {
 	mock.lockGetNvLinkState.RLock()
 	calls = mock.calls.GetNvLinkState
 	mock.lockGetNvLinkState.RUnlock()
+	return calls
+}
+
+// GetNvLinkTelemetrySamples_v1 calls GetNvLinkTelemetrySamples_v1Func.
+func (mock *Device) GetNvLinkTelemetrySamples_v1(nvlinkTelemetrySamples_v1 nvml.NvlinkTelemetrySamples_v1) (nvml.NvlinkTelemetrySamples_v1, nvml.Return) {
+	if mock.GetNvLinkTelemetrySamples_v1Func == nil {
+		panic("Device.GetNvLinkTelemetrySamples_v1Func: method is nil but Device.GetNvLinkTelemetrySamples_v1 was just called")
+	}
+	callInfo := struct {
+		NvlinkTelemetrySamples_v1 nvml.NvlinkTelemetrySamples_v1
+	}{
+		NvlinkTelemetrySamples_v1: nvlinkTelemetrySamples_v1,
+	}
+	mock.lockGetNvLinkTelemetrySamples_v1.Lock()
+	mock.calls.GetNvLinkTelemetrySamples_v1 = append(mock.calls.GetNvLinkTelemetrySamples_v1, callInfo)
+	mock.lockGetNvLinkTelemetrySamples_v1.Unlock()
+	return mock.GetNvLinkTelemetrySamples_v1Func(nvlinkTelemetrySamples_v1)
+}
+
+// GetNvLinkTelemetrySamples_v1Calls gets all the calls that were made to GetNvLinkTelemetrySamples_v1.
+// Check the length with:
+//
+//	len(mockedDevice.GetNvLinkTelemetrySamples_v1Calls())
+func (mock *Device) GetNvLinkTelemetrySamples_v1Calls() []struct {
+	NvlinkTelemetrySamples_v1 nvml.NvlinkTelemetrySamples_v1
+} {
+	var calls []struct {
+		NvlinkTelemetrySamples_v1 nvml.NvlinkTelemetrySamples_v1
+	}
+	mock.lockGetNvLinkTelemetrySamples_v1.RLock()
+	calls = mock.calls.GetNvLinkTelemetrySamples_v1
+	mock.lockGetNvLinkTelemetrySamples_v1.RUnlock()
 	return calls
 }
 
@@ -9316,6 +9565,33 @@ func (mock *Device) OnSameBoardCalls() []struct {
 	return calls
 }
 
+// PerfMetricsGetSamples_v1 calls PerfMetricsGetSamples_v1Func.
+func (mock *Device) PerfMetricsGetSamples_v1() (nvml.PerfMetricsSamples_v1, nvml.Return) {
+	if mock.PerfMetricsGetSamples_v1Func == nil {
+		panic("Device.PerfMetricsGetSamples_v1Func: method is nil but Device.PerfMetricsGetSamples_v1 was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockPerfMetricsGetSamples_v1.Lock()
+	mock.calls.PerfMetricsGetSamples_v1 = append(mock.calls.PerfMetricsGetSamples_v1, callInfo)
+	mock.lockPerfMetricsGetSamples_v1.Unlock()
+	return mock.PerfMetricsGetSamples_v1Func()
+}
+
+// PerfMetricsGetSamples_v1Calls gets all the calls that were made to PerfMetricsGetSamples_v1.
+// Check the length with:
+//
+//	len(mockedDevice.PerfMetricsGetSamples_v1Calls())
+func (mock *Device) PerfMetricsGetSamples_v1Calls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockPerfMetricsGetSamples_v1.RLock()
+	calls = mock.calls.PerfMetricsGetSamples_v1
+	mock.lockPerfMetricsGetSamples_v1.RUnlock()
+	return calls
+}
+
 // PowerSmoothingActivatePresetProfile calls PowerSmoothingActivatePresetProfileFunc.
 func (mock *Device) PowerSmoothingActivatePresetProfile(powerSmoothingProfile *nvml.PowerSmoothingProfile) nvml.Return {
 	if mock.PowerSmoothingActivatePresetProfileFunc == nil {
@@ -9730,6 +10006,38 @@ func (mock *Device) SetAccountingModeCalls() []struct {
 	mock.lockSetAccountingMode.RLock()
 	calls = mock.calls.SetAccountingMode
 	mock.lockSetAccountingMode.RUnlock()
+	return calls
+}
+
+// SetAdaptiveTgpMode_v1 calls SetAdaptiveTgpMode_v1Func.
+func (mock *Device) SetAdaptiveTgpMode_v1(enableState nvml.EnableState) nvml.Return {
+	if mock.SetAdaptiveTgpMode_v1Func == nil {
+		panic("Device.SetAdaptiveTgpMode_v1Func: method is nil but Device.SetAdaptiveTgpMode_v1 was just called")
+	}
+	callInfo := struct {
+		EnableState nvml.EnableState
+	}{
+		EnableState: enableState,
+	}
+	mock.lockSetAdaptiveTgpMode_v1.Lock()
+	mock.calls.SetAdaptiveTgpMode_v1 = append(mock.calls.SetAdaptiveTgpMode_v1, callInfo)
+	mock.lockSetAdaptiveTgpMode_v1.Unlock()
+	return mock.SetAdaptiveTgpMode_v1Func(enableState)
+}
+
+// SetAdaptiveTgpMode_v1Calls gets all the calls that were made to SetAdaptiveTgpMode_v1.
+// Check the length with:
+//
+//	len(mockedDevice.SetAdaptiveTgpMode_v1Calls())
+func (mock *Device) SetAdaptiveTgpMode_v1Calls() []struct {
+	EnableState nvml.EnableState
+} {
+	var calls []struct {
+		EnableState nvml.EnableState
+	}
+	mock.lockSetAdaptiveTgpMode_v1.RLock()
+	calls = mock.calls.SetAdaptiveTgpMode_v1
+	mock.lockSetAdaptiveTgpMode_v1.RUnlock()
 	return calls
 }
 
@@ -10328,6 +10636,46 @@ func (mock *Device) SetMemClkVfOffsetCalls() []struct {
 	return calls
 }
 
+// SetMemoryLimits_v1 calls SetMemoryLimits_v1Func.
+func (mock *Device) SetMemoryLimits_v1(s string, v1 uint64, v2 uint64) nvml.Return {
+	if mock.SetMemoryLimits_v1Func == nil {
+		panic("Device.SetMemoryLimits_v1Func: method is nil but Device.SetMemoryLimits_v1 was just called")
+	}
+	callInfo := struct {
+		S  string
+		V1 uint64
+		V2 uint64
+	}{
+		S:  s,
+		V1: v1,
+		V2: v2,
+	}
+	mock.lockSetMemoryLimits_v1.Lock()
+	mock.calls.SetMemoryLimits_v1 = append(mock.calls.SetMemoryLimits_v1, callInfo)
+	mock.lockSetMemoryLimits_v1.Unlock()
+	return mock.SetMemoryLimits_v1Func(s, v1, v2)
+}
+
+// SetMemoryLimits_v1Calls gets all the calls that were made to SetMemoryLimits_v1.
+// Check the length with:
+//
+//	len(mockedDevice.SetMemoryLimits_v1Calls())
+func (mock *Device) SetMemoryLimits_v1Calls() []struct {
+	S  string
+	V1 uint64
+	V2 uint64
+} {
+	var calls []struct {
+		S  string
+		V1 uint64
+		V2 uint64
+	}
+	mock.lockSetMemoryLimits_v1.RLock()
+	calls = mock.calls.SetMemoryLimits_v1
+	mock.lockSetMemoryLimits_v1.RUnlock()
+	return calls
+}
+
 // SetMemoryLockedClocks calls SetMemoryLockedClocksFunc.
 func (mock *Device) SetMemoryLockedClocks(v1 uint32, v2 uint32) nvml.Return {
 	if mock.SetMemoryLockedClocksFunc == nil {
@@ -10501,6 +10849,38 @@ func (mock *Device) SetNvlinkBwModeCalls() []struct {
 	mock.lockSetNvlinkBwMode.RLock()
 	calls = mock.calls.SetNvlinkBwMode
 	mock.lockSetNvlinkBwMode.RUnlock()
+	return calls
+}
+
+// SetNvlinkBwModeAsync_v1 calls SetNvlinkBwModeAsync_v1Func.
+func (mock *Device) SetNvlinkBwModeAsync_v1(nvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1) nvml.Return {
+	if mock.SetNvlinkBwModeAsync_v1Func == nil {
+		panic("Device.SetNvlinkBwModeAsync_v1Func: method is nil but Device.SetNvlinkBwModeAsync_v1 was just called")
+	}
+	callInfo := struct {
+		NvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1
+	}{
+		NvlinkSetBwModeAsync_v1: nvlinkSetBwModeAsync_v1,
+	}
+	mock.lockSetNvlinkBwModeAsync_v1.Lock()
+	mock.calls.SetNvlinkBwModeAsync_v1 = append(mock.calls.SetNvlinkBwModeAsync_v1, callInfo)
+	mock.lockSetNvlinkBwModeAsync_v1.Unlock()
+	return mock.SetNvlinkBwModeAsync_v1Func(nvlinkSetBwModeAsync_v1)
+}
+
+// SetNvlinkBwModeAsync_v1Calls gets all the calls that were made to SetNvlinkBwModeAsync_v1.
+// Check the length with:
+//
+//	len(mockedDevice.SetNvlinkBwModeAsync_v1Calls())
+func (mock *Device) SetNvlinkBwModeAsync_v1Calls() []struct {
+	NvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1
+} {
+	var calls []struct {
+		NvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1
+	}
+	mock.lockSetNvlinkBwModeAsync_v1.RLock()
+	calls = mock.calls.SetNvlinkBwModeAsync_v1
+	mock.lockSetNvlinkBwModeAsync_v1.RUnlock()
 	return calls
 }
 

--- a/pkg/nvml/mock/eventset.go
+++ b/pkg/nvml/mock/eventset.go
@@ -21,8 +21,26 @@ var _ nvml.EventSet = &EventSet{}
 //			FreeFunc: func() nvml.Return {
 //				panic("mock out the Free method")
 //			},
+//			GetContextCount_v1Func: func() (nvml.GetContextCount_v1, nvml.Return) {
+//				panic("mock out the GetContextCount_v1 method")
+//			},
+//			GetContextData_v1Func: func(getContextData_v1 nvml.GetContextData_v1) (nvml.GetContextData_v1, nvml.Return) {
+//				panic("mock out the GetContextData_v1 method")
+//			},
+//			GetContextInfo_v1Func: func(v uint32) (nvml.GetContextInfo_v1, nvml.Return) {
+//				panic("mock out the GetContextInfo_v1 method")
+//			},
+//			GetGpuOperationalEventContextLegacyXid_v1Func: func(v uint32) (uint32, nvml.Return) {
+//				panic("mock out the GetGpuOperationalEventContextLegacyXid_v1 method")
+//			},
+//			RegisterGpuOperationalEvents_v1Func: func(gpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1) nvml.Return {
+//				panic("mock out the RegisterGpuOperationalEvents_v1 method")
+//			},
 //			WaitFunc: func(v uint32) (nvml.EventData, nvml.Return) {
 //				panic("mock out the Wait method")
+//			},
+//			Wait_v3Func: func(v uint32) (nvml.EventSetWaitData_v3, nvml.Return) {
+//				panic("mock out the Wait_v3 method")
 //			},
 //		}
 //
@@ -34,22 +52,74 @@ type EventSet struct {
 	// FreeFunc mocks the Free method.
 	FreeFunc func() nvml.Return
 
+	// GetContextCount_v1Func mocks the GetContextCount_v1 method.
+	GetContextCount_v1Func func() (nvml.GetContextCount_v1, nvml.Return)
+
+	// GetContextData_v1Func mocks the GetContextData_v1 method.
+	GetContextData_v1Func func(getContextData_v1 nvml.GetContextData_v1) (nvml.GetContextData_v1, nvml.Return)
+
+	// GetContextInfo_v1Func mocks the GetContextInfo_v1 method.
+	GetContextInfo_v1Func func(v uint32) (nvml.GetContextInfo_v1, nvml.Return)
+
+	// GetGpuOperationalEventContextLegacyXid_v1Func mocks the GetGpuOperationalEventContextLegacyXid_v1 method.
+	GetGpuOperationalEventContextLegacyXid_v1Func func(v uint32) (uint32, nvml.Return)
+
+	// RegisterGpuOperationalEvents_v1Func mocks the RegisterGpuOperationalEvents_v1 method.
+	RegisterGpuOperationalEvents_v1Func func(gpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1) nvml.Return
+
 	// WaitFunc mocks the Wait method.
 	WaitFunc func(v uint32) (nvml.EventData, nvml.Return)
+
+	// Wait_v3Func mocks the Wait_v3 method.
+	Wait_v3Func func(v uint32) (nvml.EventSetWaitData_v3, nvml.Return)
 
 	// calls tracks calls to the methods.
 	calls struct {
 		// Free holds details about calls to the Free method.
 		Free []struct {
 		}
+		// GetContextCount_v1 holds details about calls to the GetContextCount_v1 method.
+		GetContextCount_v1 []struct {
+		}
+		// GetContextData_v1 holds details about calls to the GetContextData_v1 method.
+		GetContextData_v1 []struct {
+			// GetContextData_v1 is the getContextData_v1 argument value.
+			GetContextData_v1 nvml.GetContextData_v1
+		}
+		// GetContextInfo_v1 holds details about calls to the GetContextInfo_v1 method.
+		GetContextInfo_v1 []struct {
+			// V is the v argument value.
+			V uint32
+		}
+		// GetGpuOperationalEventContextLegacyXid_v1 holds details about calls to the GetGpuOperationalEventContextLegacyXid_v1 method.
+		GetGpuOperationalEventContextLegacyXid_v1 []struct {
+			// V is the v argument value.
+			V uint32
+		}
+		// RegisterGpuOperationalEvents_v1 holds details about calls to the RegisterGpuOperationalEvents_v1 method.
+		RegisterGpuOperationalEvents_v1 []struct {
+			// GpuOperationalEventConfig_v1 is the gpuOperationalEventConfig_v1 argument value.
+			GpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1
+		}
 		// Wait holds details about calls to the Wait method.
 		Wait []struct {
 			// V is the v argument value.
 			V uint32
 		}
+		// Wait_v3 holds details about calls to the Wait_v3 method.
+		Wait_v3 []struct {
+			// V is the v argument value.
+			V uint32
+		}
 	}
-	lockFree sync.RWMutex
-	lockWait sync.RWMutex
+	lockFree                                      sync.RWMutex
+	lockGetContextCount_v1                        sync.RWMutex
+	lockGetContextData_v1                         sync.RWMutex
+	lockGetContextInfo_v1                         sync.RWMutex
+	lockGetGpuOperationalEventContextLegacyXid_v1 sync.RWMutex
+	lockRegisterGpuOperationalEvents_v1           sync.RWMutex
+	lockWait                                      sync.RWMutex
+	lockWait_v3                                   sync.RWMutex
 }
 
 // Free calls FreeFunc.
@@ -76,6 +146,161 @@ func (mock *EventSet) FreeCalls() []struct {
 	mock.lockFree.RLock()
 	calls = mock.calls.Free
 	mock.lockFree.RUnlock()
+	return calls
+}
+
+// GetContextCount_v1 calls GetContextCount_v1Func.
+func (mock *EventSet) GetContextCount_v1() (nvml.GetContextCount_v1, nvml.Return) {
+	if mock.GetContextCount_v1Func == nil {
+		panic("EventSet.GetContextCount_v1Func: method is nil but EventSet.GetContextCount_v1 was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockGetContextCount_v1.Lock()
+	mock.calls.GetContextCount_v1 = append(mock.calls.GetContextCount_v1, callInfo)
+	mock.lockGetContextCount_v1.Unlock()
+	return mock.GetContextCount_v1Func()
+}
+
+// GetContextCount_v1Calls gets all the calls that were made to GetContextCount_v1.
+// Check the length with:
+//
+//	len(mockedEventSet.GetContextCount_v1Calls())
+func (mock *EventSet) GetContextCount_v1Calls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockGetContextCount_v1.RLock()
+	calls = mock.calls.GetContextCount_v1
+	mock.lockGetContextCount_v1.RUnlock()
+	return calls
+}
+
+// GetContextData_v1 calls GetContextData_v1Func.
+func (mock *EventSet) GetContextData_v1(getContextData_v1 nvml.GetContextData_v1) (nvml.GetContextData_v1, nvml.Return) {
+	if mock.GetContextData_v1Func == nil {
+		panic("EventSet.GetContextData_v1Func: method is nil but EventSet.GetContextData_v1 was just called")
+	}
+	callInfo := struct {
+		GetContextData_v1 nvml.GetContextData_v1
+	}{
+		GetContextData_v1: getContextData_v1,
+	}
+	mock.lockGetContextData_v1.Lock()
+	mock.calls.GetContextData_v1 = append(mock.calls.GetContextData_v1, callInfo)
+	mock.lockGetContextData_v1.Unlock()
+	return mock.GetContextData_v1Func(getContextData_v1)
+}
+
+// GetContextData_v1Calls gets all the calls that were made to GetContextData_v1.
+// Check the length with:
+//
+//	len(mockedEventSet.GetContextData_v1Calls())
+func (mock *EventSet) GetContextData_v1Calls() []struct {
+	GetContextData_v1 nvml.GetContextData_v1
+} {
+	var calls []struct {
+		GetContextData_v1 nvml.GetContextData_v1
+	}
+	mock.lockGetContextData_v1.RLock()
+	calls = mock.calls.GetContextData_v1
+	mock.lockGetContextData_v1.RUnlock()
+	return calls
+}
+
+// GetContextInfo_v1 calls GetContextInfo_v1Func.
+func (mock *EventSet) GetContextInfo_v1(v uint32) (nvml.GetContextInfo_v1, nvml.Return) {
+	if mock.GetContextInfo_v1Func == nil {
+		panic("EventSet.GetContextInfo_v1Func: method is nil but EventSet.GetContextInfo_v1 was just called")
+	}
+	callInfo := struct {
+		V uint32
+	}{
+		V: v,
+	}
+	mock.lockGetContextInfo_v1.Lock()
+	mock.calls.GetContextInfo_v1 = append(mock.calls.GetContextInfo_v1, callInfo)
+	mock.lockGetContextInfo_v1.Unlock()
+	return mock.GetContextInfo_v1Func(v)
+}
+
+// GetContextInfo_v1Calls gets all the calls that were made to GetContextInfo_v1.
+// Check the length with:
+//
+//	len(mockedEventSet.GetContextInfo_v1Calls())
+func (mock *EventSet) GetContextInfo_v1Calls() []struct {
+	V uint32
+} {
+	var calls []struct {
+		V uint32
+	}
+	mock.lockGetContextInfo_v1.RLock()
+	calls = mock.calls.GetContextInfo_v1
+	mock.lockGetContextInfo_v1.RUnlock()
+	return calls
+}
+
+// GetGpuOperationalEventContextLegacyXid_v1 calls GetGpuOperationalEventContextLegacyXid_v1Func.
+func (mock *EventSet) GetGpuOperationalEventContextLegacyXid_v1(v uint32) (uint32, nvml.Return) {
+	if mock.GetGpuOperationalEventContextLegacyXid_v1Func == nil {
+		panic("EventSet.GetGpuOperationalEventContextLegacyXid_v1Func: method is nil but EventSet.GetGpuOperationalEventContextLegacyXid_v1 was just called")
+	}
+	callInfo := struct {
+		V uint32
+	}{
+		V: v,
+	}
+	mock.lockGetGpuOperationalEventContextLegacyXid_v1.Lock()
+	mock.calls.GetGpuOperationalEventContextLegacyXid_v1 = append(mock.calls.GetGpuOperationalEventContextLegacyXid_v1, callInfo)
+	mock.lockGetGpuOperationalEventContextLegacyXid_v1.Unlock()
+	return mock.GetGpuOperationalEventContextLegacyXid_v1Func(v)
+}
+
+// GetGpuOperationalEventContextLegacyXid_v1Calls gets all the calls that were made to GetGpuOperationalEventContextLegacyXid_v1.
+// Check the length with:
+//
+//	len(mockedEventSet.GetGpuOperationalEventContextLegacyXid_v1Calls())
+func (mock *EventSet) GetGpuOperationalEventContextLegacyXid_v1Calls() []struct {
+	V uint32
+} {
+	var calls []struct {
+		V uint32
+	}
+	mock.lockGetGpuOperationalEventContextLegacyXid_v1.RLock()
+	calls = mock.calls.GetGpuOperationalEventContextLegacyXid_v1
+	mock.lockGetGpuOperationalEventContextLegacyXid_v1.RUnlock()
+	return calls
+}
+
+// RegisterGpuOperationalEvents_v1 calls RegisterGpuOperationalEvents_v1Func.
+func (mock *EventSet) RegisterGpuOperationalEvents_v1(gpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1) nvml.Return {
+	if mock.RegisterGpuOperationalEvents_v1Func == nil {
+		panic("EventSet.RegisterGpuOperationalEvents_v1Func: method is nil but EventSet.RegisterGpuOperationalEvents_v1 was just called")
+	}
+	callInfo := struct {
+		GpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1
+	}{
+		GpuOperationalEventConfig_v1: gpuOperationalEventConfig_v1,
+	}
+	mock.lockRegisterGpuOperationalEvents_v1.Lock()
+	mock.calls.RegisterGpuOperationalEvents_v1 = append(mock.calls.RegisterGpuOperationalEvents_v1, callInfo)
+	mock.lockRegisterGpuOperationalEvents_v1.Unlock()
+	return mock.RegisterGpuOperationalEvents_v1Func(gpuOperationalEventConfig_v1)
+}
+
+// RegisterGpuOperationalEvents_v1Calls gets all the calls that were made to RegisterGpuOperationalEvents_v1.
+// Check the length with:
+//
+//	len(mockedEventSet.RegisterGpuOperationalEvents_v1Calls())
+func (mock *EventSet) RegisterGpuOperationalEvents_v1Calls() []struct {
+	GpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1
+} {
+	var calls []struct {
+		GpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1
+	}
+	mock.lockRegisterGpuOperationalEvents_v1.RLock()
+	calls = mock.calls.RegisterGpuOperationalEvents_v1
+	mock.lockRegisterGpuOperationalEvents_v1.RUnlock()
 	return calls
 }
 
@@ -108,5 +333,37 @@ func (mock *EventSet) WaitCalls() []struct {
 	mock.lockWait.RLock()
 	calls = mock.calls.Wait
 	mock.lockWait.RUnlock()
+	return calls
+}
+
+// Wait_v3 calls Wait_v3Func.
+func (mock *EventSet) Wait_v3(v uint32) (nvml.EventSetWaitData_v3, nvml.Return) {
+	if mock.Wait_v3Func == nil {
+		panic("EventSet.Wait_v3Func: method is nil but EventSet.Wait_v3 was just called")
+	}
+	callInfo := struct {
+		V uint32
+	}{
+		V: v,
+	}
+	mock.lockWait_v3.Lock()
+	mock.calls.Wait_v3 = append(mock.calls.Wait_v3, callInfo)
+	mock.lockWait_v3.Unlock()
+	return mock.Wait_v3Func(v)
+}
+
+// Wait_v3Calls gets all the calls that were made to Wait_v3.
+// Check the length with:
+//
+//	len(mockedEventSet.Wait_v3Calls())
+func (mock *EventSet) Wait_v3Calls() []struct {
+	V uint32
+} {
+	var calls []struct {
+		V uint32
+	}
+	mock.lockWait_v3.RLock()
+	calls = mock.calls.Wait_v3
+	mock.lockWait_v3.RUnlock()
 	return calls
 }

--- a/pkg/nvml/mock/interface.go
+++ b/pkg/nvml/mock/interface.go
@@ -72,6 +72,9 @@ var _ nvml.Interface = &Interface{}
 //			DeviceGetAdaptiveClockInfoStatusFunc: func(device nvml.Device) (uint32, nvml.Return) {
 //				panic("mock out the DeviceGetAdaptiveClockInfoStatus method")
 //			},
+//			DeviceGetAdaptiveTgpModeInfo_v1Func: func(device nvml.Device) (nvml.AdaptiveTgpModeInfo_v1, nvml.Return) {
+//				panic("mock out the DeviceGetAdaptiveTgpModeInfo_v1 method")
+//			},
 //			DeviceGetAddressingModeFunc: func(device nvml.Device) (nvml.DeviceAddressingMode, nvml.Return) {
 //				panic("mock out the DeviceGetAddressingMode method")
 //			},
@@ -92,6 +95,9 @@ var _ nvml.Interface = &Interface{}
 //			},
 //			DeviceGetBBXTimeData_v1Func: func(device nvml.Device) (nvml.BBXTimeData_v1, nvml.Return) {
 //				panic("mock out the DeviceGetBBXTimeData_v1 method")
+//			},
+//			DeviceGetBankRemapperStatus_v1Func: func(device nvml.Device) (nvml.EccBankRemapperStatus_v1, nvml.Return) {
+//				panic("mock out the DeviceGetBankRemapperStatus_v1 method")
 //			},
 //			DeviceGetBoardIdFunc: func(device nvml.Device) (uint32, nvml.Return) {
 //				panic("mock out the DeviceGetBoardId method")
@@ -264,6 +270,9 @@ var _ nvml.Interface = &Interface{}
 //			DeviceGetGpuFabricInfoVFunc: func(device nvml.Device) nvml.GpuFabricInfoHandler {
 //				panic("mock out the DeviceGetGpuFabricInfoV method")
 //			},
+//			DeviceGetGpuFabricInfo_v4Func: func(device nvml.Device) (nvml.GpuFabricInfo_v4, nvml.Return) {
+//				panic("mock out the DeviceGetGpuFabricInfo_v4 method")
+//			},
 //			DeviceGetGpuInstanceByIdFunc: func(device nvml.Device, n int) (nvml.GpuInstance, nvml.Return) {
 //				panic("mock out the DeviceGetGpuInstanceById method")
 //			},
@@ -390,6 +399,9 @@ var _ nvml.Interface = &Interface{}
 //			DeviceGetMemoryInfo_v2Func: func(device nvml.Device) (nvml.Memory_v2, nvml.Return) {
 //				panic("mock out the DeviceGetMemoryInfo_v2 method")
 //			},
+//			DeviceGetMemoryLimits_v1Func: func(device nvml.Device, s string) (nvml.MemoryLimits_v1, nvml.Return) {
+//				panic("mock out the DeviceGetMemoryLimits_v1 method")
+//			},
 //			DeviceGetMigDeviceHandleByIndexFunc: func(device nvml.Device, n int) (nvml.Device, nvml.Return) {
 //				panic("mock out the DeviceGetMigDeviceHandleByIndex method")
 //			},
@@ -440,6 +452,9 @@ var _ nvml.Interface = &Interface{}
 //			},
 //			DeviceGetNvLinkStateFunc: func(device nvml.Device, n int) (nvml.EnableState, nvml.Return) {
 //				panic("mock out the DeviceGetNvLinkState method")
+//			},
+//			DeviceGetNvLinkTelemetrySamples_v1Func: func(device nvml.Device, nvlinkTelemetrySamples_v1 nvml.NvlinkTelemetrySamples_v1) (nvml.NvlinkTelemetrySamples_v1, nvml.Return) {
+//				panic("mock out the DeviceGetNvLinkTelemetrySamples_v1 method")
 //			},
 //			DeviceGetNvLinkUtilizationControlFunc: func(device nvml.Device, n1 int, n2 int) (nvml.NvLinkUtilizationControl, nvml.Return) {
 //				panic("mock out the DeviceGetNvLinkUtilizationControl method")
@@ -681,6 +696,9 @@ var _ nvml.Interface = &Interface{}
 //			DeviceOnSameBoardFunc: func(device1 nvml.Device, device2 nvml.Device) (int, nvml.Return) {
 //				panic("mock out the DeviceOnSameBoard method")
 //			},
+//			DevicePerfMetricsGetSamples_v1Func: func(device nvml.Device) (nvml.PerfMetricsSamples_v1, nvml.Return) {
+//				panic("mock out the DevicePerfMetricsGetSamples_v1 method")
+//			},
 //			DevicePowerSmoothingActivatePresetProfileFunc: func(device nvml.Device, powerSmoothingProfile *nvml.PowerSmoothingProfile) nvml.Return {
 //				panic("mock out the DevicePowerSmoothingActivatePresetProfile method")
 //			},
@@ -728,6 +746,9 @@ var _ nvml.Interface = &Interface{}
 //			},
 //			DeviceSetAccountingModeFunc: func(device nvml.Device, enableState nvml.EnableState) nvml.Return {
 //				panic("mock out the DeviceSetAccountingMode method")
+//			},
+//			DeviceSetAdaptiveTgpMode_v1Func: func(device nvml.Device, enableState nvml.EnableState) nvml.Return {
+//				panic("mock out the DeviceSetAdaptiveTgpMode_v1 method")
 //			},
 //			DeviceSetApplicationsClocksFunc: func(device nvml.Device, v1 uint32, v2 uint32) nvml.Return {
 //				panic("mock out the DeviceSetApplicationsClocks method")
@@ -783,6 +804,9 @@ var _ nvml.Interface = &Interface{}
 //			DeviceSetMemClkVfOffsetFunc: func(device nvml.Device, n int) nvml.Return {
 //				panic("mock out the DeviceSetMemClkVfOffset method")
 //			},
+//			DeviceSetMemoryLimits_v1Func: func(device nvml.Device, s string, v1 uint64, v2 uint64) nvml.Return {
+//				panic("mock out the DeviceSetMemoryLimits_v1 method")
+//			},
 //			DeviceSetMemoryLockedClocksFunc: func(device nvml.Device, v1 uint32, v2 uint32) nvml.Return {
 //				panic("mock out the DeviceSetMemoryLockedClocks method")
 //			},
@@ -797,6 +821,9 @@ var _ nvml.Interface = &Interface{}
 //			},
 //			DeviceSetNvlinkBwModeFunc: func(device nvml.Device, nvlinkSetBwMode *nvml.NvlinkSetBwMode) nvml.Return {
 //				panic("mock out the DeviceSetNvlinkBwMode method")
+//			},
+//			DeviceSetNvlinkBwModeAsync_v1Func: func(device nvml.Device, nvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1) nvml.Return {
+//				panic("mock out the DeviceSetNvlinkBwModeAsync_v1 method")
 //			},
 //			DeviceSetPersistenceModeFunc: func(device nvml.Device, enableState nvml.EnableState) nvml.Return {
 //				panic("mock out the DeviceSetPersistenceMode method")
@@ -858,8 +885,26 @@ var _ nvml.Interface = &Interface{}
 //			EventSetFreeFunc: func(eventSet nvml.EventSet) nvml.Return {
 //				panic("mock out the EventSetFree method")
 //			},
+//			EventSetGetContextCount_v1Func: func(eventSet nvml.EventSet) (nvml.GetContextCount_v1, nvml.Return) {
+//				panic("mock out the EventSetGetContextCount_v1 method")
+//			},
+//			EventSetGetContextData_v1Func: func(eventSet nvml.EventSet, getContextData_v1 nvml.GetContextData_v1) (nvml.GetContextData_v1, nvml.Return) {
+//				panic("mock out the EventSetGetContextData_v1 method")
+//			},
+//			EventSetGetContextInfo_v1Func: func(eventSet nvml.EventSet, v uint32) (nvml.GetContextInfo_v1, nvml.Return) {
+//				panic("mock out the EventSetGetContextInfo_v1 method")
+//			},
+//			EventSetGetGpuOperationalEventContextLegacyXid_v1Func: func(eventSet nvml.EventSet, v uint32) (uint32, nvml.Return) {
+//				panic("mock out the EventSetGetGpuOperationalEventContextLegacyXid_v1 method")
+//			},
+//			EventSetRegisterGpuOperationalEvents_v1Func: func(eventSet nvml.EventSet, gpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1) nvml.Return {
+//				panic("mock out the EventSetRegisterGpuOperationalEvents_v1 method")
+//			},
 //			EventSetWaitFunc: func(eventSet nvml.EventSet, v uint32) (nvml.EventData, nvml.Return) {
 //				panic("mock out the EventSetWait method")
+//			},
+//			EventSetWait_v3Func: func(eventSet nvml.EventSet, v uint32) (nvml.EventSetWaitData_v3, nvml.Return) {
+//				panic("mock out the EventSetWait_v3 method")
 //			},
 //			ExtensionsFunc: func() nvml.ExtendedInterface {
 //				panic("mock out the Extensions method")
@@ -1255,6 +1300,9 @@ type Interface struct {
 	// DeviceGetAdaptiveClockInfoStatusFunc mocks the DeviceGetAdaptiveClockInfoStatus method.
 	DeviceGetAdaptiveClockInfoStatusFunc func(device nvml.Device) (uint32, nvml.Return)
 
+	// DeviceGetAdaptiveTgpModeInfo_v1Func mocks the DeviceGetAdaptiveTgpModeInfo_v1 method.
+	DeviceGetAdaptiveTgpModeInfo_v1Func func(device nvml.Device) (nvml.AdaptiveTgpModeInfo_v1, nvml.Return)
+
 	// DeviceGetAddressingModeFunc mocks the DeviceGetAddressingMode method.
 	DeviceGetAddressingModeFunc func(device nvml.Device) (nvml.DeviceAddressingMode, nvml.Return)
 
@@ -1275,6 +1323,9 @@ type Interface struct {
 
 	// DeviceGetBBXTimeData_v1Func mocks the DeviceGetBBXTimeData_v1 method.
 	DeviceGetBBXTimeData_v1Func func(device nvml.Device) (nvml.BBXTimeData_v1, nvml.Return)
+
+	// DeviceGetBankRemapperStatus_v1Func mocks the DeviceGetBankRemapperStatus_v1 method.
+	DeviceGetBankRemapperStatus_v1Func func(device nvml.Device) (nvml.EccBankRemapperStatus_v1, nvml.Return)
 
 	// DeviceGetBoardIdFunc mocks the DeviceGetBoardId method.
 	DeviceGetBoardIdFunc func(device nvml.Device) (uint32, nvml.Return)
@@ -1447,6 +1498,9 @@ type Interface struct {
 	// DeviceGetGpuFabricInfoVFunc mocks the DeviceGetGpuFabricInfoV method.
 	DeviceGetGpuFabricInfoVFunc func(device nvml.Device) nvml.GpuFabricInfoHandler
 
+	// DeviceGetGpuFabricInfo_v4Func mocks the DeviceGetGpuFabricInfo_v4 method.
+	DeviceGetGpuFabricInfo_v4Func func(device nvml.Device) (nvml.GpuFabricInfo_v4, nvml.Return)
+
 	// DeviceGetGpuInstanceByIdFunc mocks the DeviceGetGpuInstanceById method.
 	DeviceGetGpuInstanceByIdFunc func(device nvml.Device, n int) (nvml.GpuInstance, nvml.Return)
 
@@ -1573,6 +1627,9 @@ type Interface struct {
 	// DeviceGetMemoryInfo_v2Func mocks the DeviceGetMemoryInfo_v2 method.
 	DeviceGetMemoryInfo_v2Func func(device nvml.Device) (nvml.Memory_v2, nvml.Return)
 
+	// DeviceGetMemoryLimits_v1Func mocks the DeviceGetMemoryLimits_v1 method.
+	DeviceGetMemoryLimits_v1Func func(device nvml.Device, s string) (nvml.MemoryLimits_v1, nvml.Return)
+
 	// DeviceGetMigDeviceHandleByIndexFunc mocks the DeviceGetMigDeviceHandleByIndex method.
 	DeviceGetMigDeviceHandleByIndexFunc func(device nvml.Device, n int) (nvml.Device, nvml.Return)
 
@@ -1623,6 +1680,9 @@ type Interface struct {
 
 	// DeviceGetNvLinkStateFunc mocks the DeviceGetNvLinkState method.
 	DeviceGetNvLinkStateFunc func(device nvml.Device, n int) (nvml.EnableState, nvml.Return)
+
+	// DeviceGetNvLinkTelemetrySamples_v1Func mocks the DeviceGetNvLinkTelemetrySamples_v1 method.
+	DeviceGetNvLinkTelemetrySamples_v1Func func(device nvml.Device, nvlinkTelemetrySamples_v1 nvml.NvlinkTelemetrySamples_v1) (nvml.NvlinkTelemetrySamples_v1, nvml.Return)
 
 	// DeviceGetNvLinkUtilizationControlFunc mocks the DeviceGetNvLinkUtilizationControl method.
 	DeviceGetNvLinkUtilizationControlFunc func(device nvml.Device, n1 int, n2 int) (nvml.NvLinkUtilizationControl, nvml.Return)
@@ -1864,6 +1924,9 @@ type Interface struct {
 	// DeviceOnSameBoardFunc mocks the DeviceOnSameBoard method.
 	DeviceOnSameBoardFunc func(device1 nvml.Device, device2 nvml.Device) (int, nvml.Return)
 
+	// DevicePerfMetricsGetSamples_v1Func mocks the DevicePerfMetricsGetSamples_v1 method.
+	DevicePerfMetricsGetSamples_v1Func func(device nvml.Device) (nvml.PerfMetricsSamples_v1, nvml.Return)
+
 	// DevicePowerSmoothingActivatePresetProfileFunc mocks the DevicePowerSmoothingActivatePresetProfile method.
 	DevicePowerSmoothingActivatePresetProfileFunc func(device nvml.Device, powerSmoothingProfile *nvml.PowerSmoothingProfile) nvml.Return
 
@@ -1911,6 +1974,9 @@ type Interface struct {
 
 	// DeviceSetAccountingModeFunc mocks the DeviceSetAccountingMode method.
 	DeviceSetAccountingModeFunc func(device nvml.Device, enableState nvml.EnableState) nvml.Return
+
+	// DeviceSetAdaptiveTgpMode_v1Func mocks the DeviceSetAdaptiveTgpMode_v1 method.
+	DeviceSetAdaptiveTgpMode_v1Func func(device nvml.Device, enableState nvml.EnableState) nvml.Return
 
 	// DeviceSetApplicationsClocksFunc mocks the DeviceSetApplicationsClocks method.
 	DeviceSetApplicationsClocksFunc func(device nvml.Device, v1 uint32, v2 uint32) nvml.Return
@@ -1966,6 +2032,9 @@ type Interface struct {
 	// DeviceSetMemClkVfOffsetFunc mocks the DeviceSetMemClkVfOffset method.
 	DeviceSetMemClkVfOffsetFunc func(device nvml.Device, n int) nvml.Return
 
+	// DeviceSetMemoryLimits_v1Func mocks the DeviceSetMemoryLimits_v1 method.
+	DeviceSetMemoryLimits_v1Func func(device nvml.Device, s string, v1 uint64, v2 uint64) nvml.Return
+
 	// DeviceSetMemoryLockedClocksFunc mocks the DeviceSetMemoryLockedClocks method.
 	DeviceSetMemoryLockedClocksFunc func(device nvml.Device, v1 uint32, v2 uint32) nvml.Return
 
@@ -1980,6 +2049,9 @@ type Interface struct {
 
 	// DeviceSetNvlinkBwModeFunc mocks the DeviceSetNvlinkBwMode method.
 	DeviceSetNvlinkBwModeFunc func(device nvml.Device, nvlinkSetBwMode *nvml.NvlinkSetBwMode) nvml.Return
+
+	// DeviceSetNvlinkBwModeAsync_v1Func mocks the DeviceSetNvlinkBwModeAsync_v1 method.
+	DeviceSetNvlinkBwModeAsync_v1Func func(device nvml.Device, nvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1) nvml.Return
 
 	// DeviceSetPersistenceModeFunc mocks the DeviceSetPersistenceMode method.
 	DeviceSetPersistenceModeFunc func(device nvml.Device, enableState nvml.EnableState) nvml.Return
@@ -2041,8 +2113,26 @@ type Interface struct {
 	// EventSetFreeFunc mocks the EventSetFree method.
 	EventSetFreeFunc func(eventSet nvml.EventSet) nvml.Return
 
+	// EventSetGetContextCount_v1Func mocks the EventSetGetContextCount_v1 method.
+	EventSetGetContextCount_v1Func func(eventSet nvml.EventSet) (nvml.GetContextCount_v1, nvml.Return)
+
+	// EventSetGetContextData_v1Func mocks the EventSetGetContextData_v1 method.
+	EventSetGetContextData_v1Func func(eventSet nvml.EventSet, getContextData_v1 nvml.GetContextData_v1) (nvml.GetContextData_v1, nvml.Return)
+
+	// EventSetGetContextInfo_v1Func mocks the EventSetGetContextInfo_v1 method.
+	EventSetGetContextInfo_v1Func func(eventSet nvml.EventSet, v uint32) (nvml.GetContextInfo_v1, nvml.Return)
+
+	// EventSetGetGpuOperationalEventContextLegacyXid_v1Func mocks the EventSetGetGpuOperationalEventContextLegacyXid_v1 method.
+	EventSetGetGpuOperationalEventContextLegacyXid_v1Func func(eventSet nvml.EventSet, v uint32) (uint32, nvml.Return)
+
+	// EventSetRegisterGpuOperationalEvents_v1Func mocks the EventSetRegisterGpuOperationalEvents_v1 method.
+	EventSetRegisterGpuOperationalEvents_v1Func func(eventSet nvml.EventSet, gpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1) nvml.Return
+
 	// EventSetWaitFunc mocks the EventSetWait method.
 	EventSetWaitFunc func(eventSet nvml.EventSet, v uint32) (nvml.EventData, nvml.Return)
+
+	// EventSetWait_v3Func mocks the EventSetWait_v3 method.
+	EventSetWait_v3Func func(eventSet nvml.EventSet, v uint32) (nvml.EventSetWaitData_v3, nvml.Return)
 
 	// ExtensionsFunc mocks the Extensions method.
 	ExtensionsFunc func() nvml.ExtendedInterface
@@ -2489,6 +2579,11 @@ type Interface struct {
 			// Device is the device argument value.
 			Device nvml.Device
 		}
+		// DeviceGetAdaptiveTgpModeInfo_v1 holds details about calls to the DeviceGetAdaptiveTgpModeInfo_v1 method.
+		DeviceGetAdaptiveTgpModeInfo_v1 []struct {
+			// Device is the device argument value.
+			Device nvml.Device
+		}
 		// DeviceGetAddressingMode holds details about calls to the DeviceGetAddressingMode method.
 		DeviceGetAddressingMode []struct {
 			// Device is the device argument value.
@@ -2523,6 +2618,11 @@ type Interface struct {
 		}
 		// DeviceGetBBXTimeData_v1 holds details about calls to the DeviceGetBBXTimeData_v1 method.
 		DeviceGetBBXTimeData_v1 []struct {
+			// Device is the device argument value.
+			Device nvml.Device
+		}
+		// DeviceGetBankRemapperStatus_v1 holds details about calls to the DeviceGetBankRemapperStatus_v1 method.
+		DeviceGetBankRemapperStatus_v1 []struct {
 			// Device is the device argument value.
 			Device nvml.Device
 		}
@@ -2837,6 +2937,11 @@ type Interface struct {
 			// Device is the device argument value.
 			Device nvml.Device
 		}
+		// DeviceGetGpuFabricInfo_v4 holds details about calls to the DeviceGetGpuFabricInfo_v4 method.
+		DeviceGetGpuFabricInfo_v4 []struct {
+			// Device is the device argument value.
+			Device nvml.Device
+		}
 		// DeviceGetGpuInstanceById holds details about calls to the DeviceGetGpuInstanceById method.
 		DeviceGetGpuInstanceById []struct {
 			// Device is the device argument value.
@@ -3077,6 +3182,13 @@ type Interface struct {
 			// Device is the device argument value.
 			Device nvml.Device
 		}
+		// DeviceGetMemoryLimits_v1 holds details about calls to the DeviceGetMemoryLimits_v1 method.
+		DeviceGetMemoryLimits_v1 []struct {
+			// Device is the device argument value.
+			Device nvml.Device
+			// S is the s argument value.
+			S string
+		}
 		// DeviceGetMigDeviceHandleByIndex holds details about calls to the DeviceGetMigDeviceHandleByIndex method.
 		DeviceGetMigDeviceHandleByIndex []struct {
 			// Device is the device argument value.
@@ -3181,6 +3293,13 @@ type Interface struct {
 			Device nvml.Device
 			// N is the n argument value.
 			N int
+		}
+		// DeviceGetNvLinkTelemetrySamples_v1 holds details about calls to the DeviceGetNvLinkTelemetrySamples_v1 method.
+		DeviceGetNvLinkTelemetrySamples_v1 []struct {
+			// Device is the device argument value.
+			Device nvml.Device
+			// NvlinkTelemetrySamples_v1 is the nvlinkTelemetrySamples_v1 argument value.
+			NvlinkTelemetrySamples_v1 nvml.NvlinkTelemetrySamples_v1
 		}
 		// DeviceGetNvLinkUtilizationControl holds details about calls to the DeviceGetNvLinkUtilizationControl method.
 		DeviceGetNvLinkUtilizationControl []struct {
@@ -3648,6 +3767,11 @@ type Interface struct {
 			// Device2 is the device2 argument value.
 			Device2 nvml.Device
 		}
+		// DevicePerfMetricsGetSamples_v1 holds details about calls to the DevicePerfMetricsGetSamples_v1 method.
+		DevicePerfMetricsGetSamples_v1 []struct {
+			// Device is the device argument value.
+			Device nvml.Device
+		}
 		// DevicePowerSmoothingActivatePresetProfile holds details about calls to the DevicePowerSmoothingActivatePresetProfile method.
 		DevicePowerSmoothingActivatePresetProfile []struct {
 			// Device is the device argument value.
@@ -3755,6 +3879,13 @@ type Interface struct {
 		}
 		// DeviceSetAccountingMode holds details about calls to the DeviceSetAccountingMode method.
 		DeviceSetAccountingMode []struct {
+			// Device is the device argument value.
+			Device nvml.Device
+			// EnableState is the enableState argument value.
+			EnableState nvml.EnableState
+		}
+		// DeviceSetAdaptiveTgpMode_v1 holds details about calls to the DeviceSetAdaptiveTgpMode_v1 method.
+		DeviceSetAdaptiveTgpMode_v1 []struct {
 			// Device is the device argument value.
 			Device nvml.Device
 			// EnableState is the enableState argument value.
@@ -3896,6 +4027,17 @@ type Interface struct {
 			// N is the n argument value.
 			N int
 		}
+		// DeviceSetMemoryLimits_v1 holds details about calls to the DeviceSetMemoryLimits_v1 method.
+		DeviceSetMemoryLimits_v1 []struct {
+			// Device is the device argument value.
+			Device nvml.Device
+			// S is the s argument value.
+			S string
+			// V1 is the v1 argument value.
+			V1 uint64
+			// V2 is the v2 argument value.
+			V2 uint64
+		}
 		// DeviceSetMemoryLockedClocks holds details about calls to the DeviceSetMemoryLockedClocks method.
 		DeviceSetMemoryLockedClocks []struct {
 			// Device is the device argument value.
@@ -3938,6 +4080,13 @@ type Interface struct {
 			Device nvml.Device
 			// NvlinkSetBwMode is the nvlinkSetBwMode argument value.
 			NvlinkSetBwMode *nvml.NvlinkSetBwMode
+		}
+		// DeviceSetNvlinkBwModeAsync_v1 holds details about calls to the DeviceSetNvlinkBwModeAsync_v1 method.
+		DeviceSetNvlinkBwModeAsync_v1 []struct {
+			// Device is the device argument value.
+			Device nvml.Device
+			// NvlinkSetBwModeAsync_v1 is the nvlinkSetBwModeAsync_v1 argument value.
+			NvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1
 		}
 		// DeviceSetPersistenceMode holds details about calls to the DeviceSetPersistenceMode method.
 		DeviceSetPersistenceMode []struct {
@@ -4069,8 +4218,48 @@ type Interface struct {
 			// EventSet is the eventSet argument value.
 			EventSet nvml.EventSet
 		}
+		// EventSetGetContextCount_v1 holds details about calls to the EventSetGetContextCount_v1 method.
+		EventSetGetContextCount_v1 []struct {
+			// EventSet is the eventSet argument value.
+			EventSet nvml.EventSet
+		}
+		// EventSetGetContextData_v1 holds details about calls to the EventSetGetContextData_v1 method.
+		EventSetGetContextData_v1 []struct {
+			// EventSet is the eventSet argument value.
+			EventSet nvml.EventSet
+			// GetContextData_v1 is the getContextData_v1 argument value.
+			GetContextData_v1 nvml.GetContextData_v1
+		}
+		// EventSetGetContextInfo_v1 holds details about calls to the EventSetGetContextInfo_v1 method.
+		EventSetGetContextInfo_v1 []struct {
+			// EventSet is the eventSet argument value.
+			EventSet nvml.EventSet
+			// V is the v argument value.
+			V uint32
+		}
+		// EventSetGetGpuOperationalEventContextLegacyXid_v1 holds details about calls to the EventSetGetGpuOperationalEventContextLegacyXid_v1 method.
+		EventSetGetGpuOperationalEventContextLegacyXid_v1 []struct {
+			// EventSet is the eventSet argument value.
+			EventSet nvml.EventSet
+			// V is the v argument value.
+			V uint32
+		}
+		// EventSetRegisterGpuOperationalEvents_v1 holds details about calls to the EventSetRegisterGpuOperationalEvents_v1 method.
+		EventSetRegisterGpuOperationalEvents_v1 []struct {
+			// EventSet is the eventSet argument value.
+			EventSet nvml.EventSet
+			// GpuOperationalEventConfig_v1 is the gpuOperationalEventConfig_v1 argument value.
+			GpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1
+		}
 		// EventSetWait holds details about calls to the EventSetWait method.
 		EventSetWait []struct {
+			// EventSet is the eventSet argument value.
+			EventSet nvml.EventSet
+			// V is the v argument value.
+			V uint32
+		}
+		// EventSetWait_v3 holds details about calls to the EventSetWait_v3 method.
+		EventSetWait_v3 []struct {
 			// EventSet is the eventSet argument value.
 			EventSet nvml.EventSet
 			// V is the v argument value.
@@ -4650,398 +4839,413 @@ type Interface struct {
 			N int
 		}
 	}
-	lockComputeInstanceDestroy                           sync.RWMutex
-	lockComputeInstanceGetInfo                           sync.RWMutex
-	lockDeviceClearAccountingPids                        sync.RWMutex
-	lockDeviceClearCpuAffinity                           sync.RWMutex
-	lockDeviceClearEccErrorCounts                        sync.RWMutex
-	lockDeviceClearFieldValues                           sync.RWMutex
-	lockDeviceCreateGpuInstance                          sync.RWMutex
-	lockDeviceCreateGpuInstanceWithPlacement             sync.RWMutex
-	lockDeviceDiscoverGpus                               sync.RWMutex
-	lockDeviceFreezeNvLinkUtilizationCounter             sync.RWMutex
-	lockDeviceGetAPIRestriction                          sync.RWMutex
-	lockDeviceGetAccountingBufferSize                    sync.RWMutex
-	lockDeviceGetAccountingMode                          sync.RWMutex
-	lockDeviceGetAccountingPids                          sync.RWMutex
-	lockDeviceGetAccountingStats                         sync.RWMutex
-	lockDeviceGetAccountingStats_v2                      sync.RWMutex
-	lockDeviceGetActiveVgpus                             sync.RWMutex
-	lockDeviceGetAdaptiveClockInfoStatus                 sync.RWMutex
-	lockDeviceGetAddressingMode                          sync.RWMutex
-	lockDeviceGetApplicationsClock                       sync.RWMutex
-	lockDeviceGetArchitecture                            sync.RWMutex
-	lockDeviceGetAttributes                              sync.RWMutex
-	lockDeviceGetAutoBoostedClocksEnabled                sync.RWMutex
-	lockDeviceGetBAR1MemoryInfo                          sync.RWMutex
-	lockDeviceGetBBXTimeData_v1                          sync.RWMutex
-	lockDeviceGetBoardId                                 sync.RWMutex
-	lockDeviceGetBoardPartNumber                         sync.RWMutex
-	lockDeviceGetBrand                                   sync.RWMutex
-	lockDeviceGetBridgeChipInfo                          sync.RWMutex
-	lockDeviceGetBusType                                 sync.RWMutex
-	lockDeviceGetC2cModeInfoV                            sync.RWMutex
-	lockDeviceGetCapabilities                            sync.RWMutex
-	lockDeviceGetClkMonStatus                            sync.RWMutex
-	lockDeviceGetClock                                   sync.RWMutex
-	lockDeviceGetClockInfo                               sync.RWMutex
-	lockDeviceGetClockOffsets                            sync.RWMutex
-	lockDeviceGetComputeInstanceId                       sync.RWMutex
-	lockDeviceGetComputeMode                             sync.RWMutex
-	lockDeviceGetComputeRunningProcesses                 sync.RWMutex
-	lockDeviceGetConfComputeGpuAttestationReport         sync.RWMutex
-	lockDeviceGetConfComputeGpuCertificate               sync.RWMutex
-	lockDeviceGetConfComputeMemSizeInfo                  sync.RWMutex
-	lockDeviceGetConfComputeProtectedMemoryUsage         sync.RWMutex
-	lockDeviceGetCoolerInfo                              sync.RWMutex
-	lockDeviceGetCount                                   sync.RWMutex
-	lockDeviceGetCpuAffinity                             sync.RWMutex
-	lockDeviceGetCpuAffinityWithinScope                  sync.RWMutex
-	lockDeviceGetCreatableVgpus                          sync.RWMutex
-	lockDeviceGetCudaComputeCapability                   sync.RWMutex
-	lockDeviceGetCurrPcieLinkGeneration                  sync.RWMutex
-	lockDeviceGetCurrPcieLinkWidth                       sync.RWMutex
-	lockDeviceGetCurrentClockFreqs                       sync.RWMutex
-	lockDeviceGetCurrentClocksEventReasons               sync.RWMutex
-	lockDeviceGetCurrentClocksThrottleReasons            sync.RWMutex
-	lockDeviceGetDecoderUtilization                      sync.RWMutex
-	lockDeviceGetDefaultApplicationsClock                sync.RWMutex
-	lockDeviceGetDefaultEccMode                          sync.RWMutex
-	lockDeviceGetDetailedEccErrors                       sync.RWMutex
-	lockDeviceGetDeviceHandleFromMigDeviceHandle         sync.RWMutex
-	lockDeviceGetDisplayActive                           sync.RWMutex
-	lockDeviceGetDisplayMode                             sync.RWMutex
-	lockDeviceGetDramEncryptionMode                      sync.RWMutex
-	lockDeviceGetDriverModel                             sync.RWMutex
-	lockDeviceGetDriverModel_v2                          sync.RWMutex
-	lockDeviceGetDynamicPstatesInfo                      sync.RWMutex
-	lockDeviceGetEccMode                                 sync.RWMutex
-	lockDeviceGetEncoderCapacity                         sync.RWMutex
-	lockDeviceGetEncoderSessions                         sync.RWMutex
-	lockDeviceGetEncoderStats                            sync.RWMutex
-	lockDeviceGetEncoderUtilization                      sync.RWMutex
-	lockDeviceGetEnforcedPowerLimit                      sync.RWMutex
-	lockDeviceGetFBCSessions                             sync.RWMutex
-	lockDeviceGetFBCStats                                sync.RWMutex
-	lockDeviceGetFanControlPolicy_v2                     sync.RWMutex
-	lockDeviceGetFanSpeed                                sync.RWMutex
-	lockDeviceGetFanSpeedRPM                             sync.RWMutex
-	lockDeviceGetFanSpeed_v2                             sync.RWMutex
-	lockDeviceGetFieldValues                             sync.RWMutex
-	lockDeviceGetGpcClkMinMaxVfOffset                    sync.RWMutex
-	lockDeviceGetGpcClkVfOffset                          sync.RWMutex
-	lockDeviceGetGpuFabricInfo                           sync.RWMutex
-	lockDeviceGetGpuFabricInfoV                          sync.RWMutex
-	lockDeviceGetGpuInstanceById                         sync.RWMutex
-	lockDeviceGetGpuInstanceId                           sync.RWMutex
-	lockDeviceGetGpuInstancePossiblePlacements           sync.RWMutex
-	lockDeviceGetGpuInstanceProfileInfo                  sync.RWMutex
-	lockDeviceGetGpuInstanceProfileInfoByIdV             sync.RWMutex
-	lockDeviceGetGpuInstanceProfileInfoV                 sync.RWMutex
-	lockDeviceGetGpuInstanceRemainingCapacity            sync.RWMutex
-	lockDeviceGetGpuInstances                            sync.RWMutex
-	lockDeviceGetGpuMaxPcieLinkGeneration                sync.RWMutex
-	lockDeviceGetGpuOperationMode                        sync.RWMutex
-	lockDeviceGetGraphicsRunningProcesses                sync.RWMutex
-	lockDeviceGetGridLicensableFeatures                  sync.RWMutex
-	lockDeviceGetGspFirmwareMode                         sync.RWMutex
-	lockDeviceGetGspFirmwareVersion                      sync.RWMutex
-	lockDeviceGetHandleByIndex                           sync.RWMutex
-	lockDeviceGetHandleByPciBusId                        sync.RWMutex
-	lockDeviceGetHandleBySerial                          sync.RWMutex
-	lockDeviceGetHandleByUUID                            sync.RWMutex
-	lockDeviceGetHandleByUUIDV                           sync.RWMutex
-	lockDeviceGetHostVgpuMode                            sync.RWMutex
-	lockDeviceGetHostname_v1                             sync.RWMutex
-	lockDeviceGetIndex                                   sync.RWMutex
-	lockDeviceGetInforomConfigurationChecksum            sync.RWMutex
-	lockDeviceGetInforomImageVersion                     sync.RWMutex
-	lockDeviceGetInforomVersion                          sync.RWMutex
-	lockDeviceGetIrqNum                                  sync.RWMutex
-	lockDeviceGetJpgUtilization                          sync.RWMutex
-	lockDeviceGetLastBBXFlushTime                        sync.RWMutex
-	lockDeviceGetMPSComputeRunningProcesses              sync.RWMutex
-	lockDeviceGetMarginTemperature                       sync.RWMutex
-	lockDeviceGetMaxClockInfo                            sync.RWMutex
-	lockDeviceGetMaxCustomerBoostClock                   sync.RWMutex
-	lockDeviceGetMaxMigDeviceCount                       sync.RWMutex
-	lockDeviceGetMaxPcieLinkGeneration                   sync.RWMutex
-	lockDeviceGetMaxPcieLinkWidth                        sync.RWMutex
-	lockDeviceGetMemClkMinMaxVfOffset                    sync.RWMutex
-	lockDeviceGetMemClkVfOffset                          sync.RWMutex
-	lockDeviceGetMemoryAffinity                          sync.RWMutex
-	lockDeviceGetMemoryBusWidth                          sync.RWMutex
-	lockDeviceGetMemoryErrorCounter                      sync.RWMutex
-	lockDeviceGetMemoryInfo                              sync.RWMutex
-	lockDeviceGetMemoryInfo_v2                           sync.RWMutex
-	lockDeviceGetMigDeviceHandleByIndex                  sync.RWMutex
-	lockDeviceGetMigMode                                 sync.RWMutex
-	lockDeviceGetMinMaxClockOfPState                     sync.RWMutex
-	lockDeviceGetMinMaxFanSpeed                          sync.RWMutex
-	lockDeviceGetMinorNumber                             sync.RWMutex
-	lockDeviceGetModuleId                                sync.RWMutex
-	lockDeviceGetMultiGpuBoard                           sync.RWMutex
-	lockDeviceGetName                                    sync.RWMutex
-	lockDeviceGetNumFans                                 sync.RWMutex
-	lockDeviceGetNumGpuCores                             sync.RWMutex
-	lockDeviceGetNumaNodeId                              sync.RWMutex
-	lockDeviceGetNvLinkCapability                        sync.RWMutex
-	lockDeviceGetNvLinkErrorCounter                      sync.RWMutex
-	lockDeviceGetNvLinkInfo                              sync.RWMutex
-	lockDeviceGetNvLinkRemoteDeviceType                  sync.RWMutex
-	lockDeviceGetNvLinkRemotePciInfo                     sync.RWMutex
-	lockDeviceGetNvLinkState                             sync.RWMutex
-	lockDeviceGetNvLinkUtilizationControl                sync.RWMutex
-	lockDeviceGetNvLinkUtilizationCounter                sync.RWMutex
-	lockDeviceGetNvLinkVersion                           sync.RWMutex
-	lockDeviceGetNvlinkBwMode                            sync.RWMutex
-	lockDeviceGetNvlinkSupportedBwModes                  sync.RWMutex
-	lockDeviceGetOfaUtilization                          sync.RWMutex
-	lockDeviceGetP2PStatus                               sync.RWMutex
-	lockDeviceGetPciInfo                                 sync.RWMutex
-	lockDeviceGetPciInfoExt                              sync.RWMutex
-	lockDeviceGetPcieLinkMaxSpeed                        sync.RWMutex
-	lockDeviceGetPcieReplayCounter                       sync.RWMutex
-	lockDeviceGetPcieSpeed                               sync.RWMutex
-	lockDeviceGetPcieThroughput                          sync.RWMutex
-	lockDeviceGetPdi                                     sync.RWMutex
-	lockDeviceGetPerformanceModes                        sync.RWMutex
-	lockDeviceGetPerformanceState                        sync.RWMutex
-	lockDeviceGetPersistenceMode                         sync.RWMutex
-	lockDeviceGetPgpuMetadataString                      sync.RWMutex
-	lockDeviceGetPlatformInfo                            sync.RWMutex
-	lockDeviceGetPowerManagementDefaultLimit             sync.RWMutex
-	lockDeviceGetPowerManagementLimit                    sync.RWMutex
-	lockDeviceGetPowerManagementLimitConstraints         sync.RWMutex
-	lockDeviceGetPowerManagementMode                     sync.RWMutex
-	lockDeviceGetPowerMizerMode_v1                       sync.RWMutex
-	lockDeviceGetPowerSource                             sync.RWMutex
-	lockDeviceGetPowerState                              sync.RWMutex
-	lockDeviceGetPowerUsage                              sync.RWMutex
-	lockDeviceGetProcessUtilization                      sync.RWMutex
-	lockDeviceGetProcessesUtilizationInfo                sync.RWMutex
-	lockDeviceGetRemappedRows                            sync.RWMutex
-	lockDeviceGetRemappedRows_v2                         sync.RWMutex
-	lockDeviceGetRepairStatus                            sync.RWMutex
-	lockDeviceGetRetiredPages                            sync.RWMutex
-	lockDeviceGetRetiredPagesPendingStatus               sync.RWMutex
-	lockDeviceGetRetiredPages_v2                         sync.RWMutex
-	lockDeviceGetRowRemapperHistogram                    sync.RWMutex
-	lockDeviceGetRunningProcessDetailList                sync.RWMutex
-	lockDeviceGetSamples                                 sync.RWMutex
-	lockDeviceGetSerial                                  sync.RWMutex
-	lockDeviceGetSramEccErrorStatus                      sync.RWMutex
-	lockDeviceGetSramUniqueUncorrectedEccErrorCounts     sync.RWMutex
-	lockDeviceGetSupportedClocksEventReasons             sync.RWMutex
-	lockDeviceGetSupportedClocksThrottleReasons          sync.RWMutex
-	lockDeviceGetSupportedEventTypes                     sync.RWMutex
-	lockDeviceGetSupportedGraphicsClocks                 sync.RWMutex
-	lockDeviceGetSupportedMemoryClocks                   sync.RWMutex
-	lockDeviceGetSupportedPerformanceStates              sync.RWMutex
-	lockDeviceGetSupportedVgpus                          sync.RWMutex
-	lockDeviceGetTargetFanSpeed                          sync.RWMutex
-	lockDeviceGetTemperature                             sync.RWMutex
-	lockDeviceGetTemperatureThreshold                    sync.RWMutex
-	lockDeviceGetTemperatureV                            sync.RWMutex
-	lockDeviceGetThermalSettings                         sync.RWMutex
-	lockDeviceGetTopologyCommonAncestor                  sync.RWMutex
-	lockDeviceGetTopologyNearestGpus                     sync.RWMutex
-	lockDeviceGetTotalEccErrors                          sync.RWMutex
-	lockDeviceGetTotalEnergyConsumption                  sync.RWMutex
-	lockDeviceGetUUID                                    sync.RWMutex
-	lockDeviceGetUnrepairableMemoryFlag_v1               sync.RWMutex
-	lockDeviceGetUtilizationRates                        sync.RWMutex
-	lockDeviceGetVbiosVersion                            sync.RWMutex
-	lockDeviceGetVgpuCapabilities                        sync.RWMutex
-	lockDeviceGetVgpuHeterogeneousMode                   sync.RWMutex
-	lockDeviceGetVgpuInstancesUtilizationInfo            sync.RWMutex
-	lockDeviceGetVgpuMetadata                            sync.RWMutex
-	lockDeviceGetVgpuProcessUtilization                  sync.RWMutex
-	lockDeviceGetVgpuProcessesUtilizationInfo            sync.RWMutex
-	lockDeviceGetVgpuSchedulerCapabilities               sync.RWMutex
-	lockDeviceGetVgpuSchedulerLog                        sync.RWMutex
-	lockDeviceGetVgpuSchedulerLog_v2                     sync.RWMutex
-	lockDeviceGetVgpuSchedulerState                      sync.RWMutex
-	lockDeviceGetVgpuSchedulerState_v2                   sync.RWMutex
-	lockDeviceGetVgpuTypeCreatablePlacements             sync.RWMutex
-	lockDeviceGetVgpuTypeSupportedPlacements             sync.RWMutex
-	lockDeviceGetVgpuUtilization                         sync.RWMutex
-	lockDeviceGetViolationStatus                         sync.RWMutex
-	lockDeviceGetVirtualizationMode                      sync.RWMutex
-	lockDeviceIsMigDeviceHandle                          sync.RWMutex
-	lockDeviceModifyDrainState                           sync.RWMutex
-	lockDeviceOnSameBoard                                sync.RWMutex
-	lockDevicePowerSmoothingActivatePresetProfile        sync.RWMutex
-	lockDevicePowerSmoothingSetState                     sync.RWMutex
-	lockDevicePowerSmoothingUpdatePresetProfileParam     sync.RWMutex
-	lockDeviceQueryDrainState                            sync.RWMutex
-	lockDeviceReadPRMCounters_v1                         sync.RWMutex
-	lockDeviceReadWritePRM_v1                            sync.RWMutex
-	lockDeviceRegisterEvents                             sync.RWMutex
-	lockDeviceRemoveGpu                                  sync.RWMutex
-	lockDeviceRemoveGpu_v2                               sync.RWMutex
-	lockDeviceResetApplicationsClocks                    sync.RWMutex
-	lockDeviceResetGpuLockedClocks                       sync.RWMutex
-	lockDeviceResetMemoryLockedClocks                    sync.RWMutex
-	lockDeviceResetNvLinkErrorCounters                   sync.RWMutex
-	lockDeviceResetNvLinkUtilizationCounter              sync.RWMutex
-	lockDeviceSetAPIRestriction                          sync.RWMutex
-	lockDeviceSetAccountingMode                          sync.RWMutex
-	lockDeviceSetApplicationsClocks                      sync.RWMutex
-	lockDeviceSetAutoBoostedClocksEnabled                sync.RWMutex
-	lockDeviceSetClockOffsets                            sync.RWMutex
-	lockDeviceSetComputeMode                             sync.RWMutex
-	lockDeviceSetConfComputeUnprotectedMemSize           sync.RWMutex
-	lockDeviceSetCpuAffinity                             sync.RWMutex
-	lockDeviceSetDefaultAutoBoostedClocksEnabled         sync.RWMutex
-	lockDeviceSetDefaultFanSpeed_v2                      sync.RWMutex
-	lockDeviceSetDramEncryptionMode                      sync.RWMutex
-	lockDeviceSetDriverModel                             sync.RWMutex
-	lockDeviceSetEccMode                                 sync.RWMutex
-	lockDeviceSetFanControlPolicy                        sync.RWMutex
-	lockDeviceSetFanSpeed_v2                             sync.RWMutex
-	lockDeviceSetGpcClkVfOffset                          sync.RWMutex
-	lockDeviceSetGpuLockedClocks                         sync.RWMutex
-	lockDeviceSetGpuOperationMode                        sync.RWMutex
-	lockDeviceSetHostname_v1                             sync.RWMutex
-	lockDeviceSetMemClkVfOffset                          sync.RWMutex
-	lockDeviceSetMemoryLockedClocks                      sync.RWMutex
-	lockDeviceSetMigMode                                 sync.RWMutex
-	lockDeviceSetNvLinkDeviceLowPowerThreshold           sync.RWMutex
-	lockDeviceSetNvLinkUtilizationControl                sync.RWMutex
-	lockDeviceSetNvlinkBwMode                            sync.RWMutex
-	lockDeviceSetPersistenceMode                         sync.RWMutex
-	lockDeviceSetPowerManagementLimit                    sync.RWMutex
-	lockDeviceSetPowerManagementLimit_v2                 sync.RWMutex
-	lockDeviceSetRusdSettings_v1                         sync.RWMutex
-	lockDeviceSetTemperatureThreshold                    sync.RWMutex
-	lockDeviceSetVgpuCapabilities                        sync.RWMutex
-	lockDeviceSetVgpuHeterogeneousMode                   sync.RWMutex
-	lockDeviceSetVgpuSchedulerState                      sync.RWMutex
-	lockDeviceSetVgpuSchedulerState_v2                   sync.RWMutex
-	lockDeviceSetVirtualizationMode                      sync.RWMutex
-	lockDeviceValidateInforom                            sync.RWMutex
-	lockDeviceVgpuForceGspUnload                         sync.RWMutex
-	lockDeviceWorkloadPowerProfileClearRequestedProfiles sync.RWMutex
-	lockDeviceWorkloadPowerProfileGetCurrentProfiles     sync.RWMutex
-	lockDeviceWorkloadPowerProfileGetProfilesInfo        sync.RWMutex
-	lockDeviceWorkloadPowerProfileSetRequestedProfiles   sync.RWMutex
-	lockDeviceWorkloadPowerProfileUpdateProfiles_v1      sync.RWMutex
-	lockErrorString                                      sync.RWMutex
-	lockEventSetCreate                                   sync.RWMutex
-	lockEventSetFree                                     sync.RWMutex
-	lockEventSetWait                                     sync.RWMutex
-	lockExtensions                                       sync.RWMutex
-	lockGetExcludedDeviceCount                           sync.RWMutex
-	lockGetExcludedDeviceInfoByIndex                     sync.RWMutex
-	lockGetVgpuCompatibility                             sync.RWMutex
-	lockGetVgpuDriverCapabilities                        sync.RWMutex
-	lockGetVgpuVersion                                   sync.RWMutex
-	lockGpmMetricsGet                                    sync.RWMutex
-	lockGpmMetricsGetV                                   sync.RWMutex
-	lockGpmMigSampleGet                                  sync.RWMutex
-	lockGpmQueryDeviceSupport                            sync.RWMutex
-	lockGpmQueryDeviceSupportV                           sync.RWMutex
-	lockGpmQueryIfStreamingEnabled                       sync.RWMutex
-	lockGpmSampleAlloc                                   sync.RWMutex
-	lockGpmSampleFree                                    sync.RWMutex
-	lockGpmSampleGet                                     sync.RWMutex
-	lockGpmSetStreamingEnabled                           sync.RWMutex
-	lockGpuInstanceCreateComputeInstance                 sync.RWMutex
-	lockGpuInstanceCreateComputeInstanceWithPlacement    sync.RWMutex
-	lockGpuInstanceDestroy                               sync.RWMutex
-	lockGpuInstanceGetActiveVgpus                        sync.RWMutex
-	lockGpuInstanceGetComputeInstanceById                sync.RWMutex
-	lockGpuInstanceGetComputeInstancePossiblePlacements  sync.RWMutex
-	lockGpuInstanceGetComputeInstanceProfileInfo         sync.RWMutex
-	lockGpuInstanceGetComputeInstanceProfileInfoV        sync.RWMutex
-	lockGpuInstanceGetComputeInstanceRemainingCapacity   sync.RWMutex
-	lockGpuInstanceGetComputeInstances                   sync.RWMutex
-	lockGpuInstanceGetCreatableVgpus                     sync.RWMutex
-	lockGpuInstanceGetInfo                               sync.RWMutex
-	lockGpuInstanceGetVgpuHeterogeneousMode              sync.RWMutex
-	lockGpuInstanceGetVgpuSchedulerLog                   sync.RWMutex
-	lockGpuInstanceGetVgpuSchedulerLog_v2                sync.RWMutex
-	lockGpuInstanceGetVgpuSchedulerState                 sync.RWMutex
-	lockGpuInstanceGetVgpuSchedulerState_v2              sync.RWMutex
-	lockGpuInstanceGetVgpuTypeCreatablePlacements        sync.RWMutex
-	lockGpuInstanceSetVgpuHeterogeneousMode              sync.RWMutex
-	lockGpuInstanceSetVgpuSchedulerState                 sync.RWMutex
-	lockGpuInstanceSetVgpuSchedulerState_v2              sync.RWMutex
-	lockInit                                             sync.RWMutex
-	lockInitWithFlags                                    sync.RWMutex
-	lockSetVgpuVersion                                   sync.RWMutex
-	lockShutdown                                         sync.RWMutex
-	lockSystemEventSetCreate                             sync.RWMutex
-	lockSystemEventSetFree                               sync.RWMutex
-	lockSystemEventSetWait                               sync.RWMutex
-	lockSystemGetCPER_v1                                 sync.RWMutex
-	lockSystemGetConfComputeCapabilities                 sync.RWMutex
-	lockSystemGetConfComputeGpusReadyState               sync.RWMutex
-	lockSystemGetConfComputeKeyRotationThresholdInfo     sync.RWMutex
-	lockSystemGetConfComputeSettings                     sync.RWMutex
-	lockSystemGetConfComputeState                        sync.RWMutex
-	lockSystemGetCudaDriverVersion                       sync.RWMutex
-	lockSystemGetCudaDriverVersion_v2                    sync.RWMutex
-	lockSystemGetDriverBranch                            sync.RWMutex
-	lockSystemGetDriverVersion                           sync.RWMutex
-	lockSystemGetHicVersion                              sync.RWMutex
-	lockSystemGetNVMLVersion                             sync.RWMutex
-	lockSystemGetNvlinkBwMode                            sync.RWMutex
-	lockSystemGetProcessName                             sync.RWMutex
-	lockSystemGetTopologyGpuSet                          sync.RWMutex
-	lockSystemRegisterEvents                             sync.RWMutex
-	lockSystemSetConfComputeGpusReadyState               sync.RWMutex
-	lockSystemSetConfComputeKeyRotationThresholdInfo     sync.RWMutex
-	lockSystemSetNvlinkBwMode                            sync.RWMutex
-	lockUnitGetCount                                     sync.RWMutex
-	lockUnitGetDevices                                   sync.RWMutex
-	lockUnitGetFanSpeedInfo                              sync.RWMutex
-	lockUnitGetHandleByIndex                             sync.RWMutex
-	lockUnitGetLedState                                  sync.RWMutex
-	lockUnitGetPsuInfo                                   sync.RWMutex
-	lockUnitGetTemperature                               sync.RWMutex
-	lockUnitGetUnitInfo                                  sync.RWMutex
-	lockUnitSetLedState                                  sync.RWMutex
-	lockVgpuInstanceClearAccountingPids                  sync.RWMutex
-	lockVgpuInstanceGetAccountingMode                    sync.RWMutex
-	lockVgpuInstanceGetAccountingPids                    sync.RWMutex
-	lockVgpuInstanceGetAccountingStats                   sync.RWMutex
-	lockVgpuInstanceGetEccMode                           sync.RWMutex
-	lockVgpuInstanceGetEncoderCapacity                   sync.RWMutex
-	lockVgpuInstanceGetEncoderSessions                   sync.RWMutex
-	lockVgpuInstanceGetEncoderStats                      sync.RWMutex
-	lockVgpuInstanceGetFBCSessions                       sync.RWMutex
-	lockVgpuInstanceGetFBCStats                          sync.RWMutex
-	lockVgpuInstanceGetFbUsage                           sync.RWMutex
-	lockVgpuInstanceGetFrameRateLimit                    sync.RWMutex
-	lockVgpuInstanceGetGpuInstanceId                     sync.RWMutex
-	lockVgpuInstanceGetGpuPciId                          sync.RWMutex
-	lockVgpuInstanceGetLicenseInfo                       sync.RWMutex
-	lockVgpuInstanceGetLicenseStatus                     sync.RWMutex
-	lockVgpuInstanceGetMdevUUID                          sync.RWMutex
-	lockVgpuInstanceGetMetadata                          sync.RWMutex
-	lockVgpuInstanceGetRuntimeStateSize                  sync.RWMutex
-	lockVgpuInstanceGetType                              sync.RWMutex
-	lockVgpuInstanceGetUUID                              sync.RWMutex
-	lockVgpuInstanceGetVmDriverVersion                   sync.RWMutex
-	lockVgpuInstanceGetVmID                              sync.RWMutex
-	lockVgpuInstanceSetEncoderCapacity                   sync.RWMutex
-	lockVgpuTypeGetBAR1Info                              sync.RWMutex
-	lockVgpuTypeGetCapabilities                          sync.RWMutex
-	lockVgpuTypeGetClass                                 sync.RWMutex
-	lockVgpuTypeGetDeviceID                              sync.RWMutex
-	lockVgpuTypeGetFrameRateLimit                        sync.RWMutex
-	lockVgpuTypeGetFramebufferSize                       sync.RWMutex
-	lockVgpuTypeGetGpuInstanceProfileId                  sync.RWMutex
-	lockVgpuTypeGetID                                    sync.RWMutex
-	lockVgpuTypeGetLicense                               sync.RWMutex
-	lockVgpuTypeGetMaxInstances                          sync.RWMutex
-	lockVgpuTypeGetMaxInstancesPerGpuInstance            sync.RWMutex
-	lockVgpuTypeGetMaxInstancesPerVm                     sync.RWMutex
-	lockVgpuTypeGetName                                  sync.RWMutex
-	lockVgpuTypeGetNumDisplayHeads                       sync.RWMutex
-	lockVgpuTypeGetResolution                            sync.RWMutex
+	lockComputeInstanceDestroy                            sync.RWMutex
+	lockComputeInstanceGetInfo                            sync.RWMutex
+	lockDeviceClearAccountingPids                         sync.RWMutex
+	lockDeviceClearCpuAffinity                            sync.RWMutex
+	lockDeviceClearEccErrorCounts                         sync.RWMutex
+	lockDeviceClearFieldValues                            sync.RWMutex
+	lockDeviceCreateGpuInstance                           sync.RWMutex
+	lockDeviceCreateGpuInstanceWithPlacement              sync.RWMutex
+	lockDeviceDiscoverGpus                                sync.RWMutex
+	lockDeviceFreezeNvLinkUtilizationCounter              sync.RWMutex
+	lockDeviceGetAPIRestriction                           sync.RWMutex
+	lockDeviceGetAccountingBufferSize                     sync.RWMutex
+	lockDeviceGetAccountingMode                           sync.RWMutex
+	lockDeviceGetAccountingPids                           sync.RWMutex
+	lockDeviceGetAccountingStats                          sync.RWMutex
+	lockDeviceGetAccountingStats_v2                       sync.RWMutex
+	lockDeviceGetActiveVgpus                              sync.RWMutex
+	lockDeviceGetAdaptiveClockInfoStatus                  sync.RWMutex
+	lockDeviceGetAdaptiveTgpModeInfo_v1                   sync.RWMutex
+	lockDeviceGetAddressingMode                           sync.RWMutex
+	lockDeviceGetApplicationsClock                        sync.RWMutex
+	lockDeviceGetArchitecture                             sync.RWMutex
+	lockDeviceGetAttributes                               sync.RWMutex
+	lockDeviceGetAutoBoostedClocksEnabled                 sync.RWMutex
+	lockDeviceGetBAR1MemoryInfo                           sync.RWMutex
+	lockDeviceGetBBXTimeData_v1                           sync.RWMutex
+	lockDeviceGetBankRemapperStatus_v1                    sync.RWMutex
+	lockDeviceGetBoardId                                  sync.RWMutex
+	lockDeviceGetBoardPartNumber                          sync.RWMutex
+	lockDeviceGetBrand                                    sync.RWMutex
+	lockDeviceGetBridgeChipInfo                           sync.RWMutex
+	lockDeviceGetBusType                                  sync.RWMutex
+	lockDeviceGetC2cModeInfoV                             sync.RWMutex
+	lockDeviceGetCapabilities                             sync.RWMutex
+	lockDeviceGetClkMonStatus                             sync.RWMutex
+	lockDeviceGetClock                                    sync.RWMutex
+	lockDeviceGetClockInfo                                sync.RWMutex
+	lockDeviceGetClockOffsets                             sync.RWMutex
+	lockDeviceGetComputeInstanceId                        sync.RWMutex
+	lockDeviceGetComputeMode                              sync.RWMutex
+	lockDeviceGetComputeRunningProcesses                  sync.RWMutex
+	lockDeviceGetConfComputeGpuAttestationReport          sync.RWMutex
+	lockDeviceGetConfComputeGpuCertificate                sync.RWMutex
+	lockDeviceGetConfComputeMemSizeInfo                   sync.RWMutex
+	lockDeviceGetConfComputeProtectedMemoryUsage          sync.RWMutex
+	lockDeviceGetCoolerInfo                               sync.RWMutex
+	lockDeviceGetCount                                    sync.RWMutex
+	lockDeviceGetCpuAffinity                              sync.RWMutex
+	lockDeviceGetCpuAffinityWithinScope                   sync.RWMutex
+	lockDeviceGetCreatableVgpus                           sync.RWMutex
+	lockDeviceGetCudaComputeCapability                    sync.RWMutex
+	lockDeviceGetCurrPcieLinkGeneration                   sync.RWMutex
+	lockDeviceGetCurrPcieLinkWidth                        sync.RWMutex
+	lockDeviceGetCurrentClockFreqs                        sync.RWMutex
+	lockDeviceGetCurrentClocksEventReasons                sync.RWMutex
+	lockDeviceGetCurrentClocksThrottleReasons             sync.RWMutex
+	lockDeviceGetDecoderUtilization                       sync.RWMutex
+	lockDeviceGetDefaultApplicationsClock                 sync.RWMutex
+	lockDeviceGetDefaultEccMode                           sync.RWMutex
+	lockDeviceGetDetailedEccErrors                        sync.RWMutex
+	lockDeviceGetDeviceHandleFromMigDeviceHandle          sync.RWMutex
+	lockDeviceGetDisplayActive                            sync.RWMutex
+	lockDeviceGetDisplayMode                              sync.RWMutex
+	lockDeviceGetDramEncryptionMode                       sync.RWMutex
+	lockDeviceGetDriverModel                              sync.RWMutex
+	lockDeviceGetDriverModel_v2                           sync.RWMutex
+	lockDeviceGetDynamicPstatesInfo                       sync.RWMutex
+	lockDeviceGetEccMode                                  sync.RWMutex
+	lockDeviceGetEncoderCapacity                          sync.RWMutex
+	lockDeviceGetEncoderSessions                          sync.RWMutex
+	lockDeviceGetEncoderStats                             sync.RWMutex
+	lockDeviceGetEncoderUtilization                       sync.RWMutex
+	lockDeviceGetEnforcedPowerLimit                       sync.RWMutex
+	lockDeviceGetFBCSessions                              sync.RWMutex
+	lockDeviceGetFBCStats                                 sync.RWMutex
+	lockDeviceGetFanControlPolicy_v2                      sync.RWMutex
+	lockDeviceGetFanSpeed                                 sync.RWMutex
+	lockDeviceGetFanSpeedRPM                              sync.RWMutex
+	lockDeviceGetFanSpeed_v2                              sync.RWMutex
+	lockDeviceGetFieldValues                              sync.RWMutex
+	lockDeviceGetGpcClkMinMaxVfOffset                     sync.RWMutex
+	lockDeviceGetGpcClkVfOffset                           sync.RWMutex
+	lockDeviceGetGpuFabricInfo                            sync.RWMutex
+	lockDeviceGetGpuFabricInfoV                           sync.RWMutex
+	lockDeviceGetGpuFabricInfo_v4                         sync.RWMutex
+	lockDeviceGetGpuInstanceById                          sync.RWMutex
+	lockDeviceGetGpuInstanceId                            sync.RWMutex
+	lockDeviceGetGpuInstancePossiblePlacements            sync.RWMutex
+	lockDeviceGetGpuInstanceProfileInfo                   sync.RWMutex
+	lockDeviceGetGpuInstanceProfileInfoByIdV              sync.RWMutex
+	lockDeviceGetGpuInstanceProfileInfoV                  sync.RWMutex
+	lockDeviceGetGpuInstanceRemainingCapacity             sync.RWMutex
+	lockDeviceGetGpuInstances                             sync.RWMutex
+	lockDeviceGetGpuMaxPcieLinkGeneration                 sync.RWMutex
+	lockDeviceGetGpuOperationMode                         sync.RWMutex
+	lockDeviceGetGraphicsRunningProcesses                 sync.RWMutex
+	lockDeviceGetGridLicensableFeatures                   sync.RWMutex
+	lockDeviceGetGspFirmwareMode                          sync.RWMutex
+	lockDeviceGetGspFirmwareVersion                       sync.RWMutex
+	lockDeviceGetHandleByIndex                            sync.RWMutex
+	lockDeviceGetHandleByPciBusId                         sync.RWMutex
+	lockDeviceGetHandleBySerial                           sync.RWMutex
+	lockDeviceGetHandleByUUID                             sync.RWMutex
+	lockDeviceGetHandleByUUIDV                            sync.RWMutex
+	lockDeviceGetHostVgpuMode                             sync.RWMutex
+	lockDeviceGetHostname_v1                              sync.RWMutex
+	lockDeviceGetIndex                                    sync.RWMutex
+	lockDeviceGetInforomConfigurationChecksum             sync.RWMutex
+	lockDeviceGetInforomImageVersion                      sync.RWMutex
+	lockDeviceGetInforomVersion                           sync.RWMutex
+	lockDeviceGetIrqNum                                   sync.RWMutex
+	lockDeviceGetJpgUtilization                           sync.RWMutex
+	lockDeviceGetLastBBXFlushTime                         sync.RWMutex
+	lockDeviceGetMPSComputeRunningProcesses               sync.RWMutex
+	lockDeviceGetMarginTemperature                        sync.RWMutex
+	lockDeviceGetMaxClockInfo                             sync.RWMutex
+	lockDeviceGetMaxCustomerBoostClock                    sync.RWMutex
+	lockDeviceGetMaxMigDeviceCount                        sync.RWMutex
+	lockDeviceGetMaxPcieLinkGeneration                    sync.RWMutex
+	lockDeviceGetMaxPcieLinkWidth                         sync.RWMutex
+	lockDeviceGetMemClkMinMaxVfOffset                     sync.RWMutex
+	lockDeviceGetMemClkVfOffset                           sync.RWMutex
+	lockDeviceGetMemoryAffinity                           sync.RWMutex
+	lockDeviceGetMemoryBusWidth                           sync.RWMutex
+	lockDeviceGetMemoryErrorCounter                       sync.RWMutex
+	lockDeviceGetMemoryInfo                               sync.RWMutex
+	lockDeviceGetMemoryInfo_v2                            sync.RWMutex
+	lockDeviceGetMemoryLimits_v1                          sync.RWMutex
+	lockDeviceGetMigDeviceHandleByIndex                   sync.RWMutex
+	lockDeviceGetMigMode                                  sync.RWMutex
+	lockDeviceGetMinMaxClockOfPState                      sync.RWMutex
+	lockDeviceGetMinMaxFanSpeed                           sync.RWMutex
+	lockDeviceGetMinorNumber                              sync.RWMutex
+	lockDeviceGetModuleId                                 sync.RWMutex
+	lockDeviceGetMultiGpuBoard                            sync.RWMutex
+	lockDeviceGetName                                     sync.RWMutex
+	lockDeviceGetNumFans                                  sync.RWMutex
+	lockDeviceGetNumGpuCores                              sync.RWMutex
+	lockDeviceGetNumaNodeId                               sync.RWMutex
+	lockDeviceGetNvLinkCapability                         sync.RWMutex
+	lockDeviceGetNvLinkErrorCounter                       sync.RWMutex
+	lockDeviceGetNvLinkInfo                               sync.RWMutex
+	lockDeviceGetNvLinkRemoteDeviceType                   sync.RWMutex
+	lockDeviceGetNvLinkRemotePciInfo                      sync.RWMutex
+	lockDeviceGetNvLinkState                              sync.RWMutex
+	lockDeviceGetNvLinkTelemetrySamples_v1                sync.RWMutex
+	lockDeviceGetNvLinkUtilizationControl                 sync.RWMutex
+	lockDeviceGetNvLinkUtilizationCounter                 sync.RWMutex
+	lockDeviceGetNvLinkVersion                            sync.RWMutex
+	lockDeviceGetNvlinkBwMode                             sync.RWMutex
+	lockDeviceGetNvlinkSupportedBwModes                   sync.RWMutex
+	lockDeviceGetOfaUtilization                           sync.RWMutex
+	lockDeviceGetP2PStatus                                sync.RWMutex
+	lockDeviceGetPciInfo                                  sync.RWMutex
+	lockDeviceGetPciInfoExt                               sync.RWMutex
+	lockDeviceGetPcieLinkMaxSpeed                         sync.RWMutex
+	lockDeviceGetPcieReplayCounter                        sync.RWMutex
+	lockDeviceGetPcieSpeed                                sync.RWMutex
+	lockDeviceGetPcieThroughput                           sync.RWMutex
+	lockDeviceGetPdi                                      sync.RWMutex
+	lockDeviceGetPerformanceModes                         sync.RWMutex
+	lockDeviceGetPerformanceState                         sync.RWMutex
+	lockDeviceGetPersistenceMode                          sync.RWMutex
+	lockDeviceGetPgpuMetadataString                       sync.RWMutex
+	lockDeviceGetPlatformInfo                             sync.RWMutex
+	lockDeviceGetPowerManagementDefaultLimit              sync.RWMutex
+	lockDeviceGetPowerManagementLimit                     sync.RWMutex
+	lockDeviceGetPowerManagementLimitConstraints          sync.RWMutex
+	lockDeviceGetPowerManagementMode                      sync.RWMutex
+	lockDeviceGetPowerMizerMode_v1                        sync.RWMutex
+	lockDeviceGetPowerSource                              sync.RWMutex
+	lockDeviceGetPowerState                               sync.RWMutex
+	lockDeviceGetPowerUsage                               sync.RWMutex
+	lockDeviceGetProcessUtilization                       sync.RWMutex
+	lockDeviceGetProcessesUtilizationInfo                 sync.RWMutex
+	lockDeviceGetRemappedRows                             sync.RWMutex
+	lockDeviceGetRemappedRows_v2                          sync.RWMutex
+	lockDeviceGetRepairStatus                             sync.RWMutex
+	lockDeviceGetRetiredPages                             sync.RWMutex
+	lockDeviceGetRetiredPagesPendingStatus                sync.RWMutex
+	lockDeviceGetRetiredPages_v2                          sync.RWMutex
+	lockDeviceGetRowRemapperHistogram                     sync.RWMutex
+	lockDeviceGetRunningProcessDetailList                 sync.RWMutex
+	lockDeviceGetSamples                                  sync.RWMutex
+	lockDeviceGetSerial                                   sync.RWMutex
+	lockDeviceGetSramEccErrorStatus                       sync.RWMutex
+	lockDeviceGetSramUniqueUncorrectedEccErrorCounts      sync.RWMutex
+	lockDeviceGetSupportedClocksEventReasons              sync.RWMutex
+	lockDeviceGetSupportedClocksThrottleReasons           sync.RWMutex
+	lockDeviceGetSupportedEventTypes                      sync.RWMutex
+	lockDeviceGetSupportedGraphicsClocks                  sync.RWMutex
+	lockDeviceGetSupportedMemoryClocks                    sync.RWMutex
+	lockDeviceGetSupportedPerformanceStates               sync.RWMutex
+	lockDeviceGetSupportedVgpus                           sync.RWMutex
+	lockDeviceGetTargetFanSpeed                           sync.RWMutex
+	lockDeviceGetTemperature                              sync.RWMutex
+	lockDeviceGetTemperatureThreshold                     sync.RWMutex
+	lockDeviceGetTemperatureV                             sync.RWMutex
+	lockDeviceGetThermalSettings                          sync.RWMutex
+	lockDeviceGetTopologyCommonAncestor                   sync.RWMutex
+	lockDeviceGetTopologyNearestGpus                      sync.RWMutex
+	lockDeviceGetTotalEccErrors                           sync.RWMutex
+	lockDeviceGetTotalEnergyConsumption                   sync.RWMutex
+	lockDeviceGetUUID                                     sync.RWMutex
+	lockDeviceGetUnrepairableMemoryFlag_v1                sync.RWMutex
+	lockDeviceGetUtilizationRates                         sync.RWMutex
+	lockDeviceGetVbiosVersion                             sync.RWMutex
+	lockDeviceGetVgpuCapabilities                         sync.RWMutex
+	lockDeviceGetVgpuHeterogeneousMode                    sync.RWMutex
+	lockDeviceGetVgpuInstancesUtilizationInfo             sync.RWMutex
+	lockDeviceGetVgpuMetadata                             sync.RWMutex
+	lockDeviceGetVgpuProcessUtilization                   sync.RWMutex
+	lockDeviceGetVgpuProcessesUtilizationInfo             sync.RWMutex
+	lockDeviceGetVgpuSchedulerCapabilities                sync.RWMutex
+	lockDeviceGetVgpuSchedulerLog                         sync.RWMutex
+	lockDeviceGetVgpuSchedulerLog_v2                      sync.RWMutex
+	lockDeviceGetVgpuSchedulerState                       sync.RWMutex
+	lockDeviceGetVgpuSchedulerState_v2                    sync.RWMutex
+	lockDeviceGetVgpuTypeCreatablePlacements              sync.RWMutex
+	lockDeviceGetVgpuTypeSupportedPlacements              sync.RWMutex
+	lockDeviceGetVgpuUtilization                          sync.RWMutex
+	lockDeviceGetViolationStatus                          sync.RWMutex
+	lockDeviceGetVirtualizationMode                       sync.RWMutex
+	lockDeviceIsMigDeviceHandle                           sync.RWMutex
+	lockDeviceModifyDrainState                            sync.RWMutex
+	lockDeviceOnSameBoard                                 sync.RWMutex
+	lockDevicePerfMetricsGetSamples_v1                    sync.RWMutex
+	lockDevicePowerSmoothingActivatePresetProfile         sync.RWMutex
+	lockDevicePowerSmoothingSetState                      sync.RWMutex
+	lockDevicePowerSmoothingUpdatePresetProfileParam      sync.RWMutex
+	lockDeviceQueryDrainState                             sync.RWMutex
+	lockDeviceReadPRMCounters_v1                          sync.RWMutex
+	lockDeviceReadWritePRM_v1                             sync.RWMutex
+	lockDeviceRegisterEvents                              sync.RWMutex
+	lockDeviceRemoveGpu                                   sync.RWMutex
+	lockDeviceRemoveGpu_v2                                sync.RWMutex
+	lockDeviceResetApplicationsClocks                     sync.RWMutex
+	lockDeviceResetGpuLockedClocks                        sync.RWMutex
+	lockDeviceResetMemoryLockedClocks                     sync.RWMutex
+	lockDeviceResetNvLinkErrorCounters                    sync.RWMutex
+	lockDeviceResetNvLinkUtilizationCounter               sync.RWMutex
+	lockDeviceSetAPIRestriction                           sync.RWMutex
+	lockDeviceSetAccountingMode                           sync.RWMutex
+	lockDeviceSetAdaptiveTgpMode_v1                       sync.RWMutex
+	lockDeviceSetApplicationsClocks                       sync.RWMutex
+	lockDeviceSetAutoBoostedClocksEnabled                 sync.RWMutex
+	lockDeviceSetClockOffsets                             sync.RWMutex
+	lockDeviceSetComputeMode                              sync.RWMutex
+	lockDeviceSetConfComputeUnprotectedMemSize            sync.RWMutex
+	lockDeviceSetCpuAffinity                              sync.RWMutex
+	lockDeviceSetDefaultAutoBoostedClocksEnabled          sync.RWMutex
+	lockDeviceSetDefaultFanSpeed_v2                       sync.RWMutex
+	lockDeviceSetDramEncryptionMode                       sync.RWMutex
+	lockDeviceSetDriverModel                              sync.RWMutex
+	lockDeviceSetEccMode                                  sync.RWMutex
+	lockDeviceSetFanControlPolicy                         sync.RWMutex
+	lockDeviceSetFanSpeed_v2                              sync.RWMutex
+	lockDeviceSetGpcClkVfOffset                           sync.RWMutex
+	lockDeviceSetGpuLockedClocks                          sync.RWMutex
+	lockDeviceSetGpuOperationMode                         sync.RWMutex
+	lockDeviceSetHostname_v1                              sync.RWMutex
+	lockDeviceSetMemClkVfOffset                           sync.RWMutex
+	lockDeviceSetMemoryLimits_v1                          sync.RWMutex
+	lockDeviceSetMemoryLockedClocks                       sync.RWMutex
+	lockDeviceSetMigMode                                  sync.RWMutex
+	lockDeviceSetNvLinkDeviceLowPowerThreshold            sync.RWMutex
+	lockDeviceSetNvLinkUtilizationControl                 sync.RWMutex
+	lockDeviceSetNvlinkBwMode                             sync.RWMutex
+	lockDeviceSetNvlinkBwModeAsync_v1                     sync.RWMutex
+	lockDeviceSetPersistenceMode                          sync.RWMutex
+	lockDeviceSetPowerManagementLimit                     sync.RWMutex
+	lockDeviceSetPowerManagementLimit_v2                  sync.RWMutex
+	lockDeviceSetRusdSettings_v1                          sync.RWMutex
+	lockDeviceSetTemperatureThreshold                     sync.RWMutex
+	lockDeviceSetVgpuCapabilities                         sync.RWMutex
+	lockDeviceSetVgpuHeterogeneousMode                    sync.RWMutex
+	lockDeviceSetVgpuSchedulerState                       sync.RWMutex
+	lockDeviceSetVgpuSchedulerState_v2                    sync.RWMutex
+	lockDeviceSetVirtualizationMode                       sync.RWMutex
+	lockDeviceValidateInforom                             sync.RWMutex
+	lockDeviceVgpuForceGspUnload                          sync.RWMutex
+	lockDeviceWorkloadPowerProfileClearRequestedProfiles  sync.RWMutex
+	lockDeviceWorkloadPowerProfileGetCurrentProfiles      sync.RWMutex
+	lockDeviceWorkloadPowerProfileGetProfilesInfo         sync.RWMutex
+	lockDeviceWorkloadPowerProfileSetRequestedProfiles    sync.RWMutex
+	lockDeviceWorkloadPowerProfileUpdateProfiles_v1       sync.RWMutex
+	lockErrorString                                       sync.RWMutex
+	lockEventSetCreate                                    sync.RWMutex
+	lockEventSetFree                                      sync.RWMutex
+	lockEventSetGetContextCount_v1                        sync.RWMutex
+	lockEventSetGetContextData_v1                         sync.RWMutex
+	lockEventSetGetContextInfo_v1                         sync.RWMutex
+	lockEventSetGetGpuOperationalEventContextLegacyXid_v1 sync.RWMutex
+	lockEventSetRegisterGpuOperationalEvents_v1           sync.RWMutex
+	lockEventSetWait                                      sync.RWMutex
+	lockEventSetWait_v3                                   sync.RWMutex
+	lockExtensions                                        sync.RWMutex
+	lockGetExcludedDeviceCount                            sync.RWMutex
+	lockGetExcludedDeviceInfoByIndex                      sync.RWMutex
+	lockGetVgpuCompatibility                              sync.RWMutex
+	lockGetVgpuDriverCapabilities                         sync.RWMutex
+	lockGetVgpuVersion                                    sync.RWMutex
+	lockGpmMetricsGet                                     sync.RWMutex
+	lockGpmMetricsGetV                                    sync.RWMutex
+	lockGpmMigSampleGet                                   sync.RWMutex
+	lockGpmQueryDeviceSupport                             sync.RWMutex
+	lockGpmQueryDeviceSupportV                            sync.RWMutex
+	lockGpmQueryIfStreamingEnabled                        sync.RWMutex
+	lockGpmSampleAlloc                                    sync.RWMutex
+	lockGpmSampleFree                                     sync.RWMutex
+	lockGpmSampleGet                                      sync.RWMutex
+	lockGpmSetStreamingEnabled                            sync.RWMutex
+	lockGpuInstanceCreateComputeInstance                  sync.RWMutex
+	lockGpuInstanceCreateComputeInstanceWithPlacement     sync.RWMutex
+	lockGpuInstanceDestroy                                sync.RWMutex
+	lockGpuInstanceGetActiveVgpus                         sync.RWMutex
+	lockGpuInstanceGetComputeInstanceById                 sync.RWMutex
+	lockGpuInstanceGetComputeInstancePossiblePlacements   sync.RWMutex
+	lockGpuInstanceGetComputeInstanceProfileInfo          sync.RWMutex
+	lockGpuInstanceGetComputeInstanceProfileInfoV         sync.RWMutex
+	lockGpuInstanceGetComputeInstanceRemainingCapacity    sync.RWMutex
+	lockGpuInstanceGetComputeInstances                    sync.RWMutex
+	lockGpuInstanceGetCreatableVgpus                      sync.RWMutex
+	lockGpuInstanceGetInfo                                sync.RWMutex
+	lockGpuInstanceGetVgpuHeterogeneousMode               sync.RWMutex
+	lockGpuInstanceGetVgpuSchedulerLog                    sync.RWMutex
+	lockGpuInstanceGetVgpuSchedulerLog_v2                 sync.RWMutex
+	lockGpuInstanceGetVgpuSchedulerState                  sync.RWMutex
+	lockGpuInstanceGetVgpuSchedulerState_v2               sync.RWMutex
+	lockGpuInstanceGetVgpuTypeCreatablePlacements         sync.RWMutex
+	lockGpuInstanceSetVgpuHeterogeneousMode               sync.RWMutex
+	lockGpuInstanceSetVgpuSchedulerState                  sync.RWMutex
+	lockGpuInstanceSetVgpuSchedulerState_v2               sync.RWMutex
+	lockInit                                              sync.RWMutex
+	lockInitWithFlags                                     sync.RWMutex
+	lockSetVgpuVersion                                    sync.RWMutex
+	lockShutdown                                          sync.RWMutex
+	lockSystemEventSetCreate                              sync.RWMutex
+	lockSystemEventSetFree                                sync.RWMutex
+	lockSystemEventSetWait                                sync.RWMutex
+	lockSystemGetCPER_v1                                  sync.RWMutex
+	lockSystemGetConfComputeCapabilities                  sync.RWMutex
+	lockSystemGetConfComputeGpusReadyState                sync.RWMutex
+	lockSystemGetConfComputeKeyRotationThresholdInfo      sync.RWMutex
+	lockSystemGetConfComputeSettings                      sync.RWMutex
+	lockSystemGetConfComputeState                         sync.RWMutex
+	lockSystemGetCudaDriverVersion                        sync.RWMutex
+	lockSystemGetCudaDriverVersion_v2                     sync.RWMutex
+	lockSystemGetDriverBranch                             sync.RWMutex
+	lockSystemGetDriverVersion                            sync.RWMutex
+	lockSystemGetHicVersion                               sync.RWMutex
+	lockSystemGetNVMLVersion                              sync.RWMutex
+	lockSystemGetNvlinkBwMode                             sync.RWMutex
+	lockSystemGetProcessName                              sync.RWMutex
+	lockSystemGetTopologyGpuSet                           sync.RWMutex
+	lockSystemRegisterEvents                              sync.RWMutex
+	lockSystemSetConfComputeGpusReadyState                sync.RWMutex
+	lockSystemSetConfComputeKeyRotationThresholdInfo      sync.RWMutex
+	lockSystemSetNvlinkBwMode                             sync.RWMutex
+	lockUnitGetCount                                      sync.RWMutex
+	lockUnitGetDevices                                    sync.RWMutex
+	lockUnitGetFanSpeedInfo                               sync.RWMutex
+	lockUnitGetHandleByIndex                              sync.RWMutex
+	lockUnitGetLedState                                   sync.RWMutex
+	lockUnitGetPsuInfo                                    sync.RWMutex
+	lockUnitGetTemperature                                sync.RWMutex
+	lockUnitGetUnitInfo                                   sync.RWMutex
+	lockUnitSetLedState                                   sync.RWMutex
+	lockVgpuInstanceClearAccountingPids                   sync.RWMutex
+	lockVgpuInstanceGetAccountingMode                     sync.RWMutex
+	lockVgpuInstanceGetAccountingPids                     sync.RWMutex
+	lockVgpuInstanceGetAccountingStats                    sync.RWMutex
+	lockVgpuInstanceGetEccMode                            sync.RWMutex
+	lockVgpuInstanceGetEncoderCapacity                    sync.RWMutex
+	lockVgpuInstanceGetEncoderSessions                    sync.RWMutex
+	lockVgpuInstanceGetEncoderStats                       sync.RWMutex
+	lockVgpuInstanceGetFBCSessions                        sync.RWMutex
+	lockVgpuInstanceGetFBCStats                           sync.RWMutex
+	lockVgpuInstanceGetFbUsage                            sync.RWMutex
+	lockVgpuInstanceGetFrameRateLimit                     sync.RWMutex
+	lockVgpuInstanceGetGpuInstanceId                      sync.RWMutex
+	lockVgpuInstanceGetGpuPciId                           sync.RWMutex
+	lockVgpuInstanceGetLicenseInfo                        sync.RWMutex
+	lockVgpuInstanceGetLicenseStatus                      sync.RWMutex
+	lockVgpuInstanceGetMdevUUID                           sync.RWMutex
+	lockVgpuInstanceGetMetadata                           sync.RWMutex
+	lockVgpuInstanceGetRuntimeStateSize                   sync.RWMutex
+	lockVgpuInstanceGetType                               sync.RWMutex
+	lockVgpuInstanceGetUUID                               sync.RWMutex
+	lockVgpuInstanceGetVmDriverVersion                    sync.RWMutex
+	lockVgpuInstanceGetVmID                               sync.RWMutex
+	lockVgpuInstanceSetEncoderCapacity                    sync.RWMutex
+	lockVgpuTypeGetBAR1Info                               sync.RWMutex
+	lockVgpuTypeGetCapabilities                           sync.RWMutex
+	lockVgpuTypeGetClass                                  sync.RWMutex
+	lockVgpuTypeGetDeviceID                               sync.RWMutex
+	lockVgpuTypeGetFrameRateLimit                         sync.RWMutex
+	lockVgpuTypeGetFramebufferSize                        sync.RWMutex
+	lockVgpuTypeGetGpuInstanceProfileId                   sync.RWMutex
+	lockVgpuTypeGetID                                     sync.RWMutex
+	lockVgpuTypeGetLicense                                sync.RWMutex
+	lockVgpuTypeGetMaxInstances                           sync.RWMutex
+	lockVgpuTypeGetMaxInstancesPerGpuInstance             sync.RWMutex
+	lockVgpuTypeGetMaxInstancesPerVm                      sync.RWMutex
+	lockVgpuTypeGetName                                   sync.RWMutex
+	lockVgpuTypeGetNumDisplayHeads                        sync.RWMutex
+	lockVgpuTypeGetResolution                             sync.RWMutex
 }
 
 // ComputeInstanceDestroy calls ComputeInstanceDestroyFunc.
@@ -5659,6 +5863,38 @@ func (mock *Interface) DeviceGetAdaptiveClockInfoStatusCalls() []struct {
 	return calls
 }
 
+// DeviceGetAdaptiveTgpModeInfo_v1 calls DeviceGetAdaptiveTgpModeInfo_v1Func.
+func (mock *Interface) DeviceGetAdaptiveTgpModeInfo_v1(device nvml.Device) (nvml.AdaptiveTgpModeInfo_v1, nvml.Return) {
+	if mock.DeviceGetAdaptiveTgpModeInfo_v1Func == nil {
+		panic("Interface.DeviceGetAdaptiveTgpModeInfo_v1Func: method is nil but Interface.DeviceGetAdaptiveTgpModeInfo_v1 was just called")
+	}
+	callInfo := struct {
+		Device nvml.Device
+	}{
+		Device: device,
+	}
+	mock.lockDeviceGetAdaptiveTgpModeInfo_v1.Lock()
+	mock.calls.DeviceGetAdaptiveTgpModeInfo_v1 = append(mock.calls.DeviceGetAdaptiveTgpModeInfo_v1, callInfo)
+	mock.lockDeviceGetAdaptiveTgpModeInfo_v1.Unlock()
+	return mock.DeviceGetAdaptiveTgpModeInfo_v1Func(device)
+}
+
+// DeviceGetAdaptiveTgpModeInfo_v1Calls gets all the calls that were made to DeviceGetAdaptiveTgpModeInfo_v1.
+// Check the length with:
+//
+//	len(mockedInterface.DeviceGetAdaptiveTgpModeInfo_v1Calls())
+func (mock *Interface) DeviceGetAdaptiveTgpModeInfo_v1Calls() []struct {
+	Device nvml.Device
+} {
+	var calls []struct {
+		Device nvml.Device
+	}
+	mock.lockDeviceGetAdaptiveTgpModeInfo_v1.RLock()
+	calls = mock.calls.DeviceGetAdaptiveTgpModeInfo_v1
+	mock.lockDeviceGetAdaptiveTgpModeInfo_v1.RUnlock()
+	return calls
+}
+
 // DeviceGetAddressingMode calls DeviceGetAddressingModeFunc.
 func (mock *Interface) DeviceGetAddressingMode(device nvml.Device) (nvml.DeviceAddressingMode, nvml.Return) {
 	if mock.DeviceGetAddressingModeFunc == nil {
@@ -5884,6 +6120,38 @@ func (mock *Interface) DeviceGetBBXTimeData_v1Calls() []struct {
 	mock.lockDeviceGetBBXTimeData_v1.RLock()
 	calls = mock.calls.DeviceGetBBXTimeData_v1
 	mock.lockDeviceGetBBXTimeData_v1.RUnlock()
+	return calls
+}
+
+// DeviceGetBankRemapperStatus_v1 calls DeviceGetBankRemapperStatus_v1Func.
+func (mock *Interface) DeviceGetBankRemapperStatus_v1(device nvml.Device) (nvml.EccBankRemapperStatus_v1, nvml.Return) {
+	if mock.DeviceGetBankRemapperStatus_v1Func == nil {
+		panic("Interface.DeviceGetBankRemapperStatus_v1Func: method is nil but Interface.DeviceGetBankRemapperStatus_v1 was just called")
+	}
+	callInfo := struct {
+		Device nvml.Device
+	}{
+		Device: device,
+	}
+	mock.lockDeviceGetBankRemapperStatus_v1.Lock()
+	mock.calls.DeviceGetBankRemapperStatus_v1 = append(mock.calls.DeviceGetBankRemapperStatus_v1, callInfo)
+	mock.lockDeviceGetBankRemapperStatus_v1.Unlock()
+	return mock.DeviceGetBankRemapperStatus_v1Func(device)
+}
+
+// DeviceGetBankRemapperStatus_v1Calls gets all the calls that were made to DeviceGetBankRemapperStatus_v1.
+// Check the length with:
+//
+//	len(mockedInterface.DeviceGetBankRemapperStatus_v1Calls())
+func (mock *Interface) DeviceGetBankRemapperStatus_v1Calls() []struct {
+	Device nvml.Device
+} {
+	var calls []struct {
+		Device nvml.Device
+	}
+	mock.lockDeviceGetBankRemapperStatus_v1.RLock()
+	calls = mock.calls.DeviceGetBankRemapperStatus_v1
+	mock.lockDeviceGetBankRemapperStatus_v1.RUnlock()
 	return calls
 }
 
@@ -7762,6 +8030,38 @@ func (mock *Interface) DeviceGetGpuFabricInfoVCalls() []struct {
 	return calls
 }
 
+// DeviceGetGpuFabricInfo_v4 calls DeviceGetGpuFabricInfo_v4Func.
+func (mock *Interface) DeviceGetGpuFabricInfo_v4(device nvml.Device) (nvml.GpuFabricInfo_v4, nvml.Return) {
+	if mock.DeviceGetGpuFabricInfo_v4Func == nil {
+		panic("Interface.DeviceGetGpuFabricInfo_v4Func: method is nil but Interface.DeviceGetGpuFabricInfo_v4 was just called")
+	}
+	callInfo := struct {
+		Device nvml.Device
+	}{
+		Device: device,
+	}
+	mock.lockDeviceGetGpuFabricInfo_v4.Lock()
+	mock.calls.DeviceGetGpuFabricInfo_v4 = append(mock.calls.DeviceGetGpuFabricInfo_v4, callInfo)
+	mock.lockDeviceGetGpuFabricInfo_v4.Unlock()
+	return mock.DeviceGetGpuFabricInfo_v4Func(device)
+}
+
+// DeviceGetGpuFabricInfo_v4Calls gets all the calls that were made to DeviceGetGpuFabricInfo_v4.
+// Check the length with:
+//
+//	len(mockedInterface.DeviceGetGpuFabricInfo_v4Calls())
+func (mock *Interface) DeviceGetGpuFabricInfo_v4Calls() []struct {
+	Device nvml.Device
+} {
+	var calls []struct {
+		Device nvml.Device
+	}
+	mock.lockDeviceGetGpuFabricInfo_v4.RLock()
+	calls = mock.calls.DeviceGetGpuFabricInfo_v4
+	mock.lockDeviceGetGpuFabricInfo_v4.RUnlock()
+	return calls
+}
+
 // DeviceGetGpuInstanceById calls DeviceGetGpuInstanceByIdFunc.
 func (mock *Interface) DeviceGetGpuInstanceById(device nvml.Device, n int) (nvml.GpuInstance, nvml.Return) {
 	if mock.DeviceGetGpuInstanceByIdFunc == nil {
@@ -9166,6 +9466,42 @@ func (mock *Interface) DeviceGetMemoryInfo_v2Calls() []struct {
 	return calls
 }
 
+// DeviceGetMemoryLimits_v1 calls DeviceGetMemoryLimits_v1Func.
+func (mock *Interface) DeviceGetMemoryLimits_v1(device nvml.Device, s string) (nvml.MemoryLimits_v1, nvml.Return) {
+	if mock.DeviceGetMemoryLimits_v1Func == nil {
+		panic("Interface.DeviceGetMemoryLimits_v1Func: method is nil but Interface.DeviceGetMemoryLimits_v1 was just called")
+	}
+	callInfo := struct {
+		Device nvml.Device
+		S      string
+	}{
+		Device: device,
+		S:      s,
+	}
+	mock.lockDeviceGetMemoryLimits_v1.Lock()
+	mock.calls.DeviceGetMemoryLimits_v1 = append(mock.calls.DeviceGetMemoryLimits_v1, callInfo)
+	mock.lockDeviceGetMemoryLimits_v1.Unlock()
+	return mock.DeviceGetMemoryLimits_v1Func(device, s)
+}
+
+// DeviceGetMemoryLimits_v1Calls gets all the calls that were made to DeviceGetMemoryLimits_v1.
+// Check the length with:
+//
+//	len(mockedInterface.DeviceGetMemoryLimits_v1Calls())
+func (mock *Interface) DeviceGetMemoryLimits_v1Calls() []struct {
+	Device nvml.Device
+	S      string
+} {
+	var calls []struct {
+		Device nvml.Device
+		S      string
+	}
+	mock.lockDeviceGetMemoryLimits_v1.RLock()
+	calls = mock.calls.DeviceGetMemoryLimits_v1
+	mock.lockDeviceGetMemoryLimits_v1.RUnlock()
+	return calls
+}
+
 // DeviceGetMigDeviceHandleByIndex calls DeviceGetMigDeviceHandleByIndexFunc.
 func (mock *Interface) DeviceGetMigDeviceHandleByIndex(device nvml.Device, n int) (nvml.Device, nvml.Return) {
 	if mock.DeviceGetMigDeviceHandleByIndexFunc == nil {
@@ -9747,6 +10083,42 @@ func (mock *Interface) DeviceGetNvLinkStateCalls() []struct {
 	mock.lockDeviceGetNvLinkState.RLock()
 	calls = mock.calls.DeviceGetNvLinkState
 	mock.lockDeviceGetNvLinkState.RUnlock()
+	return calls
+}
+
+// DeviceGetNvLinkTelemetrySamples_v1 calls DeviceGetNvLinkTelemetrySamples_v1Func.
+func (mock *Interface) DeviceGetNvLinkTelemetrySamples_v1(device nvml.Device, nvlinkTelemetrySamples_v1 nvml.NvlinkTelemetrySamples_v1) (nvml.NvlinkTelemetrySamples_v1, nvml.Return) {
+	if mock.DeviceGetNvLinkTelemetrySamples_v1Func == nil {
+		panic("Interface.DeviceGetNvLinkTelemetrySamples_v1Func: method is nil but Interface.DeviceGetNvLinkTelemetrySamples_v1 was just called")
+	}
+	callInfo := struct {
+		Device                    nvml.Device
+		NvlinkTelemetrySamples_v1 nvml.NvlinkTelemetrySamples_v1
+	}{
+		Device:                    device,
+		NvlinkTelemetrySamples_v1: nvlinkTelemetrySamples_v1,
+	}
+	mock.lockDeviceGetNvLinkTelemetrySamples_v1.Lock()
+	mock.calls.DeviceGetNvLinkTelemetrySamples_v1 = append(mock.calls.DeviceGetNvLinkTelemetrySamples_v1, callInfo)
+	mock.lockDeviceGetNvLinkTelemetrySamples_v1.Unlock()
+	return mock.DeviceGetNvLinkTelemetrySamples_v1Func(device, nvlinkTelemetrySamples_v1)
+}
+
+// DeviceGetNvLinkTelemetrySamples_v1Calls gets all the calls that were made to DeviceGetNvLinkTelemetrySamples_v1.
+// Check the length with:
+//
+//	len(mockedInterface.DeviceGetNvLinkTelemetrySamples_v1Calls())
+func (mock *Interface) DeviceGetNvLinkTelemetrySamples_v1Calls() []struct {
+	Device                    nvml.Device
+	NvlinkTelemetrySamples_v1 nvml.NvlinkTelemetrySamples_v1
+} {
+	var calls []struct {
+		Device                    nvml.Device
+		NvlinkTelemetrySamples_v1 nvml.NvlinkTelemetrySamples_v1
+	}
+	mock.lockDeviceGetNvLinkTelemetrySamples_v1.RLock()
+	calls = mock.calls.DeviceGetNvLinkTelemetrySamples_v1
+	mock.lockDeviceGetNvLinkTelemetrySamples_v1.RUnlock()
 	return calls
 }
 
@@ -12442,6 +12814,38 @@ func (mock *Interface) DeviceOnSameBoardCalls() []struct {
 	return calls
 }
 
+// DevicePerfMetricsGetSamples_v1 calls DevicePerfMetricsGetSamples_v1Func.
+func (mock *Interface) DevicePerfMetricsGetSamples_v1(device nvml.Device) (nvml.PerfMetricsSamples_v1, nvml.Return) {
+	if mock.DevicePerfMetricsGetSamples_v1Func == nil {
+		panic("Interface.DevicePerfMetricsGetSamples_v1Func: method is nil but Interface.DevicePerfMetricsGetSamples_v1 was just called")
+	}
+	callInfo := struct {
+		Device nvml.Device
+	}{
+		Device: device,
+	}
+	mock.lockDevicePerfMetricsGetSamples_v1.Lock()
+	mock.calls.DevicePerfMetricsGetSamples_v1 = append(mock.calls.DevicePerfMetricsGetSamples_v1, callInfo)
+	mock.lockDevicePerfMetricsGetSamples_v1.Unlock()
+	return mock.DevicePerfMetricsGetSamples_v1Func(device)
+}
+
+// DevicePerfMetricsGetSamples_v1Calls gets all the calls that were made to DevicePerfMetricsGetSamples_v1.
+// Check the length with:
+//
+//	len(mockedInterface.DevicePerfMetricsGetSamples_v1Calls())
+func (mock *Interface) DevicePerfMetricsGetSamples_v1Calls() []struct {
+	Device nvml.Device
+} {
+	var calls []struct {
+		Device nvml.Device
+	}
+	mock.lockDevicePerfMetricsGetSamples_v1.RLock()
+	calls = mock.calls.DevicePerfMetricsGetSamples_v1
+	mock.lockDevicePerfMetricsGetSamples_v1.RUnlock()
+	return calls
+}
+
 // DevicePowerSmoothingActivatePresetProfile calls DevicePowerSmoothingActivatePresetProfileFunc.
 func (mock *Interface) DevicePowerSmoothingActivatePresetProfile(device nvml.Device, powerSmoothingProfile *nvml.PowerSmoothingProfile) nvml.Return {
 	if mock.DevicePowerSmoothingActivatePresetProfileFunc == nil {
@@ -13015,6 +13419,42 @@ func (mock *Interface) DeviceSetAccountingModeCalls() []struct {
 	mock.lockDeviceSetAccountingMode.RLock()
 	calls = mock.calls.DeviceSetAccountingMode
 	mock.lockDeviceSetAccountingMode.RUnlock()
+	return calls
+}
+
+// DeviceSetAdaptiveTgpMode_v1 calls DeviceSetAdaptiveTgpMode_v1Func.
+func (mock *Interface) DeviceSetAdaptiveTgpMode_v1(device nvml.Device, enableState nvml.EnableState) nvml.Return {
+	if mock.DeviceSetAdaptiveTgpMode_v1Func == nil {
+		panic("Interface.DeviceSetAdaptiveTgpMode_v1Func: method is nil but Interface.DeviceSetAdaptiveTgpMode_v1 was just called")
+	}
+	callInfo := struct {
+		Device      nvml.Device
+		EnableState nvml.EnableState
+	}{
+		Device:      device,
+		EnableState: enableState,
+	}
+	mock.lockDeviceSetAdaptiveTgpMode_v1.Lock()
+	mock.calls.DeviceSetAdaptiveTgpMode_v1 = append(mock.calls.DeviceSetAdaptiveTgpMode_v1, callInfo)
+	mock.lockDeviceSetAdaptiveTgpMode_v1.Unlock()
+	return mock.DeviceSetAdaptiveTgpMode_v1Func(device, enableState)
+}
+
+// DeviceSetAdaptiveTgpMode_v1Calls gets all the calls that were made to DeviceSetAdaptiveTgpMode_v1.
+// Check the length with:
+//
+//	len(mockedInterface.DeviceSetAdaptiveTgpMode_v1Calls())
+func (mock *Interface) DeviceSetAdaptiveTgpMode_v1Calls() []struct {
+	Device      nvml.Device
+	EnableState nvml.EnableState
+} {
+	var calls []struct {
+		Device      nvml.Device
+		EnableState nvml.EnableState
+	}
+	mock.lockDeviceSetAdaptiveTgpMode_v1.RLock()
+	calls = mock.calls.DeviceSetAdaptiveTgpMode_v1
+	mock.lockDeviceSetAdaptiveTgpMode_v1.RUnlock()
 	return calls
 }
 
@@ -13686,6 +14126,50 @@ func (mock *Interface) DeviceSetMemClkVfOffsetCalls() []struct {
 	return calls
 }
 
+// DeviceSetMemoryLimits_v1 calls DeviceSetMemoryLimits_v1Func.
+func (mock *Interface) DeviceSetMemoryLimits_v1(device nvml.Device, s string, v1 uint64, v2 uint64) nvml.Return {
+	if mock.DeviceSetMemoryLimits_v1Func == nil {
+		panic("Interface.DeviceSetMemoryLimits_v1Func: method is nil but Interface.DeviceSetMemoryLimits_v1 was just called")
+	}
+	callInfo := struct {
+		Device nvml.Device
+		S      string
+		V1     uint64
+		V2     uint64
+	}{
+		Device: device,
+		S:      s,
+		V1:     v1,
+		V2:     v2,
+	}
+	mock.lockDeviceSetMemoryLimits_v1.Lock()
+	mock.calls.DeviceSetMemoryLimits_v1 = append(mock.calls.DeviceSetMemoryLimits_v1, callInfo)
+	mock.lockDeviceSetMemoryLimits_v1.Unlock()
+	return mock.DeviceSetMemoryLimits_v1Func(device, s, v1, v2)
+}
+
+// DeviceSetMemoryLimits_v1Calls gets all the calls that were made to DeviceSetMemoryLimits_v1.
+// Check the length with:
+//
+//	len(mockedInterface.DeviceSetMemoryLimits_v1Calls())
+func (mock *Interface) DeviceSetMemoryLimits_v1Calls() []struct {
+	Device nvml.Device
+	S      string
+	V1     uint64
+	V2     uint64
+} {
+	var calls []struct {
+		Device nvml.Device
+		S      string
+		V1     uint64
+		V2     uint64
+	}
+	mock.lockDeviceSetMemoryLimits_v1.RLock()
+	calls = mock.calls.DeviceSetMemoryLimits_v1
+	mock.lockDeviceSetMemoryLimits_v1.RUnlock()
+	return calls
+}
+
 // DeviceSetMemoryLockedClocks calls DeviceSetMemoryLockedClocksFunc.
 func (mock *Interface) DeviceSetMemoryLockedClocks(device nvml.Device, v1 uint32, v2 uint32) nvml.Return {
 	if mock.DeviceSetMemoryLockedClocksFunc == nil {
@@ -13879,6 +14363,42 @@ func (mock *Interface) DeviceSetNvlinkBwModeCalls() []struct {
 	mock.lockDeviceSetNvlinkBwMode.RLock()
 	calls = mock.calls.DeviceSetNvlinkBwMode
 	mock.lockDeviceSetNvlinkBwMode.RUnlock()
+	return calls
+}
+
+// DeviceSetNvlinkBwModeAsync_v1 calls DeviceSetNvlinkBwModeAsync_v1Func.
+func (mock *Interface) DeviceSetNvlinkBwModeAsync_v1(device nvml.Device, nvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1) nvml.Return {
+	if mock.DeviceSetNvlinkBwModeAsync_v1Func == nil {
+		panic("Interface.DeviceSetNvlinkBwModeAsync_v1Func: method is nil but Interface.DeviceSetNvlinkBwModeAsync_v1 was just called")
+	}
+	callInfo := struct {
+		Device                  nvml.Device
+		NvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1
+	}{
+		Device:                  device,
+		NvlinkSetBwModeAsync_v1: nvlinkSetBwModeAsync_v1,
+	}
+	mock.lockDeviceSetNvlinkBwModeAsync_v1.Lock()
+	mock.calls.DeviceSetNvlinkBwModeAsync_v1 = append(mock.calls.DeviceSetNvlinkBwModeAsync_v1, callInfo)
+	mock.lockDeviceSetNvlinkBwModeAsync_v1.Unlock()
+	return mock.DeviceSetNvlinkBwModeAsync_v1Func(device, nvlinkSetBwModeAsync_v1)
+}
+
+// DeviceSetNvlinkBwModeAsync_v1Calls gets all the calls that were made to DeviceSetNvlinkBwModeAsync_v1.
+// Check the length with:
+//
+//	len(mockedInterface.DeviceSetNvlinkBwModeAsync_v1Calls())
+func (mock *Interface) DeviceSetNvlinkBwModeAsync_v1Calls() []struct {
+	Device                  nvml.Device
+	NvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1
+} {
+	var calls []struct {
+		Device                  nvml.Device
+		NvlinkSetBwModeAsync_v1 *nvml.NvlinkSetBwModeAsync_v1
+	}
+	mock.lockDeviceSetNvlinkBwModeAsync_v1.RLock()
+	calls = mock.calls.DeviceSetNvlinkBwModeAsync_v1
+	mock.lockDeviceSetNvlinkBwModeAsync_v1.RUnlock()
 	return calls
 }
 
@@ -14581,6 +15101,182 @@ func (mock *Interface) EventSetFreeCalls() []struct {
 	return calls
 }
 
+// EventSetGetContextCount_v1 calls EventSetGetContextCount_v1Func.
+func (mock *Interface) EventSetGetContextCount_v1(eventSet nvml.EventSet) (nvml.GetContextCount_v1, nvml.Return) {
+	if mock.EventSetGetContextCount_v1Func == nil {
+		panic("Interface.EventSetGetContextCount_v1Func: method is nil but Interface.EventSetGetContextCount_v1 was just called")
+	}
+	callInfo := struct {
+		EventSet nvml.EventSet
+	}{
+		EventSet: eventSet,
+	}
+	mock.lockEventSetGetContextCount_v1.Lock()
+	mock.calls.EventSetGetContextCount_v1 = append(mock.calls.EventSetGetContextCount_v1, callInfo)
+	mock.lockEventSetGetContextCount_v1.Unlock()
+	return mock.EventSetGetContextCount_v1Func(eventSet)
+}
+
+// EventSetGetContextCount_v1Calls gets all the calls that were made to EventSetGetContextCount_v1.
+// Check the length with:
+//
+//	len(mockedInterface.EventSetGetContextCount_v1Calls())
+func (mock *Interface) EventSetGetContextCount_v1Calls() []struct {
+	EventSet nvml.EventSet
+} {
+	var calls []struct {
+		EventSet nvml.EventSet
+	}
+	mock.lockEventSetGetContextCount_v1.RLock()
+	calls = mock.calls.EventSetGetContextCount_v1
+	mock.lockEventSetGetContextCount_v1.RUnlock()
+	return calls
+}
+
+// EventSetGetContextData_v1 calls EventSetGetContextData_v1Func.
+func (mock *Interface) EventSetGetContextData_v1(eventSet nvml.EventSet, getContextData_v1 nvml.GetContextData_v1) (nvml.GetContextData_v1, nvml.Return) {
+	if mock.EventSetGetContextData_v1Func == nil {
+		panic("Interface.EventSetGetContextData_v1Func: method is nil but Interface.EventSetGetContextData_v1 was just called")
+	}
+	callInfo := struct {
+		EventSet          nvml.EventSet
+		GetContextData_v1 nvml.GetContextData_v1
+	}{
+		EventSet:          eventSet,
+		GetContextData_v1: getContextData_v1,
+	}
+	mock.lockEventSetGetContextData_v1.Lock()
+	mock.calls.EventSetGetContextData_v1 = append(mock.calls.EventSetGetContextData_v1, callInfo)
+	mock.lockEventSetGetContextData_v1.Unlock()
+	return mock.EventSetGetContextData_v1Func(eventSet, getContextData_v1)
+}
+
+// EventSetGetContextData_v1Calls gets all the calls that were made to EventSetGetContextData_v1.
+// Check the length with:
+//
+//	len(mockedInterface.EventSetGetContextData_v1Calls())
+func (mock *Interface) EventSetGetContextData_v1Calls() []struct {
+	EventSet          nvml.EventSet
+	GetContextData_v1 nvml.GetContextData_v1
+} {
+	var calls []struct {
+		EventSet          nvml.EventSet
+		GetContextData_v1 nvml.GetContextData_v1
+	}
+	mock.lockEventSetGetContextData_v1.RLock()
+	calls = mock.calls.EventSetGetContextData_v1
+	mock.lockEventSetGetContextData_v1.RUnlock()
+	return calls
+}
+
+// EventSetGetContextInfo_v1 calls EventSetGetContextInfo_v1Func.
+func (mock *Interface) EventSetGetContextInfo_v1(eventSet nvml.EventSet, v uint32) (nvml.GetContextInfo_v1, nvml.Return) {
+	if mock.EventSetGetContextInfo_v1Func == nil {
+		panic("Interface.EventSetGetContextInfo_v1Func: method is nil but Interface.EventSetGetContextInfo_v1 was just called")
+	}
+	callInfo := struct {
+		EventSet nvml.EventSet
+		V        uint32
+	}{
+		EventSet: eventSet,
+		V:        v,
+	}
+	mock.lockEventSetGetContextInfo_v1.Lock()
+	mock.calls.EventSetGetContextInfo_v1 = append(mock.calls.EventSetGetContextInfo_v1, callInfo)
+	mock.lockEventSetGetContextInfo_v1.Unlock()
+	return mock.EventSetGetContextInfo_v1Func(eventSet, v)
+}
+
+// EventSetGetContextInfo_v1Calls gets all the calls that were made to EventSetGetContextInfo_v1.
+// Check the length with:
+//
+//	len(mockedInterface.EventSetGetContextInfo_v1Calls())
+func (mock *Interface) EventSetGetContextInfo_v1Calls() []struct {
+	EventSet nvml.EventSet
+	V        uint32
+} {
+	var calls []struct {
+		EventSet nvml.EventSet
+		V        uint32
+	}
+	mock.lockEventSetGetContextInfo_v1.RLock()
+	calls = mock.calls.EventSetGetContextInfo_v1
+	mock.lockEventSetGetContextInfo_v1.RUnlock()
+	return calls
+}
+
+// EventSetGetGpuOperationalEventContextLegacyXid_v1 calls EventSetGetGpuOperationalEventContextLegacyXid_v1Func.
+func (mock *Interface) EventSetGetGpuOperationalEventContextLegacyXid_v1(eventSet nvml.EventSet, v uint32) (uint32, nvml.Return) {
+	if mock.EventSetGetGpuOperationalEventContextLegacyXid_v1Func == nil {
+		panic("Interface.EventSetGetGpuOperationalEventContextLegacyXid_v1Func: method is nil but Interface.EventSetGetGpuOperationalEventContextLegacyXid_v1 was just called")
+	}
+	callInfo := struct {
+		EventSet nvml.EventSet
+		V        uint32
+	}{
+		EventSet: eventSet,
+		V:        v,
+	}
+	mock.lockEventSetGetGpuOperationalEventContextLegacyXid_v1.Lock()
+	mock.calls.EventSetGetGpuOperationalEventContextLegacyXid_v1 = append(mock.calls.EventSetGetGpuOperationalEventContextLegacyXid_v1, callInfo)
+	mock.lockEventSetGetGpuOperationalEventContextLegacyXid_v1.Unlock()
+	return mock.EventSetGetGpuOperationalEventContextLegacyXid_v1Func(eventSet, v)
+}
+
+// EventSetGetGpuOperationalEventContextLegacyXid_v1Calls gets all the calls that were made to EventSetGetGpuOperationalEventContextLegacyXid_v1.
+// Check the length with:
+//
+//	len(mockedInterface.EventSetGetGpuOperationalEventContextLegacyXid_v1Calls())
+func (mock *Interface) EventSetGetGpuOperationalEventContextLegacyXid_v1Calls() []struct {
+	EventSet nvml.EventSet
+	V        uint32
+} {
+	var calls []struct {
+		EventSet nvml.EventSet
+		V        uint32
+	}
+	mock.lockEventSetGetGpuOperationalEventContextLegacyXid_v1.RLock()
+	calls = mock.calls.EventSetGetGpuOperationalEventContextLegacyXid_v1
+	mock.lockEventSetGetGpuOperationalEventContextLegacyXid_v1.RUnlock()
+	return calls
+}
+
+// EventSetRegisterGpuOperationalEvents_v1 calls EventSetRegisterGpuOperationalEvents_v1Func.
+func (mock *Interface) EventSetRegisterGpuOperationalEvents_v1(eventSet nvml.EventSet, gpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1) nvml.Return {
+	if mock.EventSetRegisterGpuOperationalEvents_v1Func == nil {
+		panic("Interface.EventSetRegisterGpuOperationalEvents_v1Func: method is nil but Interface.EventSetRegisterGpuOperationalEvents_v1 was just called")
+	}
+	callInfo := struct {
+		EventSet                     nvml.EventSet
+		GpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1
+	}{
+		EventSet:                     eventSet,
+		GpuOperationalEventConfig_v1: gpuOperationalEventConfig_v1,
+	}
+	mock.lockEventSetRegisterGpuOperationalEvents_v1.Lock()
+	mock.calls.EventSetRegisterGpuOperationalEvents_v1 = append(mock.calls.EventSetRegisterGpuOperationalEvents_v1, callInfo)
+	mock.lockEventSetRegisterGpuOperationalEvents_v1.Unlock()
+	return mock.EventSetRegisterGpuOperationalEvents_v1Func(eventSet, gpuOperationalEventConfig_v1)
+}
+
+// EventSetRegisterGpuOperationalEvents_v1Calls gets all the calls that were made to EventSetRegisterGpuOperationalEvents_v1.
+// Check the length with:
+//
+//	len(mockedInterface.EventSetRegisterGpuOperationalEvents_v1Calls())
+func (mock *Interface) EventSetRegisterGpuOperationalEvents_v1Calls() []struct {
+	EventSet                     nvml.EventSet
+	GpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1
+} {
+	var calls []struct {
+		EventSet                     nvml.EventSet
+		GpuOperationalEventConfig_v1 *nvml.GpuOperationalEventConfig_v1
+	}
+	mock.lockEventSetRegisterGpuOperationalEvents_v1.RLock()
+	calls = mock.calls.EventSetRegisterGpuOperationalEvents_v1
+	mock.lockEventSetRegisterGpuOperationalEvents_v1.RUnlock()
+	return calls
+}
+
 // EventSetWait calls EventSetWaitFunc.
 func (mock *Interface) EventSetWait(eventSet nvml.EventSet, v uint32) (nvml.EventData, nvml.Return) {
 	if mock.EventSetWaitFunc == nil {
@@ -14614,6 +15310,42 @@ func (mock *Interface) EventSetWaitCalls() []struct {
 	mock.lockEventSetWait.RLock()
 	calls = mock.calls.EventSetWait
 	mock.lockEventSetWait.RUnlock()
+	return calls
+}
+
+// EventSetWait_v3 calls EventSetWait_v3Func.
+func (mock *Interface) EventSetWait_v3(eventSet nvml.EventSet, v uint32) (nvml.EventSetWaitData_v3, nvml.Return) {
+	if mock.EventSetWait_v3Func == nil {
+		panic("Interface.EventSetWait_v3Func: method is nil but Interface.EventSetWait_v3 was just called")
+	}
+	callInfo := struct {
+		EventSet nvml.EventSet
+		V        uint32
+	}{
+		EventSet: eventSet,
+		V:        v,
+	}
+	mock.lockEventSetWait_v3.Lock()
+	mock.calls.EventSetWait_v3 = append(mock.calls.EventSetWait_v3, callInfo)
+	mock.lockEventSetWait_v3.Unlock()
+	return mock.EventSetWait_v3Func(eventSet, v)
+}
+
+// EventSetWait_v3Calls gets all the calls that were made to EventSetWait_v3.
+// Check the length with:
+//
+//	len(mockedInterface.EventSetWait_v3Calls())
+func (mock *Interface) EventSetWait_v3Calls() []struct {
+	EventSet nvml.EventSet
+	V        uint32
+} {
+	var calls []struct {
+		EventSet nvml.EventSet
+		V        uint32
+	}
+	mock.lockEventSetWait_v3.RLock()
+	calls = mock.calls.EventSetWait_v3
+	mock.lockEventSetWait_v3.RUnlock()
 	return calls
 }
 

--- a/pkg/nvml/nvml.go
+++ b/pkg/nvml/nvml.go
@@ -1097,6 +1097,24 @@ func nvmlDeviceGetEnforcedPowerLimit(nvmlDevice nvmlDevice, Limit *uint32) Retur
 	return __v
 }
 
+// nvmlDeviceSetAdaptiveTgpMode_v1 function as declared in nvml/nvml.h
+func nvmlDeviceSetAdaptiveTgpMode_v1(nvmlDevice nvmlDevice, Mode EnableState) Return {
+	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
+	cMode, _ := (C.nvmlEnableState_t)(Mode), cgoAllocsUnknown
+	__ret := C.nvmlDeviceSetAdaptiveTgpMode_v1(cnvmlDevice, cMode)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlDeviceGetAdaptiveTgpModeInfo_v1 function as declared in nvml/nvml.h
+func nvmlDeviceGetAdaptiveTgpModeInfo_v1(nvmlDevice nvmlDevice, Info *AdaptiveTgpModeInfo_v1) Return {
+	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
+	cInfo, _ := (*C.nvmlAdaptiveTgpModeInfo_v1_t)(unsafe.Pointer(Info)), cgoAllocsUnknown
+	__ret := C.nvmlDeviceGetAdaptiveTgpModeInfo_v1(cnvmlDevice, cInfo)
+	__v := (Return)(__ret)
+	return __v
+}
+
 // nvmlDeviceGetGpuOperationMode function as declared in nvml/nvml.h
 func nvmlDeviceGetGpuOperationMode(nvmlDevice nvmlDevice, Current *GpuOperationMode, Pending *GpuOperationMode) Return {
 	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
@@ -1121,6 +1139,24 @@ func nvmlDeviceGetMemoryInfo_v2(nvmlDevice nvmlDevice, Memory *Memory_v2) Return
 	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
 	cMemory, _ := (*C.nvmlMemory_v2_t)(unsafe.Pointer(Memory)), cgoAllocsUnknown
 	__ret := C.nvmlDeviceGetMemoryInfo_v2(cnvmlDevice, cMemory)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlDeviceSetMemoryLimits_v1 function as declared in nvml/nvml.h
+func nvmlDeviceSetMemoryLimits_v1(nvmlDevice nvmlDevice, Limits *SetMemoryLimits_v1) Return {
+	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
+	cLimits, _ := (*C.nvmlSetMemoryLimits_v1_t)(unsafe.Pointer(Limits)), cgoAllocsUnknown
+	__ret := C.nvmlDeviceSetMemoryLimits_v1(cnvmlDevice, cLimits)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlDeviceGetMemoryLimits_v1 function as declared in nvml/nvml.h
+func nvmlDeviceGetMemoryLimits_v1(nvmlDevice nvmlDevice, Limits *GetMemoryLimits_v1) Return {
+	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
+	cLimits, _ := (*C.nvmlGetMemoryLimits_v1_t)(unsafe.Pointer(Limits)), cgoAllocsUnknown
+	__ret := C.nvmlDeviceGetMemoryLimits_v1(cnvmlDevice, cLimits)
 	__v := (Return)(__ret)
 	return __v
 }
@@ -1543,6 +1579,15 @@ func nvmlDeviceGetGpuFabricInfoV(nvmlDevice nvmlDevice, GpuFabricInfo *GpuFabric
 	return __v
 }
 
+// nvmlDeviceGetGpuFabricInfo_v4 function as declared in nvml/nvml.h
+func nvmlDeviceGetGpuFabricInfo_v4(nvmlDevice nvmlDevice, GpuFabricInfo *GpuFabricInfo_v4) Return {
+	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
+	cGpuFabricInfo, _ := (*C.nvmlGpuFabricInfo_v4_t)(unsafe.Pointer(GpuFabricInfo)), cgoAllocsUnknown
+	__ret := C.nvmlDeviceGetGpuFabricInfo_v4(cnvmlDevice, cGpuFabricInfo)
+	__v := (Return)(__ret)
+	return __v
+}
+
 // nvmlSystemGetConfComputeCapabilities function as declared in nvml/nvml.h
 func nvmlSystemGetConfComputeCapabilities(Capabilities *ConfComputeSystemCaps) Return {
 	cCapabilities, _ := (*C.nvmlConfComputeSystemCaps_t)(unsafe.Pointer(Capabilities)), cgoAllocsUnknown
@@ -1851,6 +1896,15 @@ func nvmlDeviceGetHostname_v1(nvmlDevice nvmlDevice, Hostname *Hostname_v1) Retu
 	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
 	cHostname, _ := (*C.nvmlHostname_v1_t)(unsafe.Pointer(Hostname)), cgoAllocsUnknown
 	__ret := C.nvmlDeviceGetHostname_v1(cnvmlDevice, cHostname)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlDevicePerfMetricsGetSamples_v1 function as declared in nvml/nvml.h
+func nvmlDevicePerfMetricsGetSamples_v1(nvmlDevice nvmlDevice, Samples *PerfMetricsSamples_v1) Return {
+	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
+	cSamples, _ := (*C.nvmlPerfMetricsSamples_v1_t)(unsafe.Pointer(Samples)), cgoAllocsUnknown
+	__ret := C.nvmlDevicePerfMetricsGetSamples_v1(cnvmlDevice, cSamples)
 	__v := (Return)(__ret)
 	return __v
 }
@@ -2264,11 +2318,29 @@ func nvmlDeviceSetNvlinkBwMode(nvmlDevice nvmlDevice, SetBwMode *NvlinkSetBwMode
 	return __v
 }
 
+// nvmlDeviceSetNvlinkBwModeAsync_v1 function as declared in nvml/nvml.h
+func nvmlDeviceSetNvlinkBwModeAsync_v1(nvmlDevice nvmlDevice, SetBwModeAsync *NvlinkSetBwModeAsync_v1) Return {
+	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
+	cSetBwModeAsync, _ := (*C.nvmlNvlinkSetBwModeAsync_v1_t)(unsafe.Pointer(SetBwModeAsync)), cgoAllocsUnknown
+	__ret := C.nvmlDeviceSetNvlinkBwModeAsync_v1(cnvmlDevice, cSetBwModeAsync)
+	__v := (Return)(__ret)
+	return __v
+}
+
 // nvmlDeviceGetNvLinkInfo function as declared in nvml/nvml.h
 func nvmlDeviceGetNvLinkInfo(nvmlDevice nvmlDevice, Info *NvLinkInfo) Return {
 	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
 	cInfo, _ := (*C.nvmlNvLinkInfo_t)(unsafe.Pointer(Info)), cgoAllocsUnknown
 	__ret := C.nvmlDeviceGetNvLinkInfo(cnvmlDevice, cInfo)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlDeviceGetNvLinkTelemetrySamples_v1 function as declared in nvml/nvml.h
+func nvmlDeviceGetNvLinkTelemetrySamples_v1(nvmlDevice nvmlDevice, Samples *NvlinkTelemetrySamples_v1) Return {
+	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
+	cSamples, _ := (*C.nvmlNvlinkTelemetrySamples_v1_t)(unsafe.Pointer(Samples)), cgoAllocsUnknown
+	__ret := C.nvmlDeviceGetNvLinkTelemetrySamples_v1(cnvmlDevice, cSamples)
 	__v := (Return)(__ret)
 	return __v
 }
@@ -2306,6 +2378,60 @@ func nvmlEventSetWait_v2(Set nvmlEventSet, Data *nvmlEventData, Timeoutms uint32
 	cData, _ := (*C.nvmlEventData_t)(unsafe.Pointer(Data)), cgoAllocsUnknown
 	cTimeoutms, _ := (C.uint)(Timeoutms), cgoAllocsUnknown
 	__ret := C.nvmlEventSetWait_v2(cSet, cData, cTimeoutms)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlEventSetRegisterGpuOperationalEvents_v1 function as declared in nvml/nvml.h
+func nvmlEventSetRegisterGpuOperationalEvents_v1(nvmlEventSet nvmlEventSet, Config *GpuOperationalEventConfig_v1) Return {
+	cnvmlEventSet, _ := *(*C.nvmlEventSet_t)(unsafe.Pointer(&nvmlEventSet)), cgoAllocsUnknown
+	cConfig, _ := (*C.nvmlGpuOperationalEventConfig_v1_t)(unsafe.Pointer(Config)), cgoAllocsUnknown
+	__ret := C.nvmlEventSetRegisterGpuOperationalEvents_v1(cnvmlEventSet, cConfig)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlEventSetWait_v3 function as declared in nvml/nvml.h
+func nvmlEventSetWait_v3(Set nvmlEventSet, Params *EventSetWaitData_v3) Return {
+	cSet, _ := *(*C.nvmlEventSet_t)(unsafe.Pointer(&Set)), cgoAllocsUnknown
+	cParams, _ := (*C.nvmlEventSetWait_v3_t)(unsafe.Pointer(Params)), cgoAllocsUnknown
+	__ret := C.nvmlEventSetWait_v3(cSet, cParams)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlEventSetGetContextCount_v1 function as declared in nvml/nvml.h
+func nvmlEventSetGetContextCount_v1(Set nvmlEventSet, Params *GetContextCount_v1) Return {
+	cSet, _ := *(*C.nvmlEventSet_t)(unsafe.Pointer(&Set)), cgoAllocsUnknown
+	cParams, _ := (*C.nvmlEventSetGetContextCount_v1_t)(unsafe.Pointer(Params)), cgoAllocsUnknown
+	__ret := C.nvmlEventSetGetContextCount_v1(cSet, cParams)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlEventSetGetContextInfo_v1 function as declared in nvml/nvml.h
+func nvmlEventSetGetContextInfo_v1(Set nvmlEventSet, Params *GetContextInfo_v1) Return {
+	cSet, _ := *(*C.nvmlEventSet_t)(unsafe.Pointer(&Set)), cgoAllocsUnknown
+	cParams, _ := (*C.nvmlEventSetGetContextInfo_v1_t)(unsafe.Pointer(Params)), cgoAllocsUnknown
+	__ret := C.nvmlEventSetGetContextInfo_v1(cSet, cParams)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlEventSetGetContextData_v1 function as declared in nvml/nvml.h
+func nvmlEventSetGetContextData_v1(Set nvmlEventSet, Params *GetContextData_v1) Return {
+	cSet, _ := *(*C.nvmlEventSet_t)(unsafe.Pointer(&Set)), cgoAllocsUnknown
+	cParams, _ := (*C.nvmlEventSetGetContextData_v1_t)(unsafe.Pointer(Params)), cgoAllocsUnknown
+	__ret := C.nvmlEventSetGetContextData_v1(cSet, cParams)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlEventSetGetGpuOperationalEventContextLegacyXid_v1 function as declared in nvml/nvml.h
+func nvmlEventSetGetGpuOperationalEventContextLegacyXid_v1(Set nvmlEventSet, Params *GetGpuOperationalEventContextLegacyXid_v1) Return {
+	cSet, _ := *(*C.nvmlEventSet_t)(unsafe.Pointer(&Set)), cgoAllocsUnknown
+	cParams, _ := (*C.nvmlEventSetGetGpuOperationalEventContextLegacyXid_v1_t)(unsafe.Pointer(Params)), cgoAllocsUnknown
+	__ret := C.nvmlEventSetGetGpuOperationalEventContextLegacyXid_v1(cSet, cParams)
 	__v := (Return)(__ret)
 	return __v
 }
@@ -3681,6 +3807,15 @@ func nvmlDeviceSetRusdSettings_v1(nvmlDevice nvmlDevice, Settings *RusdSettings_
 	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
 	cSettings, _ := (*C.nvmlRusdSettings_v1_t)(unsafe.Pointer(Settings)), cgoAllocsUnknown
 	__ret := C.nvmlDeviceSetRusdSettings_v1(cnvmlDevice, cSettings)
+	__v := (Return)(__ret)
+	return __v
+}
+
+// nvmlDeviceGetBankRemapperStatus_v1 function as declared in nvml/nvml.h
+func nvmlDeviceGetBankRemapperStatus_v1(nvmlDevice nvmlDevice, PBankRemapperStatus *EccBankRemapperStatus_v1) Return {
+	cnvmlDevice, _ := *(*C.nvmlDevice_t)(unsafe.Pointer(&nvmlDevice)), cgoAllocsUnknown
+	cPBankRemapperStatus, _ := (*C.nvmlEccBankRemapperStatus_v1_t)(unsafe.Pointer(PBankRemapperStatus)), cgoAllocsUnknown
+	__ret := C.nvmlDeviceGetBankRemapperStatus_v1(cnvmlDevice, cPBankRemapperStatus)
 	__v := (Return)(__ret)
 	return __v
 }

--- a/pkg/nvml/nvml.h
+++ b/pkg/nvml/nvml.h
@@ -1,5 +1,5 @@
-/*** NVML VERSION: 13.3.29 ***/
-/*** From https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvml_dev/linux-x86_64/cuda_nvml_dev-linux-x86_64-13.3.29-archive.tar.xz ***/
+/*** NVML VERSION: 13.4.61 ***/
+/*** From https://developer.download.nvidia.com/compute/cuda/redist/cuda_nvml_dev/linux-x86_64/cuda_nvml_dev-linux-x86_64-13.4.61-archive.tar.xz ***/
 /*
  * Copyright 1993-2026 NVIDIA Corporation.  All rights reserved.
  *
@@ -281,6 +281,59 @@ typedef struct nvmlMemory_v2_st
 } nvmlMemory_v2_t;
 
 #define nvmlMemory_v2 NVML_STRUCT_VERSION(Memory, 2) //!< Version macro for \a nvmlMemory_v2_t
+
+/**
+ * Value for "maximum" memory limit.
+ */
+#define NVML_DEVICE_MEMORY_LIMIT_MAX 0xFFFFFFFFFFFFFFFF
+
+/**
+ * @brief Describes the memory limits that can be set for the device
+ *
+ * This structure holds the necessary information that can be used to set the soft
+ * and hard memory limits of a device.
+ *
+ * The softLimit is the amount of memory that is guaranteed before allocations
+ * may fail due to memory pressure.
+ *
+ * The hardLimit is the maximum amount of memory that can be allocated.
+ *
+ * This should be cross-referenced with \ref nvmlDeviceGetMemoryInfo_v2 while in
+ * that cgroup to see how much memory is actually available to allocate for the device.
+ *
+ * To clear the limits, set softLimit to 0, and hardLimit to \ref NVML_DEVICE_MEMORY_LIMIT_MAX.
+ * Removing the cgroup will also clear any limits.
+ */
+typedef struct
+{
+    const char* nameSpace;         //!<[in] Full path to sysfs cgroup file name
+    unsigned long long softLimit;  //!<[in] Soft memory limit in Bytes.
+    unsigned long long hardLimit;  //!<[in] Hard memory limit in Bytes.
+} nvmlSetMemoryLimits_v1_t;
+
+/**
+ * @brief Describes the current memory limits that are set for the device
+ *
+ * This structure holds the necessary information that can be used to get the
+ * current soft and hard memory limits of a device.
+ *
+ * The softLimit is the amount of memory that is guaranteed before allocations
+ * may fail due to memory pressure.
+ *
+ * The hardLimit is the maximum amount of memory that can be allocated.
+ *
+ * This should be cross-referenced with \ref nvmlDeviceGetMemoryInfo_v2 while in
+ * that cgroup to see how much memory is actually available to allocate for the device.
+ *
+ * No limit is set when softLimit is 0 and hardLimit is \ref NVML_DEVICE_MEMORY_LIMIT_MAX.
+ */
+typedef struct
+{
+    const char* nameSpace;           //!<[in]  Full path to sysfs cgroup file name
+    unsigned long long softLimit;    //!<[out] Currently set soft memory limit in Bytes.
+    unsigned long long hardLimit;    //!<[out] Currently set hard memory limit in Bytes.
+    unsigned long long currentUsed;  //!<[out] Currently used memory in Bytes.
+} nvmlGetMemoryLimits_v1_t;
 
 /**
  * BAR1 Memory allocation Information for a device
@@ -762,6 +815,9 @@ typedef enum
     NVML_THERMAL_CONTROLLER_UNKNOWN = -1,
 } nvmlThermalController_t;
 
+/**
+ * Struct to hold the thermal sensor settings
+ */
 typedef struct {
     nvmlThermalController_t controller;
     int defaultMinTemp;
@@ -770,9 +826,6 @@ typedef struct {
     nvmlThermalTarget_t target;
 } nvmlGpuThermalSettingsSensor_t;
 
-/**
- * Struct to hold the thermal sensor settings
- */
 typedef struct
 {
     unsigned int   count;
@@ -870,6 +923,165 @@ typedef nvmlPdi_v1_t nvmlPdi_t;
 
 #define nvmlPdi_v1 NVML_STRUCT_VERSION(Pdi, 1) //!< Version macro for \a nvmlPdi_v1_t
 
+#define NVML_PERF_METRICS_PWR_MODEL_DLPPM_1X_MAX_CORE_RAILS                                2  //!< Maximum number of core rails for DLPPM 1x power model
+#define NVML_PERF_METRICS_NNE_DESC_INFERENCE_LOOPS_MAX                                     8  //!< Maximum number of NNE descriptor inference loops
+#define NVML_PERF_METRICS_PWR_MODEL_METRICS_DLPPM_1X_OBESRVED_INTIAL_DRAMCLK_ESTIMATES_MAX 3  //!< Maximum number of initial DRAMCLK estimates for DLPPM 1x observed metrics
+#define NVML_PERF_METRICS_CONTROLLER_DLPPC_2X_PWR_POLICY_RELATIONSHIP_SET_LIMITS_MAX       4  //!< Maximum number of power policy relationship set limits for DLPPC 2x controller
+#define NVML_PERF_METRICS_CONTROLLER_STATUS_DLPPC_2X_DRAMCLK_NUM                           3  //!< Number of DRAMCLK frequencies tracked by DLPPC 2x controller status
+#define NVML_PERF_METRICS_CONTROLLER_SAMPLE_CONTROLLER_MAX_NUM                             4  //!< Maximum number of controllers that can be sampled
+#define NVML_PERF_METRICS_SAMPLE_COUNT                                                    13  //!< Total number of performance metrics samples that can be collected
+#define NVML_PERF_METRICS_PWR_MODEL_SCALE_LOOPS_MAX_PFPP_1X                               32  //!< Maximum number of power model scale loops for PFPP 1x
+#define NVML_PERF_METRICS_PWR_MODEL_SCALE_METRICS_INPUT_MAX                               16  //!< Maximum number of power model scale metrics inputs
+#define NVML_PERF_METRICS_CONTROLLER_TYPE_DLPPC_2X                                         0  //!< Controller type identifier for DLPPC 2x
+#define NVML_PERF_METRICS_CONTROLLER_TYPE_PFPP_1X                                          1  //!< Controller type identifier for PFPP 1x
+#define NVML_PERF_METRICS_PWR_MODEL_SCALE_METRICS_PFPP_1X_GPCCLK_IDX                       0  //!< Index for GPCCLK frequency in PFPP 1x scale metrics
+#define NVML_PERF_CF_PM_SENSOR_MAX_SIGNALS                                              1024  //!< Maximum number of BA PM sensor signals
+
+/**
+ * Power tuple containing power consumption in milliwatts.
+ */
+typedef struct
+{
+    unsigned int pwrmW;                                     //!< Power consumption in milliwatts
+} nvmlPmgrPwrTuple_t;
+
+/**
+ * Metrics for a single power rail, including frequency and utilization.
+ */
+typedef struct
+{
+    unsigned int freqkHz;                                   //!< Frequency in kilohertz
+    unsigned long long utilPct;                             //!< Utilization percentage (fixed-point)
+} nvmlRailMetrics_t;
+
+/**
+ * Metrics for all core rails in the system.
+ */
+typedef struct
+{
+    nvmlRailMetrics_t rails[NVML_PERF_METRICS_PWR_MODEL_DLPPM_1X_MAX_CORE_RAILS];  //!< Array of core rail metrics
+} nvmlCoreRailMetrics_t;
+
+/**
+ * Performance metrics for DLPPM 1x power model.
+ */
+typedef struct
+{
+    unsigned int perfms;                                    //!< Performance metric in milliseconds
+} nvmlPwrModelMetricsDlppm1xPerf_t;
+
+/**
+ * Complete power model metrics for DLPPM 1x, including rail metrics and TGP power.
+ */
+typedef struct
+{
+    unsigned char bValid;                                   //!< Validity flag: non-zero if metrics are valid
+    nvmlCoreRailMetrics_t coreRail;                         //!< Core rail metrics
+    nvmlRailMetrics_t fbRail;                               //!< Fb rail metrics
+    nvmlPmgrPwrTuple_t tgpPwrTuple;                         //!< Total Graphics Power (TGP) in milliwatts
+    nvmlPwrModelMetricsDlppm1xPerf_t perfMetrics;           //!< Performance metrics
+} nvmlPwrModelMetricsDlppm1x_t;
+
+/**
+ * DRAMCLK estimates containing multiple estimated metrics for different DRAMCLK frequencies.
+ */
+typedef struct
+{
+    nvmlPwrModelMetricsDlppm1x_t estimatedMetrics[NVML_PERF_METRICS_NNE_DESC_INFERENCE_LOOPS_MAX];  //!< Array of estimated metrics for each inference loop
+    unsigned char numEstimatedMetrics;                                                              //!< Number of valid entries in estimatedMetrics array
+} nvmlPwrModelMetricsDlppm1xDramclkEstimates_t;
+
+/**
+ * Observed metrics from the power model, including initial DRAMCLK estimates and current measurements.
+ */
+typedef struct
+{
+    nvmlPwrModelMetricsDlppm1xDramclkEstimates_t initialDramclkEst[NVML_PERF_METRICS_PWR_MODEL_METRICS_DLPPM_1X_OBESRVED_INTIAL_DRAMCLK_ESTIMATES_MAX];  //!< Initial DRAMCLK estimates for different scenarios
+    unsigned char bValid;                                                                                                                                //!< Validity flag: non-zero if observed metrics are valid
+    nvmlCoreRailMetrics_t coreRail;                                                                                                                      //!< Observed core rail metrics
+    nvmlRailMetrics_t fbRail;                                                                                                                            //!< Observed fb rail metrics
+    nvmlPmgrPwrTuple_t tgpPwrTuple;                                                                                                                      //!< Observed Total Graphics Power (TGP) in milliwatts
+    nvmlPwrModelMetricsDlppm1xPerf_t perfMetrics;                                                                                                        //!< Observed performance metrics
+} nvmlObservedMetrics_t;
+
+/**
+ * Performance metrics sample for DLPPC 2x controller.
+ */
+typedef struct
+{
+    nvmlObservedMetrics_t observedMetrics;                  //!< Observed metrics from the DLPPC 2x controller
+} nvmlPerfMetricsDlppc2xSample_t;
+
+/**
+ * Power model metrics sample for PFPP 1x, containing frequency inputs and estimated TGP.
+ */
+typedef struct
+{
+    unsigned int freqkHz[NVML_PERF_METRICS_PWR_MODEL_SCALE_METRICS_INPUT_MAX];  //!< Array of input frequencies in kilohertz for each domain
+    unsigned int estTgpPwrmW;                                                   //!< Estimated Total Graphics Power in milliwatts
+} nvmlPwrModelMetricsSamplePfpp1x_t;
+
+/**
+ * Operating point for PFPP 1x power model, defining a frequency-power pair.
+ */
+typedef struct
+{
+    unsigned int freqkHz;                                   //!< Operating frequency in kilohertz
+    unsigned int pwrmW;                                     //!< Power consumption at this frequency in milliwatts
+} nvmlPwrModelOperatingPointPfpp1x_t;
+
+/**
+ * Complete power model metrics for PFPP 1x, including estimated metrics and key operating points.
+ */
+typedef struct
+{
+    unsigned char numVfPoints;                                                                                //!< Number of valid vf points
+    nvmlPwrModelMetricsSamplePfpp1x_t estimatedMetrics[NVML_PERF_METRICS_PWR_MODEL_SCALE_LOOPS_MAX_PFPP_1X];  //!< Array of estimated metrics for different operating points
+    unsigned char bValid;                                                                                     //!< Validity flag: non-zero if metrics are valid
+    nvmlPwrModelOperatingPointPfpp1x_t maxPerfPerWattPoint;                                                   //!< Operating point with maximum performance per watt
+    nvmlPwrModelOperatingPointPfpp1x_t fmaxAtVmaxPoint;                                                       //!< Operating point at maximum frequency and voltage
+    unsigned int tgpHeadroommW;                                                                               //!< TGP headroom in milliwatts
+} nvmlPwrModelMetricsPfpp1x_t;
+
+/**
+ * Performance metrics sample for PFPP 1x controller.
+ */
+typedef struct
+{
+    nvmlPwrModelMetricsPfpp1x_t estimatedMetrics;           //!< Estimated metrics from the PFPP 1x controller
+} nvmlPerfMetricsPfpp1xSample_t;
+
+/**
+ * Performance metrics sample from a controller, which can be either DLPPC 2x or PFPP 1x.
+ */
+typedef struct
+{
+    unsigned int controllerType;                            //!< Controller type: NVML_PERF_METRICS_CONTROLLER_TYPE_DLPPC_2X or NVML_PERF_METRICS_CONTROLLER_TYPE_PFPP_1X
+    union{
+        nvmlPerfMetricsDlppc2xSample_t dlppc2x;             //!< DLPPC 2x controller sample data
+        nvmlPerfMetricsPfpp1xSample_t  pfpp1x;              //!< PFPP 1x controller sample data
+    } data;                                                 //!< Union containing controller-specific data
+} nvmlPerfMetricControllerSample_t;
+
+/**
+ * Single performance metrics sample containing data from one or more controllers.
+ */
+typedef struct
+{
+    unsigned char numControllerData;                                                                          //!< Number of valid controller samples in this sample
+    nvmlPerfMetricControllerSample_t controllerData[NVML_PERF_METRICS_CONTROLLER_SAMPLE_CONTROLLER_MAX_NUM];  //!< Array of controller samples
+} nvmlPerfMetricsSample_t;
+
+/**
+ * Collection of performance metrics samples (version 1).
+ * This structure contains multiple samples for performance monitoring and profiling.
+ */
+typedef struct
+{
+    unsigned int numSamples;                                          //!< Number of samples in the samples array
+    nvmlPerfMetricsSample_t samples[NVML_PERF_METRICS_SAMPLE_COUNT];  //!< Array of performance metrics samples
+} nvmlPerfMetricsSamples_v1_t;
+
 /**
  * BBX Time Data
  */
@@ -880,7 +1092,7 @@ typedef nvmlPdi_v1_t nvmlPdi_t;
 /** @} */
 
 /***************************************************************************************************/
-/** @defgroup nvmlDeviceEnumvs Device Enums
+/** @defgroup nvmlDeviceEnums Device Enums
  *  @{
  */
 /***************************************************************************************************/
@@ -934,8 +1146,11 @@ typedef enum nvmlBrandType_enum
     NVML_BRAND_NVIDIA               = 14,
     NVML_BRAND_GEFORCE_RTX          = 15,  // Unused
     NVML_BRAND_TITAN_RTX            = 16,  // Unused
+    NVML_BRAND_NVIDIA_DLA           = 17,  // Deprecated NVIDIA Deep Learning Accelerator
+    NVML_BRAND_NVIDIA_VGAMEDEV      = 18,  // NVIDIA RTX Virtual Game Dev
+    NVML_BRAND_NVIDIA_NPU           = 19,  // NVIDIA NPU
     // Keep this last
-    NVML_BRAND_COUNT                = 18,
+    NVML_BRAND_COUNT                = 20,
 } nvmlBrandType_t;
 
 /**
@@ -943,22 +1158,22 @@ typedef enum nvmlBrandType_enum
  */
 typedef enum nvmlTemperatureThresholds_enum
 {
-    NVML_TEMPERATURE_THRESHOLD_SHUTDOWN      = 0, // Temperature at which the GPU will
-                                                  // shut down for HW protection
-    NVML_TEMPERATURE_THRESHOLD_SLOWDOWN      = 1, // Temperature at which the GPU will
-                                                  // begin HW slowdown
-    NVML_TEMPERATURE_THRESHOLD_MEM_MAX       = 2, // Memory Temperature at which the GPU will
-                                                  // begin SW slowdown
-    NVML_TEMPERATURE_THRESHOLD_GPU_MAX       = 3, // GPU Temperature at which the GPU
-                                                  // can be throttled below base clock
-    NVML_TEMPERATURE_THRESHOLD_ACOUSTIC_MIN  = 4, // Minimum GPU Temperature that can be
-                                                  // set as acoustic threshold
-    NVML_TEMPERATURE_THRESHOLD_ACOUSTIC_CURR = 5, // Current temperature that is set as
-                                                  // acoustic threshold.
-    NVML_TEMPERATURE_THRESHOLD_ACOUSTIC_MAX  = 6, // Maximum GPU temperature that can be
-                                                  // set as acoustic threshold.
-    NVML_TEMPERATURE_THRESHOLD_GPS_CURR      = 7, // Current temperature that is set as
-                                                  // gps threshold.
+    NVML_TEMPERATURE_THRESHOLD_SHUTDOWN       = 0, //!< Temperature at which the GPU will
+                                                   //!< shut down for HW protection
+    NVML_TEMPERATURE_THRESHOLD_SLOWDOWN       = 1, //!< Temperature at which the GPU will
+                                                   //!< begin HW slowdown
+    NVML_TEMPERATURE_THRESHOLD_MEM_MAX        = 2, //!< Memory Temperature at which the GPU will
+                                                   //!< begin SW slowdown
+    NVML_TEMPERATURE_THRESHOLD_GPU_MAX        = 3, //!< GPU Temperature at which the GPU
+                                                   //!< can be throttled below base clock
+    NVML_TEMPERATURE_THRESHOLD_ACOUSTIC_MIN   = 4, //!< Minimum GPU Temperature that can be
+                                                   //!< set as acoustic threshold
+    NVML_TEMPERATURE_THRESHOLD_ACOUSTIC_CURR  = 5, //!< Current temperature that is set as
+                                                   //!< acoustic threshold.
+    NVML_TEMPERATURE_THRESHOLD_ACOUSTIC_MAX   = 6, //!< Maximum GPU temperature that can be
+                                                   //!< set as acoustic threshold.
+    NVML_TEMPERATURE_THRESHOLD_GPS_CURR       = 7, //!< Current temperature that is set as
+                                                   //!< gps threshold.
     // Keep this last
     NVML_TEMPERATURE_THRESHOLD_COUNT
 } nvmlTemperatureThresholds_t;
@@ -969,6 +1184,8 @@ typedef enum nvmlTemperatureThresholds_enum
 typedef enum nvmlTemperatureSensors_enum
 {
     NVML_TEMPERATURE_GPU      = 0,    //!< Temperature sensor for the GPU die
+
+    NVML_TEMPERATURE_GPU_MAX  = 1,    //!< Temperature from the hottest part of the GPU die
 
     // Keep this last
     NVML_TEMPERATURE_COUNT
@@ -1559,7 +1776,12 @@ typedef struct
 
 #define NVML_DEVICE_ARCH_BLACKWELL 10 //!< Devices based on the NVIDIA Blackwell architecture
 
+#define NVML_DEVICE_ARCH_DLA       11 //!< Devices based on the NVIDIA DLA architecture.
+#define NVML_DEVICE_ARCH_DLA2      12 //!< Devices based on the NVIDIA DLA2 architecture.
+
 #define NVML_DEVICE_ARCH_RUBIN     13 //!< Devices based on the NVIDIA Rubin architecture.
+
+#define NVML_DEVICE_ARCH_NPU3      15 //!< Devices based on the NVIDIA NPU3 architecture.
 
 #define NVML_DEVICE_ARCH_UNKNOWN   0xffffffff //!< Anything else, presumably something newer
 
@@ -1675,6 +1897,15 @@ typedef struct
 
 #define nvmlPowerValue_v2 NVML_STRUCT_VERSION(PowerValue, 2) //!< Version macro for \a nvmlPowerValue_v2_t
 
+typedef struct
+{
+    nvmlEnableState_t inBandEnableRequest;    //!< [out] In-band enable requested (NVML_FEATURE_ENABLED) or not requested (NVML_FEATURE_DISABLED)
+    nvmlEnableState_t featureAllowedByAdmin;  //!< [out] Feature allowed by out-of-band/admin (NVML_FEATURE_ENABLED) or not allowed (NVML_FEATURE_DISABLED)
+    nvmlEnableState_t adminOverrideEnabled;   //!< [out] Out-of-band/admin override active (NVML_FEATURE_ENABLED) or inactive (NVML_FEATURE_DISABLED)
+    nvmlEnableState_t enablementStatus;       //!< [out] Enablement after arbitration: active (NVML_FEATURE_ENABLED) or inactive (NVML_FEATURE_DISABLED)
+    unsigned int adjustedLimitMw;             //!< [out] Adjusted TGP limit in milliwatts (valid only when feature is enabled)
+} nvmlAdaptiveTgpModeInfo_v1_t;
+
 /** @} */
 
 /***************************************************************************************************/
@@ -1733,7 +1964,8 @@ typedef enum {
     NVML_GRID_LICENSE_FEATURE_CODE_NVIDIA_RTX   = 2,                                         //!< Nvidia RTX
     NVML_GRID_LICENSE_FEATURE_CODE_VWORKSTATION = NVML_GRID_LICENSE_FEATURE_CODE_NVIDIA_RTX, //!< Deprecated, do not use.
     NVML_GRID_LICENSE_FEATURE_CODE_GAMING       = 3,                                         //!< Gaming
-    NVML_GRID_LICENSE_FEATURE_CODE_COMPUTE      = 4                                          //!< Compute
+    NVML_GRID_LICENSE_FEATURE_CODE_COMPUTE      = 4,                                         //!< Compute
+    NVML_GRID_LICENSE_FEATURE_CODE_VGAMEDEV     = 5                                          //!< vGameDev
 } nvmlGridLicenseFeatureCode_t;
 
 /**
@@ -2031,6 +2263,9 @@ typedef nvmlVgpuRuntimeState_v1_t nvmlVgpuRuntimeState_t;
 #define NVML_VGPU_SCHEDULER_ENGINE_TYPE_NVENC1    2 //!< NVENC1
 #define NVML_VGPU_SCHEDULER_ENGINE_TYPE_NVENC0    3 //!< NVENC0
 
+/**
+ * Union to represent the vGPU Scheduler Parameters
+ */
 typedef struct {
     unsigned int avgFactor;
     unsigned int timeslice;
@@ -2040,9 +2275,6 @@ typedef struct {
     unsigned int timeslice;
 } nvmlVgpuSchedulerParamsVgpuSchedData_t;
 
-/**
- * Union to represent the vGPU Scheduler Parameters
- */
 typedef union
 {
     nvmlVgpuSchedulerParamsVgpuSchedDataWithARR_t vgpuSchedDataWithARR;
@@ -2087,6 +2319,9 @@ typedef struct nvmlVgpuSchedulerGetState_st
     nvmlVgpuSchedulerParams_t   schedulerParams;
 } nvmlVgpuSchedulerGetState_t;
 
+/**
+ * Union to represent the vGPU Scheduler set Parameters
+ */
 typedef struct {
     unsigned int avgFactor;
     unsigned int frequency;
@@ -2096,9 +2331,6 @@ typedef struct {
     unsigned int timeslice;
 } nvmlVgpuSchedulerSetParamsVgpuSchedData_t;
 
-/**
- * Union to represent the vGPU Scheduler set Parameters
- */
 typedef union
 {
     nvmlVgpuSchedulerSetParamsVgpuSchedDataWithARR_t vgpuSchedDataWithARR;
@@ -2210,6 +2442,8 @@ typedef enum nvmlDeviceGpuRecoveryAction_s  {
     NVML_GPU_RECOVERY_ACTION_DRAIN_P2P = 3,           //!< Drain P2P
     NVML_GPU_RECOVERY_ACTION_DRAIN_AND_RESET = 4,     //!< Drain P2P and Reset Gpu
     NVML_GPU_RECOVERY_ACTION_RECOVER_IMEX_DOMAIN = 5, //!< Recover IMEX Domain.
+    NVML_GPU_RECOVERY_ACTION_BUS_RESET = 6,           //!< Reset the GPU's PCIe bus
+    NVML_GPU_RECOVERY_ACTION_SYSTEM_REBOOT = 7,       //!< Reboot the system
 } nvmlDeviceGpuRecoveryAction_t;
 
 /**
@@ -2685,7 +2919,7 @@ typedef struct
  * Link ID needs to be specified in the scopeId field in nvmlFieldValue_t.
  */
 #define NVML_FI_DEV_NVLINK_GET_SPEED                  164 //!< NVLink Speed in MBps
-#define NVML_FI_DEV_NVLINK_GET_STATE                  165 //!< NVLink State - Active,Inactive
+#define NVML_FI_DEV_NVLINK_GET_STATE                  165 //!< NVLink State - one of NVML_NVLINK_STATE_* values
 #define NVML_FI_DEV_NVLINK_GET_VERSION                166 //!< NVLink Version
 
 #define NVML_FI_DEV_NVLINK_GET_POWER_STATE            167 //!< NVLink Power state. 0=HIGH_SPEED 1=LOW_SPEED
@@ -2805,7 +3039,7 @@ typedef struct
 #define NVML_FI_DEV_DRAIN_AND_RESET_STATUS                       227 //!< Deprecated, do not use (use NVML_FI_DEV_GET_GPU_RECOVERY_ACTION instead)
 #define NVML_FI_DEV_PCIE_OUTBOUND_ATOMICS_MASK                   228
 #define NVML_FI_DEV_PCIE_INBOUND_ATOMICS_MASK                    229
-#define NVML_FI_DEV_GET_GPU_RECOVERY_ACTION                      230 //!< GPU Recovery action - None/Reset/Reboot/Drain P2P/Drain and Reset
+#define NVML_FI_DEV_GET_GPU_RECOVERY_ACTION                      230 //!< GPU Recovery action. See \ref nvmlDeviceGpuRecoveryAction_t
 #define NVML_FI_DEV_C2C_LINK_ERROR_INTR                          231 //!< C2C Link CRC Error Counter
 #define NVML_FI_DEV_C2C_LINK_ERROR_REPLAY                        232 //!< C2C Link Replay Error Counter
 #define NVML_FI_DEV_C2C_LINK_ERROR_REPLAY_B2B                    233 //!< C2C Link Back to Back Replay Error Counter
@@ -2964,9 +3198,17 @@ typedef struct
 #define NVML_FI_DEV_MCLK_SWITCH_TYPE                             298 //!< See NVML_MCLK_SWITCH_TYPE_<XYZ> for all enumerations
 #define NVML_FI_DEV_MCLK_MIN_SWITCH_INTERVAL_MILLISECONDS        299 //!< minimum required elapsed time between runtime mclk switches, 0 = no rate limit
 #define NVML_FI_PWR_SMOOTHING_SOC_POWER_SMOOTHING_ENABLED        300 //!< State-Of-Charge Power Smoothing Enabled (0/DISABLED or 1/ENABLED)
+
 #define NVML_FI_DEV_REMAPPED_ROWS_COR_INACTIVE                  301 //!< Number of inactive row remappings due to correctable errors
 #define NVML_FI_DEV_REMAPPED_ROWS_UNC_INACTIVE                  302 //!< Number of inactive row remappings due to uncorrectable errors
-#define NVML_FI_MAX                                             303 //!< One greater than the largest field ID defined above
+
+/* Bank Remapper */
+#define NVML_FI_DEV_ACTIVE_BANK_REMAPPINGS          303 //!< Number of active bank remappings
+#define NVML_FI_DEV_INACTIVE_BANK_REMAPPINGS        304 //!< Number of inactive bank remappings
+#define NVML_FI_DEV_BANK_REMAPPER_HISTOGRAM_MAX     305 //!< Number of groups with full bank remap availability.
+#define NVML_FI_DEV_BANK_REMAPPER_HISTOGRAM_NONE    306 //!< Number of groups with no spare bankremap availability.
+#define NVML_FI_DEV_PENDING_BANK_REMAPPING          307 //!< If any banks are pending remapping. 1=yes 0=no
+#define NVML_FI_MAX                                 308 //!< One greater than the largest field ID defined above
 
 /**
  * NVML_FI_DEV_MCLK_SWITCH_TYPE enumerations
@@ -3255,6 +3497,119 @@ typedef struct nvmlEventData_st
 } nvmlEventData_t;
 
 /**
+ * @brief Log-level values used by GPU Operational Events.
+ *
+ * These values are used both for event reporting in \ref nvmlEventSetWait_v3_t and for subscription
+ * filtering in \ref nvmlGpuOperationalEventConfig_v1_t. Higher numeric values represent more
+ * selective log levels. \c NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_ALL disables log-level filtering
+ * when used as a subscription threshold. Event data may contain newer log-level values that are
+ * not named in this header; clients should handle unrecognized numeric values.
+ */
+typedef enum
+{
+    NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_ALL       = 0,  //!< Matches all GPU Operational Event log levels.
+    NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_TELEMETRY = 10, //!< High-volume telemetry events.
+    NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_DIAG      = 20, //!< Diagnostic events.
+    NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_NOTICE    = 30, //!< Notable operational events.
+    NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_WARNING   = 40, //!< Warning events.
+    NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_ERROR     = 50, //!< Error events.
+} nvmlGpuOperationalEventLogLevel_t;
+
+/**
+ * @brief Severity values used by Operational Events.
+ *
+ * These values are used both for event reporting in \ref nvmlEventSetWait_v3_t and for subscription
+ * filtering in \ref nvmlGpuOperationalEventConfig_v1_t. Higher numeric values represent more
+ * selective severities. \c NVML_OPERATIONAL_EVENT_SEVERITY_ALL disables severity filtering when
+ * used as a subscription threshold. Event data may contain newer severity values that are not
+ * named in this header; clients should handle unrecognized numeric values.
+ */
+typedef enum
+{
+    NVML_OPERATIONAL_EVENT_SEVERITY_ALL           = 0,  //!< Matches all Operational Event severities.
+    NVML_OPERATIONAL_EVENT_SEVERITY_INFORMATIONAL = 10, //!< Informational event.
+    NVML_OPERATIONAL_EVENT_SEVERITY_CORRECTED     = 20, //!< Corrected error event.
+    NVML_OPERATIONAL_EVENT_SEVERITY_RECOVERABLE   = 30, //!< Recoverable error event.
+    NVML_OPERATIONAL_EVENT_SEVERITY_FATAL         = 40, //!< Fatal error event.
+} nvmlOperationalEventSeverity_t;
+
+/**
+ * @brief Event data formats returned by \ref nvmlEventSetWait_v3.
+ */
+typedef enum
+{
+    NVML_EVENT_DATA_TYPE_NVML_EVENT            = 0, //!< NVML event-bit data. \c eventType contains an NVML event bit.
+    NVML_EVENT_DATA_TYPE_GPU_OPERATIONAL_EVENT = 1, //!< Structured GPU Operational Event data.
+} nvmlEventDataType_t;
+
+#define NVML_GPU_INSTANCE_ID_ANY      0xFFFFFFFFU //!< Sentinel value used when no MIG GPU instance ID applies.
+#define NVML_COMPUTE_INSTANCE_ID_ANY  0xFFFFFFFFU //!< Sentinel value used when no MIG compute instance ID applies.
+
+#define NVML_OPERATIONAL_EVENT_ATTR_UNCONTAINED        (1u << 0) //!< Event reports an uncontained condition.
+#define NVML_OPERATIONAL_EVENT_ATTR_LATENT             (1u << 1) //!< Event reports a latent condition.
+#define NVML_OPERATIONAL_EVENT_ATTR_PROPAGATED         (1u << 2) //!< Event was propagated from another source.
+#define NVML_OPERATIONAL_EVENT_ATTR_COMPONENT_RESET    (1u << 3) //!< Event involved a component reset.
+#define NVML_OPERATIONAL_EVENT_ATTR_THRESHOLD_EXCEEDED (1u << 4) //!< Event reports an exceeded threshold.
+#define NVML_OPERATIONAL_EVENT_ATTR_PRIMARY            (1u << 5) //!< Event is the primary event in its group.
+#define NVML_OPERATIONAL_EVENT_ATTR_OVERFLOW           (1u << 6) //!< One or more events or associated payloads were dropped before this event was returned.
+
+#define NVML_OPERATIONAL_EVENT_GROUP_ATTR_RECOVERED    (1u << 0) //!< Event group reports a recovered condition.
+#define NVML_OPERATIONAL_EVENT_GROUP_ATTR_PREVERR      (1u << 1) //!< Event group reports a previous error condition.
+#define NVML_OPERATIONAL_EVENT_GROUP_ATTR_SIMULATED    (1u << 2) //!< Event group was generated by simulation or testing.
+
+/**
+ * @brief NVML-defined GPU Operational Event context classifications.
+ *
+ * These values describe the NVML public interpretation of a context payload. The
+ * original source-defined context type is returned separately in
+ * \ref nvmlEventSetGetContextInfo_v1_t::sourceEventContextType.
+ */
+typedef enum
+{
+    NVML_GPU_OPERATIONAL_EVENT_CONTEXT_TYPE_UNKNOWN    = 0, //!< No NVML public interpretation is defined for this context payload.
+    NVML_GPU_OPERATIONAL_EVENT_CONTEXT_TYPE_LEGACY_XID = 1, //!< Context payload can be decoded with \ref nvmlEventSetGetGpuOperationalEventContextLegacyXid_v1.
+} nvmlGpuOperationalEventContextType_t;
+
+/**
+ * @brief Parameters for retrieving the number of context records associated with the most recent event.
+ */
+typedef struct
+{
+    unsigned int count; //!< [out] Number of context records associated with the most recent event.
+} nvmlEventSetGetContextCount_v1_t;
+
+/**
+ * @brief Parameters for retrieving context metadata associated with the most recent event.
+ */
+typedef struct
+{
+    unsigned int   index;                                //!< [in] Zero-based context index.
+    unsigned int   nvmlGpuOperationalEventContextType;  //!< [out] \ref nvmlGpuOperationalEventContextType_t value describing the NVML public interpretation of the context payload.
+    unsigned int   sourceEventContextType;              //!< [out] Source-defined context payload type identifier carried by the event.
+    unsigned int   dataSize;                            //!< [out] Context payload size in bytes, excluding alignment padding.
+    unsigned short dataFormatVersion;                   //!< [out] Payload format version for \c sourceEventContextType.
+} nvmlEventSetGetContextInfo_v1_t;
+
+/**
+ * @brief Parameters for retrieving raw context data associated with the most recent event.
+ */
+typedef struct
+{
+    void         *data;     //!< [in] Optional caller-owned buffer that receives the raw context payload.
+    unsigned int index;     //!< [in] Zero-based context index.
+    unsigned int dataSize;  //!< [in,out] Size of \c data on input; actual or required size on output.
+} nvmlEventSetGetContextData_v1_t;
+
+/**
+ * @brief Parameters for retrieving decoded GPU legacy-Xid context data.
+ */
+typedef struct
+{
+    unsigned int index;    //!< [in] Zero-based context index.
+    unsigned int xidCode;  //!< [out] Legacy Xid code carried in a GPU Operational Event context.
+} nvmlEventSetGetGpuOperationalEventContextLegacyXid_v1_t;
+
+/**
  * System Event Set
  */
 typedef struct
@@ -3424,6 +3779,20 @@ typedef nvmlSystemEventSetWaitRequest_v1_t nvmlSystemEventSetWaitRequest_t;
  */
 #define nvmlClocksEventReasonDisplayClockSetting       0x0000000000000100LL //!< Display clock setting limited.
 
+/** Board limit
+ *
+ * The board limit (operating) policy is currently limiting the GPU clocks.
+ *
+ */
+#define nvmlClocksEventReasonBoardLimit                0x0000000000000200LL //!< Board limit policy is limiting clocks.
+
+/** Reliability
+ *
+ * The reliability policy is currently limiting the GPU clocks.
+ *
+ */
+#define nvmlClocksEventReasonReliability              0x0000000000000400LL //!< Reliability policy is limiting clocks.
+
 /** Bit mask representing no clocks throttling
  *
  * Clocks are as high as possible.
@@ -3437,12 +3806,14 @@ typedef nvmlSystemEventSetWaitRequest_v1_t nvmlSystemEventSetWaitRequest_t;
       | nvmlClocksEventReasonGpuIdle                           \
       | nvmlClocksEventReasonApplicationsClocksSetting         \
       | nvmlClocksEventReasonSwPowerCap                        \
-      | nvmlClocksThrottleReasonHwSlowdown                        \
+      | nvmlClocksThrottleReasonHwSlowdown                     \
       | nvmlClocksEventReasonSyncBoost                         \
       | nvmlClocksEventReasonSwThermalSlowdown                 \
-      | nvmlClocksThrottleReasonHwThermalSlowdown                 \
-      | nvmlClocksThrottleReasonHwPowerBrakeSlowdown              \
+      | nvmlClocksThrottleReasonHwThermalSlowdown              \
+      | nvmlClocksThrottleReasonHwPowerBrakeSlowdown           \
       | nvmlClocksEventReasonDisplayClockSetting               \
+      | nvmlClocksEventReasonBoardLimit                        \
+      | nvmlClocksEventReasonReliability                       \
 ) //!< Bitmask of all clock event reasons.
 
 /**
@@ -3906,6 +4277,16 @@ typedef struct
 #define NVML_GPU_FABRIC_HEALTH_MASK_WIDTH_PARTITION_ASSIGNED 0x3       //!< Fabric Health Mask Width for Partition Assigned
 
 /**
+ * Global Fabric Manager State
+ */
+#define NVML_GPU_FABRIC_HEALTH_MASK_GFM_STATE_NOT_SUPPORTED  0 //!< Fabric Health Mask: Global Fabric Manager State not supported
+#define NVML_GPU_FABRIC_HEALTH_MASK_GFM_STATE_CONNECTED      1 //!< Fabric Health Mask: Global Fabric Manager State is Connected
+#define NVML_GPU_FABRIC_HEALTH_MASK_GFM_STATE_DISCONNECTED   2 //!< Fabric Health Mask: Global Fabric Manager State is Disconnected
+
+#define NVML_GPU_FABRIC_HEALTH_MASK_SHIFT_GFM_STATE  14        //!< Fabric Health Mask Bit Shift for Global Fabric Manager State
+#define NVML_GPU_FABRIC_HEALTH_MASK_WIDTH_GFM_STATE  0x3       //!< Fabric Health Mask Width for Global Fabric Manager State
+
+/**
  * Fabric Health
  */
 #define NVML_GPU_FABRIC_HEALTH_SUMMARY_NOT_SUPPORTED 0    //!< Fabric Health Summary: Not supported
@@ -3958,11 +4339,14 @@ typedef struct
 #define nvmlGpuFabricInfo_v2 NVML_STRUCT_VERSION(GpuFabricInfo, 2) //!< Version macro for \a nvmlGpuFabricInfo_v2_t
 
 /**
-* GPU Fabric information (v3).
-*/
+ * GPU Fabric information (v3).
+ *
+ * @deprecated  nvmlGpuFabricInfo_v3_t is deprecated and will be removed in a future release.
+ *              Use nvmlGpuFabricInfo_v4_t instead.
+ */
 typedef struct
 {
-    unsigned int         version;                               //!< Structure version identifier (set to nvmlGpuFabricInfo_v2)
+    unsigned int         version;                               //!< Structure version identifier (set to nvmlGpuFabricInfo_v3)
     unsigned char        clusterUuid[NVML_GPU_FABRIC_UUID_LEN]; //!< Uuid of the cluster to which this GPU belongs
     nvmlReturn_t         status;                                //!< Probe Error status, if any. Must be checked only if Probe state returns "complete".
     unsigned int         cliqueId;                              //!< ID of the fabric clique to which this GPU belongs
@@ -3978,81 +4362,134 @@ typedef nvmlGpuFabricInfo_v3_t nvmlGpuFabricInfoV_t;
 */
 #define nvmlGpuFabricInfo_v3 NVML_STRUCT_VERSION(GpuFabricInfo, 3) //!< Version macro for \a nvmlGpuFabricInfo_v3_t
 
-/** @} */
-
-/***************************************************************************************************/
-/** @defgroup nvmlInitializationAndCleanup Initialization and Cleanup
- * This chapter describes the methods that handle NVML initialization and cleanup.
- * It is the user's responsibility to call \ref nvmlInit_v2() before calling any other methods, and
- * nvmlShutdown() once NVML is no longer being used.
- *  @{
+/**
+ * Maximum number of fabric clique entries.
  */
-/***************************************************************************************************/
+#define NVML_GPU_FABRIC_CLIQUE_MAX       64
 
-#define NVML_INIT_FLAG_NO_GPUS      (1 << 0)   //!< Don't fail nvmlInit() when no GPUs are found
-#define NVML_INIT_FLAG_NO_ATTACH    (1 << 1)   //!< Don't attach GPUs
-#define NVML_INIT_FLAG_FORCE_INIT   (1 << 2)   //!< Force GPU initialization when a previous nvmlInit was called with NO_GPUS and NO_ATTACH flags
+#define NVML_GPU_FABRIC_CLIQUE_TYPE_UNICAST_POINTER                         0 //!< Unicast pointer-based access
+#define NVML_GPU_FABRIC_CLIQUE_TYPE_MULTICAST_POINTER                       1 //!< Multicast pointer-based access
+#define NVML_GPU_FABRIC_CLIQUE_TYPE_UNICAST_LOGICAL_ENDPOINT                2 //!< Unicast logical-endpoint-based access
+#define NVML_GPU_FABRIC_CLIQUE_TYPE_MULTICAST_LOGICAL_ENDPOINT              3 //!< Multicast logical-endpoint-based access
 
 /**
- * Initialize NVML, but don't initialize any GPUs yet.
+ * Fabric clique entry. Each entry represents a single (type, id) pair
+ * describing a clique assignment for a given fabric operation type.
+ */
+typedef struct
+{
+    unsigned char type;  //!< Clique type. See NVML_GPU_FABRIC_CLIQUE_TYPE_*
+    unsigned int  id;    //!< Clique ID assigned by the Fabric Manager
+} nvmlGpuFabricClique_v1_t;
+
+/**
+ * GPU Fabric information (v4).
  *
- * \note nvmlInit_v3 introduces a "flags" argument, that allows passing boolean values
- *       modifying the behaviour of nvmlInit().
- * \note In NVML 5.319 new nvmlInit_v2 has replaced nvmlInit"_v1" (default in NVML 4.304 and older) that
- *       did initialize all GPU devices in the system.
+ * Extends v3 by replacing the single \a cliqueId field with a flat array
+ * of (type, id) clique entries. The legacy v3 \a cliqueId maps to the
+ * \a id of the first \ref NVML_GPU_FABRIC_CLIQUE_TYPE_UNICAST_POINTER entry.
+ */
+typedef struct
+{
+    unsigned char            clusterUuid[NVML_GPU_FABRIC_UUID_LEN]; //!< Uuid of the cluster to which this GPU belongs
+    nvmlReturn_t             status;                               //!< Probe Error status, if any. Must be checked only if state returns "complete".
+    nvmlGpuFabricClique_v1_t cliques[NVML_GPU_FABRIC_CLIQUE_MAX];  //!< Clique entries, sorted by ascending type then ascending id
+    unsigned int             numCliques;                           //!< Number of valid entries in \a cliques[]
+    nvmlGpuFabricState_t     state;                                //!< Current Probe State. See NVML_GPU_FABRIC_STATE_*
+    unsigned int             healthMask;                           //!< GPU Fabric health Status Mask. See NVML_GPU_FABRIC_HEALTH_MASK_*
+    unsigned char            healthSummary;                        //!< GPU Fabric health summary. See NVML_GPU_FABRIC_HEALTH_SUMMARY_*
+} nvmlGpuFabricInfo_v4_t;
+
+/** @} */
+
+/**
+ * @defgroup nvmlInitializationAndCleanup Initialization and Cleanup
+ * @brief NVML Methods that handle the NVML Library initialization and cleanup.
  *
- * This allows NVML to communicate with a GPU
- * when other GPUs in the system are unstable or in a bad state.  When using this API, GPUs are
- * discovered and initialized in nvmlDeviceGetHandleBy* functions instead.
+ * This chapter describes the methods that handle NVML initialization and cleanup.
+ * It is the user's responsibility to call \ref nvmlInit_v2() before calling any
+ * other methods, and \ref nvmlShutdown() once NVML is no longer being used.
+ * @{
+ */
+
+#define NVML_INIT_FLAG_NO_GPUS      (1 << 0)   //!< Initialize the NVML Library even when no devices are found.
+#define NVML_INIT_FLAG_NO_ATTACH    (1 << 1)   //!< Initialize the NVML Library without attaching any discovered devices.
+#define NVML_INIT_FLAG_FORCE_INIT   (1 << 2)   //!< Force device initialization even when a previous nvmlInit was called with the NO_GPUS and NO_ATTACH flags.
+
+/**
+ * @brief Initialize the NVML Library lazily, without allocating any device state.
  *
- * \note To contrast nvmlInit_v2 with nvmlInit"_v1", NVML 4.304 nvmlInit"_v1" will fail when any detected GPU is in
- *       a bad or unstable state.
+ * This will initialize the NVML Library state without enumerating any discovered
+ * devices. This will allow NVML to communicate with a device, even if other devices
+ * are in an unstable or bad state. Enumeration of a device can be done by obtaining
+ * the device handle via the nvmlDeviceGetHandleBy* class of APIs.
+ *
+ * This method needs to be called once before any usage of NVML Library APIs.
  *
  * For all products.
  *
- * This method, should be called once before invoking any other methods in the library.
- * A reference count of the number of initializations is maintained.  Shutdown only occurs
- * when the reference count reaches zero.
- *
  * @return
- *         - \ref NVML_SUCCESS                   if NVML has been properly initialized
- *         - \ref NVML_ERROR_DRIVER_NOT_LOADED   if NVIDIA driver is not running
- *         - \ref NVML_ERROR_NO_PERMISSION       if NVML does not have permission to talk to the driver
- *         - \ref NVML_ERROR_UNKNOWN             on any unexpected error
+ * - \ref NVML_SUCCESS                   if the NVML Library was properly initialized.
+ * - \ref NVML_ERROR_DRIVER_NOT_LOADED   if the NVIDIA driver is not running.
+ * - \ref NVML_ERROR_NO_PERMISSION       if the NVML Library does not have permission to talk to the driver.
+ * - \ref NVML_ERROR_UNKNOWN             if there is an unexpected error.
+ *
+ * @note  A reference count of the number of initializations is maintained, and
+ *        a corresponding call to \ref nvmlShutdown() needs to be issued once usage
+ *        of the NVML Library is complete. Shutdown will only occur after the
+ *        reference count reaches zero.
+ *
+ * @see nvmlShutdown()
  */
 nvmlReturn_t DECLDIR nvmlInit_v2(void);
 
 /**
- * nvmlInitWithFlags is a variant of nvmlInit(), that allows passing a set of boolean values
- *       modifying the behaviour of nvmlInit().
- *       Other than the "flags" parameter it is completely similar to \ref nvmlInit_v2.
+ * @brief Initialize the NVML Library lazily, without allocating any device state, with additional init flags.
+ *
+ * A variant of \ref nvmlInit_v2(), this will initialize the NVML Library state without
+ * enumerating any discovered devices. An option to pass in additional flags
+ * is provided to modify the behavior of NVML Library init. The usage of these
+ * flags can be obtained from NVML_INIT_FLAG_*. These flags can be combined together.
+ *
+ * Other than the "flags" parameter, this method is completely identical to \ref nvmlInit_v2().
  *
  * For all products.
  *
- * @param flags                                 behaviour modifier flags
+ * @param[in]  flags                     NVML_INIT_FLAG_* flags that can modify NVML Init behavior.
  *
  * @return
- *         - \ref NVML_SUCCESS                   if NVML has been properly initialized
- *         - \ref NVML_ERROR_DRIVER_NOT_LOADED   if NVIDIA driver is not running
- *         - \ref NVML_ERROR_NO_PERMISSION       if NVML does not have permission to talk to the driver
- *         - \ref NVML_ERROR_UNKNOWN             on any unexpected error
+ * - \ref NVML_SUCCESS                   if the NVML Library was properly initialized.
+ * - \ref NVML_ERROR_DRIVER_NOT_LOADED   if the NVIDIA driver is not running.
+ * - \ref NVML_ERROR_NO_PERMISSION       if the NVML Library does not have permission to talk to the driver.
+ * - \ref NVML_ERROR_UNKNOWN             if there is an unexpected error.
+ *
+ * @note  A reference count of the number of initializations is maintained, and
+ *        a corresponding call to \ref nvmlShutdown() needs to be issued once usage
+ *        of the NVML Library is complete. Shutdown will only occur after the
+ *        reference count reaches zero.
+ *
+ * @see nvmlShutdown()
  */
 nvmlReturn_t DECLDIR nvmlInitWithFlags(unsigned int flags);
 
 /**
- * Shut down NVML by releasing all GPU resources previously allocated with \ref nvmlInit_v2().
+ * @brief Shut down and cleanup NVML Library state.
+ *
+ * This will shut down and cleanup NVML Library state by releasing all device and
+ * library resources previously allocated with \ref nvmlInit_v2() or \ref nvmlInitWithFlags().
+ * This should be called after all NVML work is done, and once for each call to
+ * \ref nvmlInit_v2() or \ref nvmlInitWithFlags().
+ *
+ * Complete shutdown will only occur when the reference count of all prior NVML
+ * initializations reaches zero. No error will be reported if this is called
+ * more times than \ref nvmlInit_v2() or \ref nvmlInitWithFlags().
  *
  * For all products.
  *
- * This method should be called after NVML work is done, once for each call to \ref nvmlInit_v2()
- * A reference count of the number of initializations is maintained.  Shutdown only occurs
- * when the reference count reaches zero.  For backwards compatibility, no error is reported if
- * nvmlShutdown() is called more times than nvmlInit().
- *
  * @return
- *         - \ref NVML_SUCCESS                 if NVML has been properly shut down
- *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
- *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ * - \ref NVML_SUCCESS                 if the NVML Library was properly shut down.
+ * - \ref NVML_ERROR_UNINITIALIZED     if the NVML Library was not previously initialized.
+ * - \ref NVML_ERROR_UNKNOWN           if there is an unexpected error.
  */
 nvmlReturn_t DECLDIR nvmlShutdown(void);
 
@@ -4136,6 +4573,65 @@ const DECLDIR char* nvmlErrorString(nvmlReturn_t result);
 #define NVML_DEVICE_VBIOS_VERSION_BUFFER_SIZE         32
 
 /** @} */
+
+/**
+ * @brief Configuration for registering structured GPU Operational Events with
+ * \ref nvmlEventSetRegisterGpuOperationalEvents_v1.
+ *
+ * Initialize the structure to zero and then set \c uuid to select the target GPU. Default values
+ * register new device-wide events with log-level and severity filters disabled.
+ */
+typedef struct nvmlGpuOperationalEventConfig_v1_st
+{
+    char                                uuid[NVML_DEVICE_UUID_V2_BUFFER_SIZE]; //!< [in] Target GPU UUID string. Must be a NULL-terminated "GPU-..." UUID.
+    unsigned int                        minLogLevel;                           //!< [in] \ref nvmlGpuOperationalEventLogLevel_t value for the minimum GPU Operational Event log level. \c NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_ALL means no filter.
+    unsigned int                        minSeverity;                           //!< [in] \ref nvmlOperationalEventSeverity_t value for the minimum Operational Event severity threshold. \c NVML_OPERATIONAL_EVENT_SEVERITY_ALL means no filter.
+} nvmlGpuOperationalEventConfig_v1_t;
+
+/**
+ * @brief Parameters for waiting on an event set with \ref nvmlEventSetWait_v3.
+ *
+ * This structure supplies the wait timeout and returns either NVML event-bit or structured event data.
+ * For NVML event-bit data,
+ * \c dataType is \ref NVML_EVENT_DATA_TYPE_NVML_EVENT, \c eventType contains the NVML event bit,
+ * fields such as \c eventData, \c gpuInstanceId, and \c computeInstanceId preserve existing
+ * semantics, and structured-only fields are set to 0 or empty values. For structured GPU Operational
+ * Events, \c dataType is \ref NVML_EVENT_DATA_TYPE_GPU_OPERATIONAL_EVENT, \c eventType is set to
+ * \ref nvmlEventTypeNone, and the structured metadata fields are populated.
+ *
+ * Clients that subscribe to both NVML event-bit and structured formats on the same event set should branch
+ * on \c dataType to determine which format was returned. During the transition period, the
+ * same underlying incident may generate both an NVML event-bit notification and a structured notification.
+ *
+ */
+typedef struct
+{
+    unsigned int        timeoutMs;                             //!< [in] Maximum amount of time to wait, in milliseconds.
+    unsigned int        dataType;                              //!< [out] \ref nvmlEventDataType_t value indicating which event-data format is populated.
+    char                uuid[NVML_DEVICE_UUID_V2_BUFFER_SIZE]; //!< [out] UUID for the GPU where the event occurred. Empty if unavailable.
+    char                sourceModule[16];                      //!< [out] Source module signature for structured events. Not guaranteed to be NULL-terminated. Empty for NVML event-bit events.
+    unsigned long long  eventType;                             //!< [out] NVML event bit for \ref NVML_EVENT_DATA_TYPE_NVML_EVENT events; \ref nvmlEventTypeNone for structured events.
+    unsigned long long  eventData;                             //!< [out] Xid code for \ref nvmlEventTypeXidCriticalError, or 0 when not applicable.
+    unsigned long long  groupCursor;                           //!< [out] Structured event group identifier. 0 for NVML event-bit events.
+    unsigned long long  instanceId;                            //!< [out] Structured event sequence identifier. 0 for NVML event-bit events.
+    unsigned long long  timestampUsec;                         //!< [out] Event timestamp in microseconds. 0 if unavailable.
+    unsigned long long  traceId;                               //!< [out] Structured event trace identifier. 0 for NVML event-bit events.
+    unsigned int        gpuInstanceId;                         //!< [out] MIG GPU instance ID for NVML event-bit data, or \c NVML_GPU_INSTANCE_ID_ANY when not applicable.
+    unsigned int        computeInstanceId;                     //!< [out] MIG compute instance ID for NVML event-bit data, or \c NVML_COMPUTE_INSTANCE_ID_ANY when not applicable.
+    unsigned int        severity;                              //!< [out] \ref nvmlOperationalEventSeverity_t value for structured events. May contain newer severity values not named in this header. \c NVML_OPERATIONAL_EVENT_SEVERITY_ALL for NVML event-bit events.
+    unsigned int        categoryId;                            //!< [out] Source-defined structured event category identifier. 0 for NVML event-bit events.
+    unsigned int        moduleEventCode;                       //!< [out] Source-module-defined event code. Interpret with \c sourceModule. 0 for NVML event-bit events.
+    unsigned int        scope;                                 //!< [out] Structured event scope identifier. 0 for NVML event-bit events.
+    unsigned int        originator;                            //!< [out] Structured event originator identifier. 0 for NVML event-bit events.
+    unsigned int        moduleInstance;                        //!< [out] Structured event module instance identifier. 0 for NVML event-bit events.
+    unsigned int        chipletId;                             //!< [out] Structured event chiplet identifier. 0 for NVML event-bit events.
+    unsigned int        logLevel;                              //!< [out] \ref nvmlGpuOperationalEventLogLevel_t value for structured GPU Operational Events. May contain newer log-level values not named in this header. \c NVML_GPU_OPERATIONAL_EVENT_LOG_LEVEL_ALL for NVML event-bit events.
+    unsigned int        attributes;                            //!< [out] Bitmask of \c NVML_OPERATIONAL_EVENT_ATTR_* values for structured events. May contain newer bits not named in this header. 0 for NVML event-bit events. May include \c NVML_OPERATIONAL_EVENT_ATTR_OVERFLOW if events or associated payloads were dropped.
+    unsigned int        groupCperSize;                         //!< [out] Associated CPER record size in bytes. 0 when unavailable.
+    unsigned int        groupAttributes;                       //!< [out] Bitmask of \c NVML_OPERATIONAL_EVENT_GROUP_ATTR_* values for structured events. May contain newer bits not named in this header. 0 for NVML event-bit events.
+    unsigned char       groupSize;                             //!< [out] Total number of events in the structured event group. 0 for NVML event-bit events.
+    unsigned char       groupIndex;                            //!< [out] Zero-based index within the structured event group. 0 for NVML event-bit events.
+} nvmlEventSetWait_v3_t;
 
 /***************************************************************************************************/
 /** @defgroup nvmlCPER CPER (Common Platform Error Record)
@@ -6618,7 +7114,6 @@ nvmlReturn_t DECLDIR nvmlDeviceGetPowerMizerMode_v1(nvmlDevice_t device, nvmlDev
 
 nvmlReturn_t DECLDIR nvmlDeviceSetPowerMizerMode_v1(nvmlDevice_t device, nvmlDevicePowerMizerModes_v1_t *powerMizerMode);
 
-
 /**
  * Retrieves total energy consumption for this GPU in millijoules (mJ) since the driver was last reloaded
  *
@@ -6657,6 +7152,58 @@ nvmlReturn_t DECLDIR nvmlDeviceGetTotalEnergyConsumption(nvmlDevice_t device, un
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetEnforcedPowerLimit(nvmlDevice_t device, unsigned int *limit);
+
+/**
+ * Request to enable or disable Adaptive TGP Mode for a GPU.
+ *
+ * %RUBIN_OR_NEWER%
+ * Requires root/admin privileges.
+ *
+ * Adaptive TGP Mode assigns tailored power budgets to two binned GPU parts within the same
+ * module, reducing node-to-node and rack-to-rack performance variation.
+ * An out-of-band administrator policy may override the in-band request;
+ * use \ref nvmlDeviceGetAdaptiveTgpModeInfo_v1 to query the arbitrated state.
+ *
+ * @param device     The identifier of the target device
+ * @param mode       NVML_FEATURE_ENABLED or NVML_FEATURE_DISABLED
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if the request was accepted
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a mode is not a valid \ref nvmlEnableState_t
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support Adaptive TGP Mode
+ *         - \ref NVML_ERROR_NO_PERMISSION     if the caller lacks root/admin privileges
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlDeviceGetAdaptiveTgpModeInfo_v1()
+ */
+nvmlReturn_t DECLDIR nvmlDeviceSetAdaptiveTgpMode_v1(nvmlDevice_t device, nvmlEnableState_t mode);
+
+/**
+ * Retrieves Adaptive TGP Mode state and telemetry for a GPU.
+ *
+ * %RUBIN_OR_NEWER%
+ *
+ * Populates \a info with the in-band request, out-of-band enablement status, out-of-band
+ * override status, arbitrated enablement state, and adjusted base power limit. The adjusted base
+ * power is valid only when feature is enabled.
+ * See \ref nvmlAdaptiveTgpModeInfo_v1_t for field details.
+ *
+ * @param device     The identifier of the target device
+ * @param info       Reference in which to return the Adaptive TGP Mode information
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if \a info has been populated
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a info is NULL
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support Adaptive TGP Mode
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlDeviceSetAdaptiveTgpMode_v1()
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetAdaptiveTgpModeInfo_v1(nvmlDevice_t device, nvmlAdaptiveTgpModeInfo_v1_t *info);
 
 /**
  * Retrieves the current GOM and pending GOM (the one that GPU will switch to after reboot).
@@ -6769,6 +7316,60 @@ nvmlReturn_t DECLDIR nvmlDeviceGetMemoryInfo(nvmlDevice_t device, nvmlMemory_t *
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetMemoryInfo_v2(nvmlDevice_t device, nvmlMemory_v2_t *memory);
+
+/**
+ * @brief Set the memory limits of the device for the cgroup partition.
+ *
+ * This method will set the memory limits of the device for the specified cgroup
+ * partition. The limits will indicate the amount of memory that can be allocated
+ * for the device for use of an application in that cgroup.
+ *
+ * For all products.
+ * For Linux only.
+ * Requires root/admin permissions.
+ *
+ * @param[in] device                               The identifier of the target device
+ * @param[in] limits                               A pointer to \ref nvmlSetMemoryLimits_v1_t where the limits can be set
+ *
+ * @return
+ *  - \ref NVML_SUCCESS                 if the operation was successful
+ *  - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *  - \ref NVML_ERROR_NO_PERMISSION     if the user doesn't have permission to perform this operation
+ *  - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid, \a limits is NULL,
+ *                                      the softLimit exceeds the hardLimit, or a limit
+ *                                      exceeds total device memory
+ *  - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support this feature
+ *  - \ref NVML_ERROR_OPERATING_SYSTEM  if the cgroup path cannot be opened
+ *  - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @note MIG handles are not supported
+ */
+nvmlReturn_t DECLDIR nvmlDeviceSetMemoryLimits_v1(nvmlDevice_t device, nvmlSetMemoryLimits_v1_t *limits);
+
+/**
+ * @brief Get the memory limits of the device for the cgroup partition.
+ *
+ * This method will get the current memory limits of the device for the specified
+ * cgroup partition, as well as the current memory used against the limits.
+ *
+ * For all products.
+ * For Linux only.
+ *
+ * @param[in]     device                           The identifier of the target device
+ * @param[in,out] limits                           A pointer to \ref nvmlGetMemoryLimits_v1_t
+ *
+ * @return
+ *  - \ref NVML_SUCCESS                 if the operation was successful
+ *  - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *  - \ref NVML_ERROR_INVALID_ARGUMENT  if \a device is invalid or \a limits is NULL
+ *  - \ref NVML_ERROR_NOT_SUPPORTED     if the device does not support this feature
+ *  - \ref NVML_ERROR_NOT_FOUND         if the limits were not found for this device and cgroup
+ *  - \ref NVML_ERROR_OPERATING_SYSTEM  if the cgroup path cannot be opened
+ *  - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @note MIG handles are not supported
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetMemoryLimits_v1(nvmlDevice_t device, nvmlGetMemoryLimits_v1_t *limits);
 
 /**
  * Retrieves the current compute mode for the device or MIG device.
@@ -7318,6 +7919,8 @@ nvmlReturn_t DECLDIR nvmlDeviceGetFBCSessions(nvmlDevice_t device, unsigned int 
  *
  * On Windows platforms the device driver can run in either WDDM, MCDM or WDM (TCC) modes. If a display is attached
  * to the device it must run in WDDM mode. MCDM mode is preferred if a display is not attached. TCC mode is deprecated.
+ * Driver-model availability is architecture-specific; attempting to set an unsupported driver model returns
+ * NVML_ERROR_NOT_SUPPORTED.
  *
  * See \ref nvmlDriverModel_t for details on available driver models.
  *
@@ -7872,6 +8475,37 @@ DEPRECATED(13.0) nvmlReturn_t DECLDIR nvmlDeviceGetGpuFabricInfo(nvmlDevice_t de
 */
 nvmlReturn_t DECLDIR nvmlDeviceGetGpuFabricInfoV(nvmlDevice_t device,
                                                  nvmlGpuFabricInfoV_t *gpuFabricInfo);
+
+/**
+ * Retrieves GPU fabric information including per-type clique assignments.
+ *
+ * Returns fabric clique data via \ref nvmlGpuFabricInfo_v4_t.
+ * Each entry in the \a cliques array is a (type, id) pair representing a single
+ * clique assignment. The number of valid entries is given by \a numCliques.
+ * Entries are sorted by ascending type (NVML_GPU_FABRIC_CLIQUE_TYPE_*), then by
+ * ascending clique id within each type.
+ *
+ * On Hopper systems, the driver reports Unicast Pointer and Multicast Pointer cliques.
+ * On Blackwell and Rubin, Unicast Logical Endpoint and Multicast Logical Endpoint
+ * are additionally reported.
+ *
+ * \code
+ *     nvmlGpuFabricInfo_v4_t fabricInfo = {0};
+ *     nvmlReturn_t result = nvmlDeviceGetGpuFabricInfo_v4(device, &fabricInfo);
+ * \endcode
+ *
+ * For Hopper &tm; or newer fully supported devices.
+ *
+ * @param device                               The identifier of the target device
+ * @param gpuFabricInfo                        Information about GPU fabric state including per-type cliques
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 Upon success
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     If \a device doesn't support gpu fabric
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  If \a device or \a gpuFabricInfo is invalid
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetGpuFabricInfo_v4(nvmlDevice_t device,
+                                                   nvmlGpuFabricInfo_v4_t *gpuFabricInfo);
 
 /**
  * Get Conf Computing System capabilities.
@@ -8686,6 +9320,20 @@ nvmlReturn_t DECLDIR nvmlDeviceSetHostname_v1(nvmlDevice_t device, nvmlHostname_
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetHostname_v1(nvmlDevice_t device, nvmlHostname_v1_t *hostname);
 
+/**
+    * Get Performance Metric samples
+    *
+    * See \ref nvmlPerfMetricsSamples_v1_t for more information on the struct.
+    *
+    * @param[in] device                            The identifier of the target device
+    * @param[out] samples                          Reference to \a nvmlPerfMetricsSamples_v1_t.
+    *
+    * @return
+    *        - \ref NVML_SUCCESS                         if the query is successful
+    *        - \ref NVML_ERROR_NOT_SUPPORTED             if this query is not supported by the device
+    **/
+nvmlReturn_t DECLDIR nvmlDevicePerfMetricsGetSamples_v1(nvmlDevice_t device, nvmlPerfMetricsSamples_v1_t *samples);
+
 /** @} */
 
 /***************************************************************************************************/
@@ -8881,6 +9529,9 @@ nvmlReturn_t DECLDIR nvmlDeviceClearEccErrorCounts(nvmlDevice_t device, nvmlEccC
  *
  * On Windows platforms the device driver can run in either WDDM or WDM (TCC) mode. If a display is attached
  * to the device it must run in WDDM mode.
+ *
+ * Driver-model availability is architecture-specific; attempting to set an unsupported driver model returns
+ * NVML_ERROR_NOT_SUPPORTED.
  *
  * It is possible to force the change to WDM (TCC) while the display is still attached with a force flag (nvmlFlagForce).
  * This should only be done if the host is subsequently powered down and the display is detached from the device
@@ -9408,9 +10059,10 @@ nvmlReturn_t DECLDIR nvmlDeviceClearAccountingPids(nvmlDevice_t device);
 /*
  * NVML_FI_DEV_NVLINK_GET_STATE state enums
  */
-#define NVML_NVLINK_STATE_INACTIVE 0x0 //!< NVLink is inactive.
-#define NVML_NVLINK_STATE_ACTIVE   0x1 //!< NVLink is active.
-#define NVML_NVLINK_STATE_SLEEP    0x2 //!< NVLink is in sleep state.
+#define NVML_NVLINK_STATE_INACTIVE 0x0          //!< NVLink is inactive.
+#define NVML_NVLINK_STATE_ACTIVE   0x1          //!< NVLink is active.
+#define NVML_NVLINK_STATE_SLEEP    0x2          //!< NVLink is in sleep state.
+#define NVML_NVLINK_STATE_ACTIVE_TRAFFIC_DISABLED 0x3 //!< NVLink is active, but not usable for traffic
 
 /**
  * Represents Nvlink Version
@@ -9456,6 +10108,21 @@ typedef struct
 } nvmlNvlinkSetBwMode_v1_t;
 typedef nvmlNvlinkSetBwMode_v1_t nvmlNvlinkSetBwMode_t;
 #define nvmlNvlinkSetBwMode_v1 NVML_STRUCT_VERSION(NvlinkSetBwMode, 1) //!< Version macro for \a nvmlNvlinkSetBwMode_v1_t
+
+/**
+ * @brief Describes the parameters involved to setting Nvlink RBM mode asynchronously.
+ *
+ * This structure holds the parameters needed to correctly set a Device's Nvlink
+ * Reduced Bandwidth Mode asynchronously. Polling for NVML_GPU_FABRIC_STATE_COMPLETED
+ * from \ref nvmlDeviceGetGpuFabricInfoV() is needed to check if the setting was applied.
+ *
+ */
+typedef struct
+{
+    unsigned int bSetBest;           //!< [in]  - Set to the best available Bandwidth mode
+    unsigned int bwMode;             //!< [in]  - Requested Bandwidth mode to set. Values can be found from \ref nvmlDeviceGetNvlinkSupportedBwModes()
+    unsigned int asyncPollTimeoutMs; //!< [out] - Time in ms to poll to validate bandwidth setting.
+} nvmlNvlinkSetBwModeAsync_v1_t;
 
 /**
  * Struct to represent per device NVLINK information v1
@@ -9859,6 +10526,26 @@ nvmlReturn_t DECLDIR nvmlDeviceSetNvlinkBwMode(nvmlDevice_t device,
                                                nvmlNvlinkSetBwMode_t *setBwMode);
 
 /**
+ * Set the NvLink Reduced Bandwidth Mode asynchronously for the device. Polling should be
+ * done by checking for \a NVML_GPU_FABRIC_STATE_COMPLETED from \ref nvmlDeviceGetGpuFabricInfoV().
+ *
+ * %RUBIN_OR_NEWER%
+ *
+ * @param[in]     device                              The identifier of the target device
+ * @param[in,out] setBwModeAsync                      Reference to \ref nvmlNvlinkSetBwModeAsync_v1_t
+ *
+ * @return
+ *        - \ref NVML_SUCCESS                         if the Bandwidth mode was successfully set
+ *        - \ref NVML_ERROR_INVALID_ARGUMENT          if device or \p setBwModeAsync is invalid
+ *        - \ref NVML_ERROR_NO_PERMISSION             if user does not have permission to change Bandwidth mode
+ *        - \ref NVML_ERROR_NOT_SUPPORTED             if this feature is not supported by the device
+ *
+ * @see nvmlDeviceGetGpuFabricInfoV()
+ *
+ **/
+nvmlReturn_t DECLDIR nvmlDeviceSetNvlinkBwModeAsync_v1(nvmlDevice_t device, nvmlNvlinkSetBwModeAsync_v1_t *setBwModeAsync);
+
+/**
  * Query NVLINK information associated with this device.
  *
  * @param[in]  device                              The identifier of the target device
@@ -9874,6 +10561,66 @@ nvmlReturn_t DECLDIR nvmlDeviceSetNvlinkBwMode(nvmlDevice_t device,
  *         - \ref NVML_ERROR_UNKNOWN                    on any unexpected error
  */
 nvmlReturn_t DECLDIR nvmlDeviceGetNvLinkInfo(nvmlDevice_t device, nvmlNvLinkInfo_t *info);
+
+/**
+ * Per-link NVLink telemetry sample types.
+ */
+typedef enum
+{
+    NVML_NVLINK_TELEMETRY_SAMPLE_TYPE_THROUGHPUT_RAW_TX = 0, //!< Raw TX flit counter for a single link
+    NVML_NVLINK_TELEMETRY_SAMPLE_TYPE_THROUGHPUT_RAW_RX = 1, //!< Raw RX flit counter for a single link
+    NVML_NVLINK_TELEMETRY_SAMPLE_TYPE_COUNT             = 2  //!< Number of valid sample types
+} nvmlNvlinkTelemetrySampleType_t;
+
+/**
+ * Struct representing one (link, metric) telemetry request / response slot.
+ */
+typedef struct
+{
+    unsigned int linkId;         //!<[in] LinkId
+    unsigned int sampleType;     //!<[in] Type of telemetry to sample, specified by `nvmlNvlinkTelemetrySampleType_t`
+    unsigned int sampleCount;    //!<[in,out]: Number of samples users need to allocate. If set to 0, will return max
+                                 //! supported count of samples without touching the `samples` pointer.
+    unsigned long long *samples; //!<[in,out]: Array of samples allocated by the user. Can be set to NULL when getting count
+    nvmlReturn_t nvmlReturn;     //!<[out]: Return code for retrieving this sample. This must be checked by the client
+                                 //! before looking at any output values, as they are invalid if `nvmlReturn != NVML_SUCCESS`.
+} nvmlNvlinkTelemetrySample_v1_t;
+
+/**
+ * Batched NVLink telemetry request.
+ */
+typedef struct
+{
+    unsigned int telemetryCount;                      //!<[in]     Number of valid entries in \a telemetrySamples
+    nvmlNvlinkTelemetrySample_v1_t *telemetrySamples; //!<[in,out] Caller-allocated array of \a telemetryCount request slots
+} nvmlNvlinkTelemetrySamples_v1_t;
+
+/**
+ * \brief Retrieve a batch of historical NVLink per-link telemetry samples.
+ *
+ * Samples are taken at approximately 100 ms intervals.
+ * Intended for use with periodic polling every ~2 seconds.
+ * Longer polling intervals are possible, but can result in dropped samples
+ * if the supported `sampleCount` is too low for the given polling interval.
+ *
+ * %RUBIN_OR_NEWER%
+ *
+ * @param[in]     device  The device handle of the GPU to retrieve samples for
+ * @param[in,out] samples Request/response batch (see \ref nvmlNvlinkTelemetrySamples_v1_t)
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 If the call succeeded.
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  If any required pointer is NULL,
+ *                                             a given enum value is out of range,
+ *                                             a slot's `linkId` is out of range,
+ *                                             a slot's `sampleCount` is non-zero with a NULL `samples` pointer, or
+ *                                             a slot's `sampleCount` is greater than the supported `sampleCount` for the given link.
+ *         - \ref NVML_ERROR_GPU_IS_LOST       If the target GPU has fallen off the bus or is otherwise inaccessible.
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     If the given device does not support this API.
+ *         - \ref NVML_ERROR_UNKNOWN           On any unexpected error.
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetNvLinkTelemetrySamples_v1(nvmlDevice_t device,
+                                                            nvmlNvlinkTelemetrySamples_v1_t *samples);
 
 /** @} */ // @defgroup NvLink NvLink Methods
 
@@ -9989,7 +10736,7 @@ nvmlReturn_t DECLDIR nvmlDeviceGetSupportedEventTypes(nvmlDevice_t device, unsig
  * @return
  *         - \ref NVML_SUCCESS                 if the data has been set
  *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
- *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a data is NULL
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a set or \a data is NULL
  *         - \ref NVML_ERROR_TIMEOUT           if no event arrived in specified timeout or interrupt arrived
  *         - \ref NVML_ERROR_GPU_IS_LOST       if a GPU has fallen off the bus or is otherwise inaccessible
  *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
@@ -9998,6 +10745,223 @@ nvmlReturn_t DECLDIR nvmlDeviceGetSupportedEventTypes(nvmlDevice_t device, unsig
  * @see nvmlDeviceRegisterEvents
  */
 nvmlReturn_t DECLDIR nvmlEventSetWait_v2(nvmlEventSet_t set, nvmlEventData_t * data, unsigned int timeoutms);
+
+/**
+ * @brief Adds a GPU Operational Event subscription to an event set.
+ *
+ * This API is separate from \ref nvmlDeviceRegisterEvents. Calling this API opts the event set into
+ * the structured GPU Operational Event format for the target GPU UUID. Subscriptions are identified
+ * by \a config; registering the same subscription more than once is treated as success.
+ *
+ * \ref nvmlDeviceRegisterEvents and \ref nvmlEventSetRegisterGpuOperationalEvents_v1 may both be used on the same
+ * event set. In that mixed-subscription model, NVML event-bit subscriptions continue to deliver event
+ * bits such as \ref nvmlEventTypeXidCriticalError, while GPU Operational Event subscriptions deliver
+ * \ref NVML_EVENT_DATA_TYPE_GPU_OPERATIONAL_EVENT records through \ref nvmlEventSetWait_v3 with
+ * \c eventType set to \ref nvmlEventTypeNone. The same underlying incident may generate both an NVML
+ * event-bit notification and a structured notification.
+ *
+ * This API supports GPU UUID subscriptions.
+ *
+ * For Turing &tm; or newer fully supported devices.
+ *
+ * For Linux only.
+ *
+ * @param[in] eventSet                         Event set created by \ref nvmlEventSetCreate
+ * @param[in] config                           GPU Operational Event subscription configuration
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if the GPU Operational Event subscription was registered
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a eventSet or \a config is invalid
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if structured GPU Operational Events are not supported on this platform,
+ *                                             or if the requested subscription is not supported
+ *         - \ref NVML_ERROR_NO_PERMISSION     if the caller lacks permission for the requested scope
+ *         - \ref NVML_ERROR_INSUFFICIENT_RESOURCES
+ *                                             if the event set cannot accept another subscription
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if the target GPU has fallen off the bus or is otherwise inaccessible
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlGpuOperationalEventConfig_v1_t
+ * @see nvmlEventSetWait_v3
+ * @see nvmlEventSetFree
+ */
+nvmlReturn_t DECLDIR nvmlEventSetRegisterGpuOperationalEvents_v1(nvmlEventSet_t eventSet,
+                                                                  const nvmlGpuOperationalEventConfig_v1_t *config);
+
+/**
+ * @brief Waits on an event set and returns the next event in the extended event format.
+ *
+ * This API is the unified wait surface for NVML event-bit subscriptions registered with
+ * \ref nvmlDeviceRegisterEvents and structured GPU Operational Event subscriptions registered with
+ * \ref nvmlEventSetRegisterGpuOperationalEvents_v1.
+ *
+ * The returned format is distinguished by \c dataType in \a params. If \c dataType is
+ * \ref NVML_EVENT_DATA_TYPE_NVML_EVENT, the event came from the \ref nvmlDeviceRegisterEvents path,
+ * \c eventType is an NVML event bit such as \ref nvmlEventTypeXidCriticalError, and the existing
+ * fields preserve their historical semantics. If \c dataType is
+ * \ref NVML_EVENT_DATA_TYPE_GPU_OPERATIONAL_EVENT, the event came from the structured format,
+ * \c eventType is \ref nvmlEventTypeNone, and the structured metadata fields are populated.
+ *
+ * When an event set contains only NVML event-bit subscriptions, this API normalizes those events into
+ * \ref nvmlEventSetWait_v3_t. When an event set contains both NVML event-bit and structured subscriptions,
+ * each successful call returns the next available event from either path. Clients should branch on
+ * \c dataType to determine which format was returned. An event set is not required to have
+ * structured GPU Operational Event subscriptions to be used with this API.
+ *
+ * Context records for the returned event, if any, are made available through
+ * \ref nvmlEventSetGetContextCount_v1, \ref nvmlEventSetGetContextInfo_v1, and
+ * \ref nvmlEventSetGetContextData_v1. Context records remain associated with the event set until the
+ * next successful call to \ref nvmlEventSetWait_v3 on the same event set or until the event set is freed.
+ *
+ * For Turing &tm; or newer fully supported devices.
+ *
+ * For Linux only.
+ *
+ * @param[in] set                              Reference to set of events to wait on
+ * @param[in,out] params                       Wait parameters and returned event data
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if the event data has been set
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a set or \a params is NULL
+ *         - \ref NVML_ERROR_TIMEOUT           if no event arrived in specified timeout or interrupt arrived
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if this API is not available on the platform or driver
+ *         - \ref NVML_ERROR_MEMORY            if system memory is insufficient
+ *         - \ref NVML_ERROR_GPU_IS_LOST       if a GPU has fallen off the bus or is otherwise inaccessible
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlEventSetWait_v3_t
+ * @see nvmlDeviceRegisterEvents
+ * @see nvmlEventSetRegisterGpuOperationalEvents_v1
+ * @see nvmlEventSetGetContextCount_v1
+ */
+nvmlReturn_t DECLDIR nvmlEventSetWait_v3(nvmlEventSet_t set, nvmlEventSetWait_v3_t *params);
+
+/**
+ * @brief Gets the number of context records for the most recent event returned by
+ * \ref nvmlEventSetWait_v3 on this event set.
+ *
+ * This count is tied to the event set, not to a caller-owned copy of \ref nvmlEventSetWait_v3_t. It is
+ * replaced by the next successful call to \ref nvmlEventSetWait_v3 on the same event set.
+ *
+ * For Turing &tm; or newer fully supported devices.
+ *
+ * For Linux only.
+ *
+ * @param[in] set                              Event set previously used with \ref nvmlEventSetWait_v3
+ * @param[out] params                          Parameters in which to return the number of context records
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if \a params has been set
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if \a set or \a params is NULL
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if this API is not available on the platform or driver
+ *         - \ref NVML_ERROR_NOT_FOUND         if no event has been returned by \ref nvmlEventSetWait_v3
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlEventSetWait_v3
+ * @see nvmlEventSetGetContextInfo_v1
+ * @see nvmlEventSetGetContextData_v1
+ */
+nvmlReturn_t DECLDIR nvmlEventSetGetContextCount_v1(nvmlEventSet_t set,
+                                                     nvmlEventSetGetContextCount_v1_t *params);
+
+/**
+ * @brief Gets metadata for a context record from the most recent event returned by
+ * \ref nvmlEventSetWait_v3.
+ *
+ * The returned metadata identifies the NVML public interpretation, the source-defined context payload
+ * type, payload size, and payload format version. The raw payload for any context record can be
+ * copied with \ref nvmlEventSetGetContextData_v1 and decoded using the public operational event
+ * schema or documentation for
+ * \ref nvmlEventSetGetContextInfo_v1_t::sourceEventContextType. When
+ * \c nvmlGpuOperationalEventContextType names a type-specific accessor, callers may use that
+ * accessor instead. Metadata is replaced by the next successful call to \ref nvmlEventSetWait_v3
+ * on the same event set.
+ *
+ * For Turing &tm; or newer fully supported devices.
+ *
+ * For Linux only.
+ *
+ * @param[in] set                              Event set previously used with \ref nvmlEventSetWait_v3
+ * @param[in,out] params                       Context index and returned context metadata
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if the context metadata has been returned
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if arguments are invalid or \c params->index is out of range
+ *         - \ref NVML_ERROR_NOT_FOUND         if no event has been returned by \ref nvmlEventSetWait_v3
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if this API is not available on the platform or driver
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlEventSetGetContextInfo_v1_t
+ * @see nvmlEventSetGetContextCount_v1
+ * @see nvmlEventSetGetContextData_v1
+ */
+nvmlReturn_t DECLDIR nvmlEventSetGetContextInfo_v1(nvmlEventSet_t set,
+                                                    nvmlEventSetGetContextInfo_v1_t *params);
+
+/**
+ * @brief Copies the raw payload for a context record from the most recent event returned by
+ * \ref nvmlEventSetWait_v3.
+ *
+ * Passing \c params->data as NULL performs a size query. In that case \c params->dataSize is set to the required
+ * payload size and the function returns \ref NVML_ERROR_INSUFFICIENT_SIZE when the payload is
+ * non-empty. If the context payload is empty, \c params->dataSize is set to 0 and the function returns
+ * \ref NVML_SUCCESS.
+ *
+ * For Turing &tm; or newer fully supported devices.
+ *
+ * For Linux only.
+ *
+ * @param[in] set                              Event set previously used with \ref nvmlEventSetWait_v3
+ * @param[in,out] params                       Context index, optional data buffer, and buffer size
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if the raw context payload has been copied
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if arguments are invalid or \c params->index is out of range
+ *         - \ref NVML_ERROR_NOT_FOUND         if no event has been returned by \ref nvmlEventSetWait_v3
+ *         - \ref NVML_ERROR_INSUFFICIENT_SIZE if \c params->data is NULL or too small for a non-empty payload
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if this API is not available on the platform or driver
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlEventSetWait_v3
+ * @see nvmlEventSetGetContextCount_v1
+ * @see nvmlEventSetGetContextInfo_v1
+ */
+nvmlReturn_t DECLDIR nvmlEventSetGetContextData_v1(nvmlEventSet_t set,
+                                                    nvmlEventSetGetContextData_v1_t *params);
+
+/**
+ * @brief Gets decoded GPU legacy-Xid context data for a context record from the most recent event returned
+ * by \ref nvmlEventSetWait_v3.
+ *
+ * This helper succeeds only for context records whose \c nvmlGpuOperationalEventContextType is
+ * \ref NVML_GPU_OPERATIONAL_EVENT_CONTEXT_TYPE_LEGACY_XID. Other context records remain available
+ * through \ref nvmlEventSetGetContextData_v1.
+ *
+ * For Turing &tm; or newer fully supported devices.
+ *
+ * For Linux only.
+ *
+ * @param[in] set                              Event set previously used with \ref nvmlEventSetWait_v3
+ * @param[in,out] params                       Context index and returned legacy-Xid data
+ *
+ * @return
+ *         - \ref NVML_SUCCESS                 if the GPU legacy-Xid context has been returned
+ *         - \ref NVML_ERROR_UNINITIALIZED     if the library has not been successfully initialized
+ *         - \ref NVML_ERROR_INVALID_ARGUMENT  if arguments are invalid or \c params->index is out of range
+ *         - \ref NVML_ERROR_NOT_FOUND         if no event has been returned or the context is not a GPU legacy-Xid context
+ *         - \ref NVML_ERROR_NOT_SUPPORTED     if this API is not available on the platform or driver
+ *         - \ref NVML_ERROR_UNKNOWN           on any unexpected error
+ *
+ * @see nvmlEventSetGetGpuOperationalEventContextLegacyXid_v1_t
+ * @see nvmlEventSetGetContextInfo_v1
+ * @see nvmlEventSetGetContextData_v1
+ */
+nvmlReturn_t DECLDIR nvmlEventSetGetGpuOperationalEventContextLegacyXid_v1(nvmlEventSet_t set,
+                                                                           nvmlEventSetGetGpuOperationalEventContextLegacyXid_v1_t *params);
 
 /**
  * Releases events in the set
@@ -12404,33 +13368,44 @@ typedef struct
  */
 nvmlReturn_t DECLDIR nvmlDeviceReadWritePRM_v1(nvmlDevice_t device, nvmlPRMTLV_v1_t *buffer);
 
-/** @} */
-
 /**
  * PRM Counter IDs
  */
 typedef enum
 {
-    NVML_PRM_COUNTER_ID_NONE = 0,
+    NVML_PRM_COUNTER_ID_NONE = 0,                                                                       //!< Sentinel
+                                                                                                        //
     /* Physical Layer Counters (PPCNT group 0x12) */
-    NVML_PRM_COUNTER_ID_PPCNT_PHYSICAL_LAYER_CTRS_LINK_DOWN_EVENTS = 1,
-    NVML_PRM_COUNTER_ID_PPCNT_PHYSICAL_LAYER_CTRS_SUCCESSFUL_RECOVERY_EVENTS = 2,
+    NVML_PRM_COUNTER_ID_PPCNT_PHYSICAL_LAYER_CTRS_LINK_DOWN_EVENTS = 1,                                 //!< PPCNT group 0x12, link_down_events
+    NVML_PRM_COUNTER_ID_PPCNT_PHYSICAL_LAYER_CTRS_SUCCESSFUL_RECOVERY_EVENTS = 2,                       //!< PPCNT group 0x12, successful_recovery_events
+
     /* Recovery counters (PPCNT group 0x1A) */
-    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_SUCCESSFUL_RECOVERY_EVENTS = 101,
-    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_SINCE_LAST_RECOVERY = 102,
-    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_BETWEEN_LAST_TWO_RECOVERIES = 103,
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_SUCCESSFUL_RECOVERY_EVENTS = 101,                     //!< PPCNT group 0x1A, total_successful_recovery_events
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_SINCE_LAST_RECOVERY = 102,                             //!< PPCNT group 0x1A, time_since_last_recovery
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_BETWEEN_LAST_TWO_RECOVERIES = 103,                     //!< PPCNT group 0x1A, time_between_last_two_recoveries
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TIME_IN_LAST_HOST_SERDES_FEQ_RECOVERY = 104,                //!< PPCNT group 0x1A, time_in_last_host_serdes_feq_recovery
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_TIME_IN_HOST_SERDES_FEQ_RECOVERY = 105,               //!< PPCNT group 0x1A, total_time_in_host_serdes_feq_recovery
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_HOST_SERDES_FEQ_RECOVERY_COUNT = 106,                 //!< PPCNT group 0x1A, total_host_serdes_feq_recovery_count
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_HOST_SERDES_FEQ_SUCCESSFUL_RECOVERY_COUNT = 107,      //!< PPCNT group 0x1A, total_host_serdes_feq_successful_recovery_count
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_LAST_HOST_SERDES_FEQ_ATTEMPTS_COUNT = 108,                  //!< PPCNT group 0x1A, last_host_serdes_feq_attempts_count
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_LAST_SUCCESSFUL_RECOVERY_STEP_ATTEMPTS = 109,               //!< PPCNT group 0x1A, last_successful_recovery_step_attempts
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_LAST_SUCCESSFUL_RECOVERY_TIME = 110,                        //!< PPCNT group 0x1A, last_successful_recovery_time
+    NVML_PRM_COUNTER_ID_PPCNT_RECOVERY_CTRS_TOTAL_SUCCESSFUL_RECOVERY_TIME = 111,                       //!< PPCNT group 0x1A, total_successful_recovery_time
+
     /* Infiniband PortCounters Attribute (PPCNT group 0x20) */
-    NVML_PRM_COUNTER_ID_PPCNT_PORTCOUNTERS_PORT_XMIT_WAIT = 201,
+    NVML_PRM_COUNTER_ID_PPCNT_PORTCOUNTERS_PORT_XMIT_WAIT = 201,                                        //!< PPCNT group 0x20, port_xmit_wait
+
     /* PLR counters (PPCNT group 0x22) */
-    NVML_PRM_COUNTER_ID_PPCNT_PLR_RCV_CODES = 301,
-    NVML_PRM_COUNTER_ID_PPCNT_PLR_RCV_CODE_ERR = 302,
-    NVML_PRM_COUNTER_ID_PPCNT_PLR_RCV_UNCORRECTABLE_CODE = 303,
-    NVML_PRM_COUNTER_ID_PPCNT_PLR_XMIT_CODES = 304,
-    NVML_PRM_COUNTER_ID_PPCNT_PLR_XMIT_RETRY_CODES = 305,
-    NVML_PRM_COUNTER_ID_PPCNT_PLR_XMIT_RETRY_EVENTS = 306,
-    NVML_PRM_COUNTER_ID_PPCNT_PLR_SYNC_EVENTS = 307,
+    NVML_PRM_COUNTER_ID_PPCNT_PLR_RCV_CODES = 301,                                                      //!< PPCNT group 0x22, plr_rcv_codes
+    NVML_PRM_COUNTER_ID_PPCNT_PLR_RCV_CODE_ERR = 302,                                                   //!< PPCNT group 0x22, plr_rcv_code_err
+    NVML_PRM_COUNTER_ID_PPCNT_PLR_RCV_UNCORRECTABLE_CODE = 303,                                         //!< PPCNT group 0x22, plr_rcv_uncorrectable_code
+    NVML_PRM_COUNTER_ID_PPCNT_PLR_XMIT_CODES = 304,                                                     //!< PPCNT group 0x22, plr_xmit_codes
+    NVML_PRM_COUNTER_ID_PPCNT_PLR_XMIT_RETRY_CODES = 305,                                               //!< PPCNT group 0x22, plr_xmit_retry_codes
+    NVML_PRM_COUNTER_ID_PPCNT_PLR_XMIT_RETRY_EVENTS = 306,                                              //!< PPCNT group 0x22, plr_xmit_retry_events
+    NVML_PRM_COUNTER_ID_PPCNT_PLR_SYNC_EVENTS = 307,                                                    //!< PPCNT group 0x22, plr_sync_events
+
     /* PPRM counters */
-    NVML_PRM_COUNTER_ID_PPRM_OPER_RECOVERY = 1001,
+    NVML_PRM_COUNTER_ID_PPRM_OPER_RECOVERY = 1001,                                                      //!< PPRM, oper_recovery
 } nvmlPRMCounterId_t;
 
 /**
@@ -12490,6 +13465,7 @@ typedef struct
  *        - \ref NVML_ERROR_UNKNOWN                     on any other error
  */
 nvmlReturn_t DECLDIR nvmlDeviceReadPRMCounters_v1(nvmlDevice_t device, nvmlPRMCounterList_v1_t *counterList);
+/** @} */
 
 /***************************************************************************************************/
 /** @defgroup nvmlMultiInstanceGPU Multi Instance GPU Management
@@ -13574,152 +14550,152 @@ typedef enum
     NVML_GPM_METRIC_NVLINK_L16_TX_PER_SEC       = 95,   //!< NvLink write bandwidth for link 16 in MiB/sec
     NVML_GPM_METRIC_NVLINK_L17_RX_PER_SEC       = 96,   //!< NvLink read bandwidth for link 17 in MiB/sec
     NVML_GPM_METRIC_NVLINK_L17_TX_PER_SEC       = 97,   //!< NvLink write bandwidth for link 17 in MiB/sec
-    NVML_GPM_METRIC_C2C_TOTAL_TX_PER_SEC        = 100,
-    NVML_GPM_METRIC_C2C_TOTAL_RX_PER_SEC        = 101,
-    NVML_GPM_METRIC_C2C_DATA_TX_PER_SEC         = 102,
-    NVML_GPM_METRIC_C2C_DATA_RX_PER_SEC         = 103,
-    NVML_GPM_METRIC_C2C_LINK0_TOTAL_TX_PER_SEC  = 104,
-    NVML_GPM_METRIC_C2C_LINK0_TOTAL_RX_PER_SEC  = 105,
-    NVML_GPM_METRIC_C2C_LINK0_DATA_TX_PER_SEC   = 106,
-    NVML_GPM_METRIC_C2C_LINK0_DATA_RX_PER_SEC   = 107,
-    NVML_GPM_METRIC_C2C_LINK1_TOTAL_TX_PER_SEC  = 108,
-    NVML_GPM_METRIC_C2C_LINK1_TOTAL_RX_PER_SEC  = 109,
-    NVML_GPM_METRIC_C2C_LINK1_DATA_TX_PER_SEC   = 110,
-    NVML_GPM_METRIC_C2C_LINK1_DATA_RX_PER_SEC   = 111,
-    NVML_GPM_METRIC_C2C_LINK2_TOTAL_TX_PER_SEC  = 112,
-    NVML_GPM_METRIC_C2C_LINK2_TOTAL_RX_PER_SEC  = 113,
-    NVML_GPM_METRIC_C2C_LINK2_DATA_TX_PER_SEC   = 114,
-    NVML_GPM_METRIC_C2C_LINK2_DATA_RX_PER_SEC   = 115,
-    NVML_GPM_METRIC_C2C_LINK3_TOTAL_TX_PER_SEC  = 116,
-    NVML_GPM_METRIC_C2C_LINK3_TOTAL_RX_PER_SEC  = 117,
-    NVML_GPM_METRIC_C2C_LINK3_DATA_TX_PER_SEC   = 118,
-    NVML_GPM_METRIC_C2C_LINK3_DATA_RX_PER_SEC   = 119,
-    NVML_GPM_METRIC_C2C_LINK4_TOTAL_TX_PER_SEC  = 120,
-    NVML_GPM_METRIC_C2C_LINK4_TOTAL_RX_PER_SEC  = 121,
-    NVML_GPM_METRIC_C2C_LINK4_DATA_TX_PER_SEC   = 122,
-    NVML_GPM_METRIC_C2C_LINK4_DATA_RX_PER_SEC   = 123,
-    NVML_GPM_METRIC_C2C_LINK5_TOTAL_TX_PER_SEC  = 124,
-    NVML_GPM_METRIC_C2C_LINK5_TOTAL_RX_PER_SEC  = 125,
-    NVML_GPM_METRIC_C2C_LINK5_DATA_TX_PER_SEC   = 126,
-    NVML_GPM_METRIC_C2C_LINK5_DATA_RX_PER_SEC   = 127,
-    NVML_GPM_METRIC_C2C_LINK6_TOTAL_TX_PER_SEC  = 128,
-    NVML_GPM_METRIC_C2C_LINK6_TOTAL_RX_PER_SEC  = 129,
-    NVML_GPM_METRIC_C2C_LINK6_DATA_TX_PER_SEC   = 130,
-    NVML_GPM_METRIC_C2C_LINK6_DATA_RX_PER_SEC   = 131,
-    NVML_GPM_METRIC_C2C_LINK7_TOTAL_TX_PER_SEC  = 132,
-    NVML_GPM_METRIC_C2C_LINK7_TOTAL_RX_PER_SEC  = 133,
-    NVML_GPM_METRIC_C2C_LINK7_DATA_TX_PER_SEC   = 134,
-    NVML_GPM_METRIC_C2C_LINK7_DATA_RX_PER_SEC   = 135,
-    NVML_GPM_METRIC_C2C_LINK8_TOTAL_TX_PER_SEC  = 136,
-    NVML_GPM_METRIC_C2C_LINK8_TOTAL_RX_PER_SEC  = 137,
-    NVML_GPM_METRIC_C2C_LINK8_DATA_TX_PER_SEC   = 138,
-    NVML_GPM_METRIC_C2C_LINK8_DATA_RX_PER_SEC   = 139,
-    NVML_GPM_METRIC_C2C_LINK9_TOTAL_TX_PER_SEC  = 140,
-    NVML_GPM_METRIC_C2C_LINK9_TOTAL_RX_PER_SEC  = 141,
-    NVML_GPM_METRIC_C2C_LINK9_DATA_TX_PER_SEC   = 142,
-    NVML_GPM_METRIC_C2C_LINK9_DATA_RX_PER_SEC   = 143,
-    NVML_GPM_METRIC_C2C_LINK10_TOTAL_TX_PER_SEC = 144,
-    NVML_GPM_METRIC_C2C_LINK10_TOTAL_RX_PER_SEC = 145,
-    NVML_GPM_METRIC_C2C_LINK10_DATA_TX_PER_SEC  = 146,
-    NVML_GPM_METRIC_C2C_LINK10_DATA_RX_PER_SEC  = 147,
-    NVML_GPM_METRIC_C2C_LINK11_TOTAL_TX_PER_SEC = 148,
-    NVML_GPM_METRIC_C2C_LINK11_TOTAL_RX_PER_SEC = 149,
-    NVML_GPM_METRIC_C2C_LINK11_DATA_TX_PER_SEC  = 150,
-    NVML_GPM_METRIC_C2C_LINK11_DATA_RX_PER_SEC  = 151,
-    NVML_GPM_METRIC_C2C_LINK12_TOTAL_TX_PER_SEC = 152,
-    NVML_GPM_METRIC_C2C_LINK12_TOTAL_RX_PER_SEC = 153,
-    NVML_GPM_METRIC_C2C_LINK12_DATA_TX_PER_SEC  = 154,
-    NVML_GPM_METRIC_C2C_LINK12_DATA_RX_PER_SEC  = 155,
-    NVML_GPM_METRIC_C2C_LINK13_TOTAL_TX_PER_SEC = 156,
-    NVML_GPM_METRIC_C2C_LINK13_TOTAL_RX_PER_SEC = 157,
-    NVML_GPM_METRIC_C2C_LINK13_DATA_TX_PER_SEC  = 158,
-    NVML_GPM_METRIC_C2C_LINK13_DATA_RX_PER_SEC  = 159,
-    NVML_GPM_METRIC_HOSTMEM_CACHE_HIT           = 160,
-    NVML_GPM_METRIC_HOSTMEM_CACHE_MISS          = 161,
-    NVML_GPM_METRIC_PEERMEM_CACHE_HIT           = 162,
-    NVML_GPM_METRIC_PEERMEM_CACHE_MISS          = 163,
-    NVML_GPM_METRIC_DRAM_CACHE_HIT              = 164,
-    NVML_GPM_METRIC_DRAM_CACHE_MISS             = 165,
-    NVML_GPM_METRIC_NVENC_0_UTIL                = 166,
-    NVML_GPM_METRIC_NVENC_1_UTIL                = 167,
-    NVML_GPM_METRIC_NVENC_2_UTIL                = 168,
-    NVML_GPM_METRIC_NVENC_3_UTIL                = 169,
-    NVML_GPM_METRIC_GR0_CTXSW_CYCLES_ELAPSED    = 170,
-    NVML_GPM_METRIC_GR0_CTXSW_CYCLES_ACTIVE     = 171,
-    NVML_GPM_METRIC_GR0_CTXSW_REQUESTS          = 172,
-    NVML_GPM_METRIC_GR0_CTXSW_CYCLES_PER_REQ    = 173,
-    NVML_GPM_METRIC_GR0_CTXSW_ACTIVE_PCT        = 174,
-    NVML_GPM_METRIC_GR1_CTXSW_CYCLES_ELAPSED    = 175,
-    NVML_GPM_METRIC_GR1_CTXSW_CYCLES_ACTIVE     = 176,
-    NVML_GPM_METRIC_GR1_CTXSW_REQUESTS          = 177,
-    NVML_GPM_METRIC_GR1_CTXSW_CYCLES_PER_REQ    = 178,
-    NVML_GPM_METRIC_GR1_CTXSW_ACTIVE_PCT        = 179,
-    NVML_GPM_METRIC_GR2_CTXSW_CYCLES_ELAPSED    = 180,
-    NVML_GPM_METRIC_GR2_CTXSW_CYCLES_ACTIVE     = 181,
-    NVML_GPM_METRIC_GR2_CTXSW_REQUESTS          = 182,
-    NVML_GPM_METRIC_GR2_CTXSW_CYCLES_PER_REQ    = 183,
-    NVML_GPM_METRIC_GR2_CTXSW_ACTIVE_PCT        = 184,
-    NVML_GPM_METRIC_GR3_CTXSW_CYCLES_ELAPSED    = 185,
-    NVML_GPM_METRIC_GR3_CTXSW_CYCLES_ACTIVE     = 186,
-    NVML_GPM_METRIC_GR3_CTXSW_REQUESTS          = 187,
-    NVML_GPM_METRIC_GR3_CTXSW_CYCLES_PER_REQ    = 188,
-    NVML_GPM_METRIC_GR3_CTXSW_ACTIVE_PCT        = 189,
-    NVML_GPM_METRIC_GR4_CTXSW_CYCLES_ELAPSED    = 190,
-    NVML_GPM_METRIC_GR4_CTXSW_CYCLES_ACTIVE     = 191,
-    NVML_GPM_METRIC_GR4_CTXSW_REQUESTS          = 192,
-    NVML_GPM_METRIC_GR4_CTXSW_CYCLES_PER_REQ    = 193,
-    NVML_GPM_METRIC_GR4_CTXSW_ACTIVE_PCT        = 194,
-    NVML_GPM_METRIC_GR5_CTXSW_CYCLES_ELAPSED    = 195,
-    NVML_GPM_METRIC_GR5_CTXSW_CYCLES_ACTIVE     = 196,
-    NVML_GPM_METRIC_GR5_CTXSW_REQUESTS          = 197,
-    NVML_GPM_METRIC_GR5_CTXSW_CYCLES_PER_REQ    = 198,
-    NVML_GPM_METRIC_GR5_CTXSW_ACTIVE_PCT        = 199,
-    NVML_GPM_METRIC_GR6_CTXSW_CYCLES_ELAPSED    = 200,
-    NVML_GPM_METRIC_GR6_CTXSW_CYCLES_ACTIVE     = 201,
-    NVML_GPM_METRIC_GR6_CTXSW_REQUESTS          = 202,
-    NVML_GPM_METRIC_GR6_CTXSW_CYCLES_PER_REQ    = 203,
-    NVML_GPM_METRIC_GR6_CTXSW_ACTIVE_PCT        = 204,
-    NVML_GPM_METRIC_GR7_CTXSW_CYCLES_ELAPSED    = 205,
-    NVML_GPM_METRIC_GR7_CTXSW_CYCLES_ACTIVE     = 206,
-    NVML_GPM_METRIC_GR7_CTXSW_REQUESTS          = 207,
-    NVML_GPM_METRIC_GR7_CTXSW_CYCLES_PER_REQ    = 208,
-    NVML_GPM_METRIC_GR7_CTXSW_ACTIVE_PCT        = 209,
-    NVML_GPM_METRIC_NVLINK_L18_RX_PER_SEC       = 212,
-    NVML_GPM_METRIC_NVLINK_L18_TX_PER_SEC       = 213,
-    NVML_GPM_METRIC_NVLINK_L19_RX_PER_SEC       = 214,
-    NVML_GPM_METRIC_NVLINK_L19_TX_PER_SEC       = 215,
-    NVML_GPM_METRIC_NVLINK_L20_RX_PER_SEC       = 216,
-    NVML_GPM_METRIC_NVLINK_L20_TX_PER_SEC       = 217,
-    NVML_GPM_METRIC_NVLINK_L21_RX_PER_SEC       = 218,
-    NVML_GPM_METRIC_NVLINK_L21_TX_PER_SEC       = 219,
-    NVML_GPM_METRIC_NVLINK_L22_RX_PER_SEC       = 220,
-    NVML_GPM_METRIC_NVLINK_L22_TX_PER_SEC       = 221,
-    NVML_GPM_METRIC_NVLINK_L23_RX_PER_SEC       = 222,
-    NVML_GPM_METRIC_NVLINK_L23_TX_PER_SEC       = 223,
-    NVML_GPM_METRIC_NVLINK_L24_RX_PER_SEC       = 224,
-    NVML_GPM_METRIC_NVLINK_L24_TX_PER_SEC       = 225,
-    NVML_GPM_METRIC_NVLINK_L25_RX_PER_SEC       = 226,
-    NVML_GPM_METRIC_NVLINK_L25_TX_PER_SEC       = 227,
-    NVML_GPM_METRIC_NVLINK_L26_RX_PER_SEC       = 228,
-    NVML_GPM_METRIC_NVLINK_L26_TX_PER_SEC       = 229,
-    NVML_GPM_METRIC_NVLINK_L27_RX_PER_SEC       = 230,
-    NVML_GPM_METRIC_NVLINK_L27_TX_PER_SEC       = 231,
-    NVML_GPM_METRIC_NVLINK_L28_RX_PER_SEC       = 232,
-    NVML_GPM_METRIC_NVLINK_L28_TX_PER_SEC       = 233,
-    NVML_GPM_METRIC_NVLINK_L29_RX_PER_SEC       = 234,
-    NVML_GPM_METRIC_NVLINK_L29_TX_PER_SEC       = 235,
-    NVML_GPM_METRIC_NVLINK_L30_RX_PER_SEC       = 236,
-    NVML_GPM_METRIC_NVLINK_L30_TX_PER_SEC       = 237,
-    NVML_GPM_METRIC_NVLINK_L31_RX_PER_SEC       = 238,
-    NVML_GPM_METRIC_NVLINK_L31_TX_PER_SEC       = 239,
-    NVML_GPM_METRIC_NVLINK_L32_RX_PER_SEC       = 240,
-    NVML_GPM_METRIC_NVLINK_L32_TX_PER_SEC       = 241,
-    NVML_GPM_METRIC_NVLINK_L33_RX_PER_SEC       = 242,
-    NVML_GPM_METRIC_NVLINK_L33_TX_PER_SEC       = 243,
-    NVML_GPM_METRIC_NVLINK_L34_RX_PER_SEC       = 244,
-    NVML_GPM_METRIC_NVLINK_L34_TX_PER_SEC       = 245,
-    NVML_GPM_METRIC_NVLINK_L35_RX_PER_SEC       = 246,
-    NVML_GPM_METRIC_NVLINK_L35_TX_PER_SEC       = 247,
+    NVML_GPM_METRIC_C2C_TOTAL_TX_PER_SEC        = 100,  //!< C2C total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_TOTAL_RX_PER_SEC        = 101,  //!< C2C total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_DATA_TX_PER_SEC         = 102,  //!< C2C data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_DATA_RX_PER_SEC         = 103,  //!< C2C data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK0_TOTAL_TX_PER_SEC  = 104,  //!< C2C link 0 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK0_TOTAL_RX_PER_SEC  = 105,  //!< C2C link 0 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK0_DATA_TX_PER_SEC   = 106,  //!< C2C link 0 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK0_DATA_RX_PER_SEC   = 107,  //!< C2C link 0 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK1_TOTAL_TX_PER_SEC  = 108,  //!< C2C link 1 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK1_TOTAL_RX_PER_SEC  = 109,  //!< C2C link 1 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK1_DATA_TX_PER_SEC   = 110,  //!< C2C link 1 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK1_DATA_RX_PER_SEC   = 111,  //!< C2C link 1 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK2_TOTAL_TX_PER_SEC  = 112,  //!< C2C link 2 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK2_TOTAL_RX_PER_SEC  = 113,  //!< C2C link 2 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK2_DATA_TX_PER_SEC   = 114,  //!< C2C link 2 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK2_DATA_RX_PER_SEC   = 115,  //!< C2C link 2 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK3_TOTAL_TX_PER_SEC  = 116,  //!< C2C link 3 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK3_TOTAL_RX_PER_SEC  = 117,  //!< C2C link 3 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK3_DATA_TX_PER_SEC   = 118,  //!< C2C link 3 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK3_DATA_RX_PER_SEC   = 119,  //!< C2C link 3 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK4_TOTAL_TX_PER_SEC  = 120,  //!< C2C link 4 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK4_TOTAL_RX_PER_SEC  = 121,  //!< C2C link 4 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK4_DATA_TX_PER_SEC   = 122,  //!< C2C link 4 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK4_DATA_RX_PER_SEC   = 123,  //!< C2C link 4 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK5_TOTAL_TX_PER_SEC  = 124,  //!< C2C link 5 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK5_TOTAL_RX_PER_SEC  = 125,  //!< C2C link 5 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK5_DATA_TX_PER_SEC   = 126,  //!< C2C link 5 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK5_DATA_RX_PER_SEC   = 127,  //!< C2C link 5 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK6_TOTAL_TX_PER_SEC  = 128,  //!< C2C link 6 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK6_TOTAL_RX_PER_SEC  = 129,  //!< C2C link 6 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK6_DATA_TX_PER_SEC   = 130,  //!< C2C link 6 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK6_DATA_RX_PER_SEC   = 131,  //!< C2C link 6 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK7_TOTAL_TX_PER_SEC  = 132,  //!< C2C link 7 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK7_TOTAL_RX_PER_SEC  = 133,  //!< C2C link 7 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK7_DATA_TX_PER_SEC   = 134,  //!< C2C link 7 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK7_DATA_RX_PER_SEC   = 135,  //!< C2C link 7 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK8_TOTAL_TX_PER_SEC  = 136,  //!< C2C link 8 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK8_TOTAL_RX_PER_SEC  = 137,  //!< C2C link 8 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK8_DATA_TX_PER_SEC   = 138,  //!< C2C link 8 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK8_DATA_RX_PER_SEC   = 139,  //!< C2C link 8 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK9_TOTAL_TX_PER_SEC  = 140,  //!< C2C link 9 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK9_TOTAL_RX_PER_SEC  = 141,  //!< C2C link 9 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK9_DATA_TX_PER_SEC   = 142,  //!< C2C link 9 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK9_DATA_RX_PER_SEC   = 143,  //!< C2C link 9 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK10_TOTAL_TX_PER_SEC = 144,  //!< C2C link 10 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK10_TOTAL_RX_PER_SEC = 145,  //!< C2C link 10 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK10_DATA_TX_PER_SEC  = 146,  //!< C2C link 10 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK10_DATA_RX_PER_SEC  = 147,  //!< C2C link 10 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK11_TOTAL_TX_PER_SEC = 148,  //!< C2C link 11 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK11_TOTAL_RX_PER_SEC = 149,  //!< C2C link 11 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK11_DATA_TX_PER_SEC  = 150,  //!< C2C link 11 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK11_DATA_RX_PER_SEC  = 151,  //!< C2C link 11 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK12_TOTAL_TX_PER_SEC = 152,  //!< C2C link 12 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK12_TOTAL_RX_PER_SEC = 153,  //!< C2C link 12 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK12_DATA_TX_PER_SEC  = 154,  //!< C2C link 12 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK12_DATA_RX_PER_SEC  = 155,  //!< C2C link 12 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK13_TOTAL_TX_PER_SEC = 156,  //!< C2C link 13 total transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK13_TOTAL_RX_PER_SEC = 157,  //!< C2C link 13 total receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK13_DATA_TX_PER_SEC  = 158,  //!< C2C link 13 data transmit bandwidth in MiB/sec
+    NVML_GPM_METRIC_C2C_LINK13_DATA_RX_PER_SEC  = 159,  //!< C2C link 13 data receive bandwidth in MiB/sec
+    NVML_GPM_METRIC_HOSTMEM_CACHE_HIT           = 160,  //!< Percentage of host memory cache hits. 0.0 - 100.0
+    NVML_GPM_METRIC_HOSTMEM_CACHE_MISS          = 161,  //!< Percentage of host memory cache misses. 0.0 - 100.0
+    NVML_GPM_METRIC_PEERMEM_CACHE_HIT           = 162,  //!< Percentage of peer memory cache hits. 0.0 - 100.0
+    NVML_GPM_METRIC_PEERMEM_CACHE_MISS          = 163,  //!< Percentage of peer memory cache misses. 0.0 - 100.0
+    NVML_GPM_METRIC_DRAM_CACHE_HIT              = 164,  //!< Percentage of DRAM cache hits. 0.0 - 100.0
+    NVML_GPM_METRIC_DRAM_CACHE_MISS             = 165,  //!< Percentage of DRAM cache misses. 0.0 - 100.0
+    NVML_GPM_METRIC_NVENC_0_UTIL                = 166,  //!< Percent utilization of NVENC 0. 0.0 - 100.0
+    NVML_GPM_METRIC_NVENC_1_UTIL                = 167,  //!< Percent utilization of NVENC 1. 0.0 - 100.0
+    NVML_GPM_METRIC_NVENC_2_UTIL                = 168,  //!< Percent utilization of NVENC 2. 0.0 - 100.0
+    NVML_GPM_METRIC_NVENC_3_UTIL                = 169,  //!< Percent utilization of NVENC 3. 0.0 - 100.0
+    NVML_GPM_METRIC_GR0_CTXSW_CYCLES_ELAPSED    = 170,  //!< Total context switch cycles elapsed for GR engine 0
+    NVML_GPM_METRIC_GR0_CTXSW_CYCLES_ACTIVE     = 171,  //!< Active context switch cycles for GR engine 0
+    NVML_GPM_METRIC_GR0_CTXSW_REQUESTS          = 172,  //!< Number of context switch requests for GR engine 0
+    NVML_GPM_METRIC_GR0_CTXSW_CYCLES_PER_REQ    = 173,  //!< Average context switch cycles per request for GR engine 0
+    NVML_GPM_METRIC_GR0_CTXSW_ACTIVE_PCT        = 174,  //!< Percentage of time GR engine 0 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_GR1_CTXSW_CYCLES_ELAPSED    = 175,  //!< Total context switch cycles elapsed for GR engine 1
+    NVML_GPM_METRIC_GR1_CTXSW_CYCLES_ACTIVE     = 176,  //!< Active context switch cycles for GR engine 1
+    NVML_GPM_METRIC_GR1_CTXSW_REQUESTS          = 177,  //!< Number of context switch requests for GR engine 1
+    NVML_GPM_METRIC_GR1_CTXSW_CYCLES_PER_REQ    = 178,  //!< Average context switch cycles per request for GR engine 1
+    NVML_GPM_METRIC_GR1_CTXSW_ACTIVE_PCT        = 179,  //!< Percentage of time GR engine 1 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_GR2_CTXSW_CYCLES_ELAPSED    = 180,  //!< Total context switch cycles elapsed for GR engine 2
+    NVML_GPM_METRIC_GR2_CTXSW_CYCLES_ACTIVE     = 181,  //!< Active context switch cycles for GR engine 2
+    NVML_GPM_METRIC_GR2_CTXSW_REQUESTS          = 182,  //!< Number of context switch requests for GR engine 2
+    NVML_GPM_METRIC_GR2_CTXSW_CYCLES_PER_REQ    = 183,  //!< Average context switch cycles per request for GR engine 2
+    NVML_GPM_METRIC_GR2_CTXSW_ACTIVE_PCT        = 184,  //!< Percentage of time GR engine 2 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_GR3_CTXSW_CYCLES_ELAPSED    = 185,  //!< Total context switch cycles elapsed for GR engine 3
+    NVML_GPM_METRIC_GR3_CTXSW_CYCLES_ACTIVE     = 186,  //!< Active context switch cycles for GR engine 3
+    NVML_GPM_METRIC_GR3_CTXSW_REQUESTS          = 187,  //!< Number of context switch requests for GR engine 3
+    NVML_GPM_METRIC_GR3_CTXSW_CYCLES_PER_REQ    = 188,  //!< Average context switch cycles per request for GR engine 3
+    NVML_GPM_METRIC_GR3_CTXSW_ACTIVE_PCT        = 189,  //!< Percentage of time GR engine 3 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_GR4_CTXSW_CYCLES_ELAPSED    = 190,  //!< Total context switch cycles elapsed for GR engine 4
+    NVML_GPM_METRIC_GR4_CTXSW_CYCLES_ACTIVE     = 191,  //!< Active context switch cycles for GR engine 4
+    NVML_GPM_METRIC_GR4_CTXSW_REQUESTS          = 192,  //!< Number of context switch requests for GR engine 4
+    NVML_GPM_METRIC_GR4_CTXSW_CYCLES_PER_REQ    = 193,  //!< Average context switch cycles per request for GR engine 4
+    NVML_GPM_METRIC_GR4_CTXSW_ACTIVE_PCT        = 194,  //!< Percentage of time GR engine 4 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_GR5_CTXSW_CYCLES_ELAPSED    = 195,  //!< Total context switch cycles elapsed for GR engine 5
+    NVML_GPM_METRIC_GR5_CTXSW_CYCLES_ACTIVE     = 196,  //!< Active context switch cycles for GR engine 5
+    NVML_GPM_METRIC_GR5_CTXSW_REQUESTS          = 197,  //!< Number of context switch requests for GR engine 5
+    NVML_GPM_METRIC_GR5_CTXSW_CYCLES_PER_REQ    = 198,  //!< Average context switch cycles per request for GR engine 5
+    NVML_GPM_METRIC_GR5_CTXSW_ACTIVE_PCT        = 199,  //!< Percentage of time GR engine 5 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_GR6_CTXSW_CYCLES_ELAPSED    = 200,  //!< Total context switch cycles elapsed for GR engine 6
+    NVML_GPM_METRIC_GR6_CTXSW_CYCLES_ACTIVE     = 201,  //!< Active context switch cycles for GR engine 6
+    NVML_GPM_METRIC_GR6_CTXSW_REQUESTS          = 202,  //!< Number of context switch requests for GR engine 6
+    NVML_GPM_METRIC_GR6_CTXSW_CYCLES_PER_REQ    = 203,  //!< Average context switch cycles per request for GR engine 6
+    NVML_GPM_METRIC_GR6_CTXSW_ACTIVE_PCT        = 204,  //!< Percentage of time GR engine 6 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_GR7_CTXSW_CYCLES_ELAPSED    = 205,  //!< Total context switch cycles elapsed for GR engine 7
+    NVML_GPM_METRIC_GR7_CTXSW_CYCLES_ACTIVE     = 206,  //!< Active context switch cycles for GR engine 7
+    NVML_GPM_METRIC_GR7_CTXSW_REQUESTS          = 207,  //!< Number of context switch requests for GR engine 7
+    NVML_GPM_METRIC_GR7_CTXSW_CYCLES_PER_REQ    = 208,  //!< Average context switch cycles per request for GR engine 7
+    NVML_GPM_METRIC_GR7_CTXSW_ACTIVE_PCT        = 209,  //!< Percentage of time GR engine 7 context switches were active. 0.0 - 100.0
+    NVML_GPM_METRIC_NVLINK_L18_RX_PER_SEC       = 212,  //!< NvLink read bandwidth for link 18 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L18_TX_PER_SEC       = 213,  //!< NvLink write bandwidth for link 18 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L19_RX_PER_SEC       = 214,  //!< NvLink read bandwidth for link 19 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L19_TX_PER_SEC       = 215,  //!< NvLink write bandwidth for link 19 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L20_RX_PER_SEC       = 216,  //!< NvLink read bandwidth for link 20 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L20_TX_PER_SEC       = 217,  //!< NvLink write bandwidth for link 20 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L21_RX_PER_SEC       = 218,  //!< NvLink read bandwidth for link 21 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L21_TX_PER_SEC       = 219,  //!< NvLink write bandwidth for link 21 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L22_RX_PER_SEC       = 220,  //!< NvLink read bandwidth for link 22 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L22_TX_PER_SEC       = 221,  //!< NvLink write bandwidth for link 22 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L23_RX_PER_SEC       = 222,  //!< NvLink read bandwidth for link 23 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L23_TX_PER_SEC       = 223,  //!< NvLink write bandwidth for link 23 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L24_RX_PER_SEC       = 224,  //!< NvLink read bandwidth for link 24 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L24_TX_PER_SEC       = 225,  //!< NvLink write bandwidth for link 24 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L25_RX_PER_SEC       = 226,  //!< NvLink read bandwidth for link 25 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L25_TX_PER_SEC       = 227,  //!< NvLink write bandwidth for link 25 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L26_RX_PER_SEC       = 228,  //!< NvLink read bandwidth for link 26 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L26_TX_PER_SEC       = 229,  //!< NvLink write bandwidth for link 26 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L27_RX_PER_SEC       = 230,  //!< NvLink read bandwidth for link 27 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L27_TX_PER_SEC       = 231,  //!< NvLink write bandwidth for link 27 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L28_RX_PER_SEC       = 232,  //!< NvLink read bandwidth for link 28 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L28_TX_PER_SEC       = 233,  //!< NvLink write bandwidth for link 28 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L29_RX_PER_SEC       = 234,  //!< NvLink read bandwidth for link 29 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L29_TX_PER_SEC       = 235,  //!< NvLink write bandwidth for link 29 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L30_RX_PER_SEC       = 236,  //!< NvLink read bandwidth for link 30 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L30_TX_PER_SEC       = 237,  //!< NvLink write bandwidth for link 30 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L31_RX_PER_SEC       = 238,  //!< NvLink read bandwidth for link 31 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L31_TX_PER_SEC       = 239,  //!< NvLink write bandwidth for link 31 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L32_RX_PER_SEC       = 240,  //!< NvLink read bandwidth for link 32 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L32_TX_PER_SEC       = 241,  //!< NvLink write bandwidth for link 32 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L33_RX_PER_SEC       = 242,  //!< NvLink read bandwidth for link 33 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L33_TX_PER_SEC       = 243,  //!< NvLink write bandwidth for link 33 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L34_RX_PER_SEC       = 244,  //!< NvLink read bandwidth for link 34 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L34_TX_PER_SEC       = 245,  //!< NvLink write bandwidth for link 34 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L35_RX_PER_SEC       = 246,  //!< NvLink read bandwidth for link 35 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L35_TX_PER_SEC       = 247,  //!< NvLink write bandwidth for link 35 in MiB/sec
     NVML_GPM_METRIC_SM_CYCLES_ELAPSED           = 248,  //!< The GPU's SM cycles elapsed since reboot
     NVML_GPM_METRIC_SM_CYCLES_ACTIVE            = 249,  //!< The GPU's SM activity since reboot
     NVML_GPM_METRIC_MMA_CYCLES_ACTIVE           = 250,  //!< The GPU's SM MMA tensor activity since reboot
@@ -13731,8 +14707,8 @@ typedef enum
     NVML_GPM_METRIC_PCIE_RX                     = 256,  //!< The PCIe RX traffic since reboot
     NVML_GPM_METRIC_INTEGER_CYCLES_ACTIVE       = 257,  //!< The GPU's SM integer activity since reboot
     NVML_GPM_METRIC_FP64_CYCLES_ACTIVE          = 258,  //!< The GPU's SM FP64 activity since reboot
-    NVML_GPM_METRIC_FP32_CYCLES_ACTIVE          = 259,  //!< The GPU's SM FP64 activity since reboot
-    NVML_GPM_METRIC_FP16_CYCLES_ACTIVE          = 260,  //!< The GPU's SM FP64 activity since reboot
+    NVML_GPM_METRIC_FP32_CYCLES_ACTIVE          = 259,  //!< The GPU's SM FP32 activity since reboot
+    NVML_GPM_METRIC_FP16_CYCLES_ACTIVE          = 260,  //!< The GPU's SM FP16 activity since reboot
     NVML_GPM_METRIC_NVLINK_L0_RX                = 261,  //!< NvLink read for link 0 in bytes since reboot
     NVML_GPM_METRIC_NVLINK_L0_TX                = 262,  //!< NvLink write for link 0 in bytes since reboot
     NVML_GPM_METRIC_NVLINK_L1_RX                = 263,  //!< NvLink read for link 1 in bytes since reboot
@@ -13805,7 +14781,151 @@ typedef enum
     NVML_GPM_METRIC_NVLINK_L34_TX               = 330,  //!< NvLink write for link 34 in bytes since reboot
     NVML_GPM_METRIC_NVLINK_L35_RX               = 331,  //!< NvLink read for link 35 in bytes since reboot
     NVML_GPM_METRIC_NVLINK_L35_TX               = 332,  //!< NvLink write for link 35 in bytes since reboot
-    NVML_GPM_METRIC_MAX                         = 333,  //!< Maximum value above +1
+    NVML_GPM_METRIC_NVLINK_L36_RX               = 333,  //!< NvLink read for link 36 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L36_TX               = 334,  //!< NvLink write for link 36 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L37_RX               = 335,  //!< NvLink read for link 37 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L37_TX               = 336,  //!< NvLink write for link 37 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L38_RX               = 337,  //!< NvLink read for link 38 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L38_TX               = 338,  //!< NvLink write for link 38 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L39_RX               = 339,  //!< NvLink read for link 39 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L39_TX               = 340,  //!< NvLink write for link 39 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L40_RX               = 341,  //!< NvLink read for link 40 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L40_TX               = 342,  //!< NvLink write for link 40 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L41_RX               = 343,  //!< NvLink read for link 41 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L41_TX               = 344,  //!< NvLink write for link 41 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L42_RX               = 345,  //!< NvLink read for link 42 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L42_TX               = 346,  //!< NvLink write for link 42 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L43_RX               = 347,  //!< NvLink read for link 43 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L43_TX               = 348,  //!< NvLink write for link 43 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L44_RX               = 349,  //!< NvLink read for link 44 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L44_TX               = 350,  //!< NvLink write for link 44 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L45_RX               = 351,  //!< NvLink read for link 45 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L45_TX               = 352,  //!< NvLink write for link 45 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L46_RX               = 353,  //!< NvLink read for link 46 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L46_TX               = 354,  //!< NvLink write for link 46 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L47_RX               = 355,  //!< NvLink read for link 47 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L47_TX               = 356,  //!< NvLink write for link 47 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L48_RX               = 357,  //!< NvLink read for link 48 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L48_TX               = 358,  //!< NvLink write for link 48 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L49_RX               = 359,  //!< NvLink read for link 49 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L49_TX               = 360,  //!< NvLink write for link 49 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L50_RX               = 361,  //!< NvLink read for link 50 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L50_TX               = 362,  //!< NvLink write for link 50 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L51_RX               = 363,  //!< NvLink read for link 51 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L51_TX               = 364,  //!< NvLink write for link 51 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L52_RX               = 365,  //!< NvLink read for link 52 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L52_TX               = 366,  //!< NvLink write for link 52 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L53_RX               = 367,  //!< NvLink read for link 53 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L53_TX               = 368,  //!< NvLink write for link 53 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L54_RX               = 369,  //!< NvLink read for link 54 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L54_TX               = 370,  //!< NvLink write for link 54 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L55_RX               = 371,  //!< NvLink read for link 55 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L55_TX               = 372,  //!< NvLink write for link 55 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L56_RX               = 373,  //!< NvLink read for link 56 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L56_TX               = 374,  //!< NvLink write for link 56 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L57_RX               = 375,  //!< NvLink read for link 57 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L57_TX               = 376,  //!< NvLink write for link 57 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L58_RX               = 377,  //!< NvLink read for link 58 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L58_TX               = 378,  //!< NvLink write for link 58 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L59_RX               = 379,  //!< NvLink read for link 59 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L59_TX               = 380,  //!< NvLink write for link 59 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L60_RX               = 381,  //!< NvLink read for link 60 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L60_TX               = 382,  //!< NvLink write for link 60 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L61_RX               = 383,  //!< NvLink read for link 61 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L61_TX               = 384,  //!< NvLink write for link 61 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L62_RX               = 385,  //!< NvLink read for link 62 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L62_TX               = 386,  //!< NvLink write for link 62 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L63_RX               = 387,  //!< NvLink read for link 63 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L63_TX               = 388,  //!< NvLink write for link 63 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L64_RX               = 389,  //!< NvLink read for link 64 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L64_TX               = 390,  //!< NvLink write for link 64 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L65_RX               = 391,  //!< NvLink read for link 65 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L65_TX               = 392,  //!< NvLink write for link 65 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L66_RX               = 393,  //!< NvLink read for link 66 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L66_TX               = 394,  //!< NvLink write for link 66 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L67_RX               = 395,  //!< NvLink read for link 67 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L67_TX               = 396,  //!< NvLink write for link 67 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L68_RX               = 397,  //!< NvLink read for link 68 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L68_TX               = 398,  //!< NvLink write for link 68 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L69_RX               = 399,  //!< NvLink read for link 69 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L69_TX               = 400,  //!< NvLink write for link 69 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L70_RX               = 401,  //!< NvLink read for link 70 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L70_TX               = 402,  //!< NvLink write for link 70 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L71_RX               = 403,  //!< NvLink read for link 71 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L71_TX               = 404,  //!< NvLink write for link 71 in bytes since reboot
+    NVML_GPM_METRIC_NVLINK_L36_RX_PER_SEC       = 405,  //!< NvLink read bandwidth for link 36 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L36_TX_PER_SEC       = 406,  //!< NvLink write bandwidth for link 36 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L37_RX_PER_SEC       = 407,  //!< NvLink read bandwidth for link 37 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L37_TX_PER_SEC       = 408,  //!< NvLink write bandwidth for link 37 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L38_RX_PER_SEC       = 409,  //!< NvLink read bandwidth for link 38 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L38_TX_PER_SEC       = 410,  //!< NvLink write bandwidth for link 38 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L39_RX_PER_SEC       = 411,  //!< NvLink read bandwidth for link 39 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L39_TX_PER_SEC       = 412,  //!< NvLink write bandwidth for link 39 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L40_RX_PER_SEC       = 413,  //!< NvLink read bandwidth for link 40 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L40_TX_PER_SEC       = 414,  //!< NvLink write bandwidth for link 40 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L41_RX_PER_SEC       = 415,  //!< NvLink read bandwidth for link 41 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L41_TX_PER_SEC       = 416,  //!< NvLink write bandwidth for link 41 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L42_RX_PER_SEC       = 417,  //!< NvLink read bandwidth for link 42 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L42_TX_PER_SEC       = 418,  //!< NvLink write bandwidth for link 42 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L43_RX_PER_SEC       = 419,  //!< NvLink read bandwidth for link 43 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L43_TX_PER_SEC       = 420,  //!< NvLink write bandwidth for link 43 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L44_RX_PER_SEC       = 421,  //!< NvLink read bandwidth for link 44 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L44_TX_PER_SEC       = 422,  //!< NvLink write bandwidth for link 44 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L45_RX_PER_SEC       = 423,  //!< NvLink read bandwidth for link 45 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L45_TX_PER_SEC       = 424,  //!< NvLink write bandwidth for link 45 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L46_RX_PER_SEC       = 425,  //!< NvLink read bandwidth for link 46 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L46_TX_PER_SEC       = 426,  //!< NvLink write bandwidth for link 46 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L47_RX_PER_SEC       = 427,  //!< NvLink read bandwidth for link 47 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L47_TX_PER_SEC       = 428,  //!< NvLink write bandwidth for link 47 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L48_RX_PER_SEC       = 429,  //!< NvLink read bandwidth for link 48 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L48_TX_PER_SEC       = 430,  //!< NvLink write bandwidth for link 48 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L49_RX_PER_SEC       = 431,  //!< NvLink read bandwidth for link 49 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L49_TX_PER_SEC       = 432,  //!< NvLink write bandwidth for link 49 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L50_RX_PER_SEC       = 433,  //!< NvLink read bandwidth for link 50 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L50_TX_PER_SEC       = 434,  //!< NvLink write bandwidth for link 50 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L51_RX_PER_SEC       = 435,  //!< NvLink read bandwidth for link 51 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L51_TX_PER_SEC       = 436,  //!< NvLink write bandwidth for link 51 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L52_RX_PER_SEC       = 437,  //!< NvLink read bandwidth for link 52 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L52_TX_PER_SEC       = 438,  //!< NvLink write bandwidth for link 52 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L53_RX_PER_SEC       = 439,  //!< NvLink read bandwidth for link 53 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L53_TX_PER_SEC       = 440,  //!< NvLink write bandwidth for link 53 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L54_RX_PER_SEC       = 441,  //!< NvLink read bandwidth for link 54 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L54_TX_PER_SEC       = 442,  //!< NvLink write bandwidth for link 54 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L55_RX_PER_SEC       = 443,  //!< NvLink read bandwidth for link 55 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L55_TX_PER_SEC       = 444,  //!< NvLink write bandwidth for link 55 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L56_RX_PER_SEC       = 445,  //!< NvLink read bandwidth for link 56 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L56_TX_PER_SEC       = 446,  //!< NvLink write bandwidth for link 56 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L57_RX_PER_SEC       = 447,  //!< NvLink read bandwidth for link 57 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L57_TX_PER_SEC       = 448,  //!< NvLink write bandwidth for link 57 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L58_RX_PER_SEC       = 449,  //!< NvLink read bandwidth for link 58 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L58_TX_PER_SEC       = 450,  //!< NvLink write bandwidth for link 58 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L59_RX_PER_SEC       = 451,  //!< NvLink read bandwidth for link 59 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L59_TX_PER_SEC       = 452,  //!< NvLink write bandwidth for link 59 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L60_RX_PER_SEC       = 453,  //!< NvLink read bandwidth for link 60 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L60_TX_PER_SEC       = 454,  //!< NvLink write bandwidth for link 60 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L61_RX_PER_SEC       = 455,  //!< NvLink read bandwidth for link 61 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L61_TX_PER_SEC       = 456,  //!< NvLink write bandwidth for link 61 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L62_RX_PER_SEC       = 457,  //!< NvLink read bandwidth for link 62 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L62_TX_PER_SEC       = 458,  //!< NvLink write bandwidth for link 62 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L63_RX_PER_SEC       = 459,  //!< NvLink read bandwidth for link 63 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L63_TX_PER_SEC       = 460,  //!< NvLink write bandwidth for link 63 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L64_RX_PER_SEC       = 461,  //!< NvLink read bandwidth for link 64 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L64_TX_PER_SEC       = 462,  //!< NvLink write bandwidth for link 64 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L65_RX_PER_SEC       = 463,  //!< NvLink read bandwidth for link 65 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L65_TX_PER_SEC       = 464,  //!< NvLink write bandwidth for link 65 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L66_RX_PER_SEC       = 465,  //!< NvLink read bandwidth for link 66 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L66_TX_PER_SEC       = 466,  //!< NvLink write bandwidth for link 66 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L67_RX_PER_SEC       = 467,  //!< NvLink read bandwidth for link 67 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L67_TX_PER_SEC       = 468,  //!< NvLink write bandwidth for link 67 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L68_RX_PER_SEC       = 469,  //!< NvLink read bandwidth for link 68 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L68_TX_PER_SEC       = 470,  //!< NvLink write bandwidth for link 68 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L69_RX_PER_SEC       = 471,  //!< NvLink read bandwidth for link 69 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L69_TX_PER_SEC       = 472,  //!< NvLink write bandwidth for link 69 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L70_RX_PER_SEC       = 473,  //!< NvLink read bandwidth for link 70 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L70_TX_PER_SEC       = 474,  //!< NvLink write bandwidth for link 70 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L71_RX_PER_SEC       = 475,  //!< NvLink read bandwidth for link 71 in MiB/sec
+    NVML_GPM_METRIC_NVLINK_L71_TX_PER_SEC       = 476,  //!< NvLink write bandwidth for link 71 in MiB/sec
+    NVML_GPM_METRIC_MAX                         = 477,  //!< Maximum value above +1
 } nvmlGpmMetricId_t;
 
 /** @} */ // @defgroup nvmlGpmEnums
@@ -13825,15 +14945,15 @@ typedef struct
     struct nvmlGpmSample_st* handle;
 } nvmlGpmSample_t;
 
+/**
+ * GPM metric information.
+ */
 typedef struct {
     char *shortName;
     char *longName;
     char *unit;
 } nvmlGpmMetricMetricInfo_t;
 
-/**
- * GPM metric information.
- */
 typedef struct
 {
     unsigned int metricId;   //!<  IN: NVML_GPM_METRIC_? define of which metric to retrieve
@@ -14090,23 +15210,33 @@ typedef struct
 #define NVML_WORKLOAD_POWER_MAX_PROFILES        (255)
 typedef enum
 {
-    NVML_POWER_PROFILE_MAX_P            = 0,
-    NVML_POWER_PROFILE_MAX_Q            = 1,
-    NVML_POWER_PROFILE_COMPUTE          = 2,
-    NVML_POWER_PROFILE_MEMORY_BOUND     = 3,
-    NVML_POWER_PROFILE_NETWORK          = 4,
-    NVML_POWER_PROFILE_BALANCED         = 5,
-    NVML_POWER_PROFILE_LLM_INFERENCE    = 6,
-    NVML_POWER_PROFILE_LLM_TRAINING     = 7,
-    NVML_POWER_PROFILE_RBM              = 8,
-    NVML_POWER_PROFILE_DCPCIE           = 9,
-    NVML_POWER_PROFILE_HMMA_SPARSE      = 10,
-    NVML_POWER_PROFILE_HMMA_DENSE       = 11,
-    NVML_POWER_PROFILE_SYNC_BALANCED    = 12,
-    NVML_POWER_PROFILE_HPC              = 13,
-    NVML_POWER_PROFILE_MIG              = 14,
+    NVML_POWER_PROFILE_MAX_P                       = 0,
+    NVML_POWER_PROFILE_MAX_Q                       = 1,
+    NVML_POWER_PROFILE_COMPUTE                     = 2,
+    NVML_POWER_PROFILE_MEMORY_BOUND                = 3,
+    NVML_POWER_PROFILE_NETWORK                     = 4,
+    NVML_POWER_PROFILE_BALANCED                    = 5,
+    NVML_POWER_PROFILE_LLM_INFERENCE               = 6,
+    NVML_POWER_PROFILE_LLM_TRAINING                = 7,
+    NVML_POWER_PROFILE_RBM                         = 8,
+    NVML_POWER_PROFILE_DCPCIE                      = 9,
+    NVML_POWER_PROFILE_HMMA_SPARSE                 = 10,
+    NVML_POWER_PROFILE_HMMA_DENSE                  = 11,
+    NVML_POWER_PROFILE_SYNC_BALANCED               = 12,
+    NVML_POWER_PROFILE_HPC                         = 13,
+    NVML_POWER_PROFILE_MIG                         = 14,
+    NVML_POWER_PROFILE_MAX_Q_1                     = 15,
+    NVML_POWER_PROFILE_NETWORK_BOUND               = 16,
+    NVML_POWER_PROFILE_HIGH_THROUGHPUT_INFERENCE   = 17,
+    NVML_POWER_PROFILE_MEDIUM_THROUGHPUT_INFERENCE = 18,
+    NVML_POWER_PROFILE_LOW_LATENCY_INFERENCE       = 19,
+    NVML_POWER_PROFILE_TRAINING                    = 20,
+    NVML_POWER_PROFILE_INFERENCE                   = 21,
+    NVML_POWER_PROFILE_MAX_Q_2                     = 22,
+    NVML_POWER_PROFILE_MAX_Q_3                     = 23,
+    NVML_POWER_PROFILE_LOW_PRIORITY_BACKGROUND     = 24,
 
-    NVML_POWER_PROFILE_MAX              = 15,
+    NVML_POWER_PROFILE_MAX                         = 25,
 } nvmlPowerProfileType_t;
 
 /**
@@ -14237,7 +15367,7 @@ nvmlReturn_t DECLDIR nvmlDeviceWorkloadPowerProfileGetCurrentProfiles(nvmlDevice
  *
  * For Blackwell &tm; or newer fully supported devices.
  * See \ref nvmlWorkloadPowerProfileRequestedProfiles_v1_t for more information on the struct.
- * Reuqest one or more performance profiles be activated using the input bitmask
+ * Request one or more performance profiles be activated using the input bitmask
  * \a requestedProfilesMask, where each bit set corresponds to a supported bit from
  * the \a perfProfilesMask. These profiles will be added to existing list of
  * currently requested profiles.
@@ -14293,7 +15423,7 @@ DEPRECATED(13.1) nvmlReturn_t DECLDIR nvmlDeviceWorkloadPowerProfileClearRequest
  * \a updateProfilesMask, where each bit set corresponds to a supported bit from
  * the \a perfProfilesMask.
  * The \a operation parameter specifies the operation to perform, see \ref nvmlPowerProfileOperation_t for more information.
- * Requires root/admin permissions.
+ * Requires root/admin permissions or access to the NVIDIA WPPS capability.
  *
  * @param device                The identifier of the target device
  * @param updateProfiles        Reference to struct \a nvmlWorkloadPowerProfileUpdateProfiles_v1_t
@@ -14510,6 +15640,45 @@ nvmlReturn_t DECLDIR nvmlDeviceGetRemappedRows_v2(nvmlDevice_t device, nvmlRemap
  *
  **/
 nvmlReturn_t DECLDIR nvmlDeviceSetRusdSettings_v1(nvmlDevice_t device, nvmlRusdSettings_v1_t *settings);
+
+/**
+ * Structure to store bank remapper histogram
+ */
+typedef struct
+{
+    unsigned int maxSpareGroupCount;    //!< Number of groups that have maximum spare.
+    unsigned int noSpareGroupCount;     //!< Number of groups that have not spare.
+} nvmlEccBankRemapperHistogram_v1_t;
+
+/**
+ * Structure to store bank remapper status
+ */
+typedef struct
+{
+    unsigned int activeRemappings;                      //!< Number of active remappings
+    unsigned int inactiveRemappings;                    //!< Number of inactive remappings
+    unsigned int bPending;                              //!< Whether there exists any pending bank remapping. 0 for no pending remapping, 1 for pending remapping.
+    nvmlEccBankRemapperHistogram_v1_t histogram;        //!< Bank remapper histogram
+} nvmlEccBankRemapperStatus_v1_t;
+
+/**
+ * Get bank remapper status.
+ *
+ * %RUBIN_OR_NEWER%
+ *
+ * @param device                 The identifier of the target device
+ * @param pBankRemapperStatus    Reference to \a nvmlEccBankRemapperStatus_t
+ *
+ * @return
+ * - \ref NVML_SUCCESS if \a pBankRemapperStatus was populated
+ * - \ref NVML_ERROR_UNINITIALIZED if the library has not been successfully initialized
+ * - \ref NVML_ERROR_INVALID_ARGUMENT if \a device is invalid or \a pBankRemapperStatus is NULL
+ * - \ref NVML_ERROR_NOT_SUPPORTED if the device doesn't support this feature
+ * - \ref NVML_ERROR_GPU_IS_LOST if the target GPU has fallen off the bus or is otherwise inaccessible
+ * - \ref NVML_ERROR_UNKNOWN on any unexpected error
+ */
+nvmlReturn_t DECLDIR nvmlDeviceGetBankRemapperStatus_v1(nvmlDevice_t device,
+                                                        nvmlEccBankRemapperStatus_v1_t *pBankRemapperStatus);
 
 /**
  * NVML API versioning support

--- a/pkg/nvml/types_gen.go
+++ b/pkg/nvml/types_gen.go
@@ -73,6 +73,19 @@ type Memory_v2 struct {
 	Used     uint64
 }
 
+type SetMemoryLimits_v1 struct {
+	NameSpace *int8
+	SoftLimit uint64
+	HardLimit uint64
+}
+
+type GetMemoryLimits_v1 struct {
+	NameSpace   *int8
+	SoftLimit   uint64
+	HardLimit   uint64
+	CurrentUsed uint64
+}
+
 type BAR1Memory struct {
 	Bar1Total uint64
 	Bar1Free  uint64
@@ -252,6 +265,91 @@ type Pdi_v1 struct {
 type Pdi struct {
 	Version uint32
 	Value   uint64
+}
+
+type PmgrPwrTuple struct {
+	PwrmW uint32
+}
+
+type RailMetrics struct {
+	FreqkHz uint32
+	UtilPct uint64
+}
+
+type CoreRailMetrics struct {
+	Rails [2]RailMetrics
+}
+
+type PwrModelMetricsDlppm1xPerf struct {
+	Perfms uint32
+}
+
+type PwrModelMetricsDlppm1x struct {
+	BValid      uint8
+	CoreRail    CoreRailMetrics
+	FbRail      RailMetrics
+	TgpPwrTuple PmgrPwrTuple
+	PerfMetrics PwrModelMetricsDlppm1xPerf
+}
+
+type PwrModelMetricsDlppm1xDramclkEstimates struct {
+	EstimatedMetrics    [8]PwrModelMetricsDlppm1x
+	NumEstimatedMetrics uint8
+	Pad_cgo_0           [7]byte
+}
+
+type ObservedMetrics struct {
+	InitialDramclkEst [3]PwrModelMetricsDlppm1xDramclkEstimates
+	BValid            uint8
+	CoreRail          CoreRailMetrics
+	FbRail            RailMetrics
+	TgpPwrTuple       PmgrPwrTuple
+	PerfMetrics       PwrModelMetricsDlppm1xPerf
+}
+
+type PerfMetricsDlppc2xSample struct {
+	ObservedMetrics ObservedMetrics
+}
+
+type PwrModelMetricsSamplePfpp1x struct {
+	FreqkHz     [16]uint32
+	EstTgpPwrmW uint32
+}
+
+type PwrModelOperatingPointPfpp1x struct {
+	FreqkHz uint32
+	PwrmW   uint32
+}
+
+type PwrModelMetricsPfpp1x struct {
+	NumVfPoints         uint8
+	EstimatedMetrics    [32]PwrModelMetricsSamplePfpp1x
+	BValid              uint8
+	MaxPerfPerWattPoint PwrModelOperatingPointPfpp1x
+	FmaxAtVmaxPoint     PwrModelOperatingPointPfpp1x
+	TgpHeadroommW       uint32
+}
+
+type PerfMetricsPfpp1xSample struct {
+	EstimatedMetrics PwrModelMetricsPfpp1x
+}
+
+type PerfMetricControllerSample struct {
+	ControllerType uint32
+	Pad_cgo_0      [4]byte
+	Data           [2208]byte
+}
+
+type PerfMetricsSample struct {
+	NumControllerData uint8
+	Pad_cgo_0         [7]byte
+	ControllerData    [4]PerfMetricControllerSample
+}
+
+type PerfMetricsSamples_v1 struct {
+	NumSamples uint32
+	Pad_cgo_0  [4]byte
+	Samples    [13]PerfMetricsSample
 }
 
 type BBXTimeData_v1 struct {
@@ -516,6 +614,14 @@ type PowerValue_v2 struct {
 	Version      uint32
 	PowerScope   uint8
 	PowerValueMw uint32
+}
+
+type AdaptiveTgpModeInfo_v1 struct {
+	InBandEnableRequest   uint32
+	FeatureAllowedByAdmin uint32
+	AdminOverrideEnabled  uint32
+	EnablementStatus      uint32
+	AdjustedLimitMw       uint32
 }
 
 type nvmlVgpuTypeId uint32
@@ -976,6 +1082,30 @@ type nvmlEventData struct {
 	ComputeInstanceId uint32
 }
 
+type GetContextCount_v1 struct {
+	Count uint32
+}
+
+type GetContextInfo_v1 struct {
+	Index                              uint32
+	NvmlGpuOperationalEventContextType uint32
+	SourceEventContextType             uint32
+	DataSize                           uint32
+	DataFormatVersion                  uint16
+	Pad_cgo_0                          [2]byte
+}
+
+type GetContextData_v1 struct {
+	Data     *byte
+	Index    uint32
+	DataSize uint32
+}
+
+type GetGpuOperationalEventContextLegacyXid_v1 struct {
+	Index   uint32
+	XidCode uint32
+}
+
 type SystemEventSet struct {
 	Handle *_Ctype_struct_nvmlSystemEventSet_st
 }
@@ -1200,6 +1330,57 @@ type GpuFabricInfoV struct {
 	Pad_cgo_0     [3]byte
 }
 
+type GpuFabricClique_v1 struct {
+	Type uint8
+	Id   uint32
+}
+
+type GpuFabricInfo_v4 struct {
+	ClusterUuid   [16]uint8
+	Status        uint32
+	Cliques       [64]GpuFabricClique_v1
+	NumCliques    uint32
+	State         uint8
+	HealthMask    uint32
+	HealthSummary uint8
+	Pad_cgo_0     [3]byte
+}
+
+type GpuOperationalEventConfig_v1 struct {
+	Uuid        [96]int8
+	MinLogLevel uint32
+	MinSeverity uint32
+}
+
+type EventSetWaitData_v3 struct {
+	TimeoutMs         uint32
+	DataType          uint32
+	Uuid              [96]int8
+	SourceModule      [16]int8
+	EventType         uint64
+	EventData         uint64
+	GroupCursor       uint64
+	InstanceId        uint64
+	TimestampUsec     uint64
+	TraceId           uint64
+	GpuInstanceId     uint32
+	ComputeInstanceId uint32
+	Severity          uint32
+	CategoryId        uint32
+	ModuleEventCode   uint32
+	Scope             uint32
+	Originator        uint32
+	ModuleInstance    uint32
+	ChipletId         uint32
+	LogLevel          uint32
+	Attributes        uint32
+	GroupCperSize     uint32
+	GroupAttributes   uint32
+	GroupSize         uint8
+	GroupIndex        uint8
+	Pad_cgo_0         [2]byte
+}
+
 type CPERCursorHandle uint64
 
 type CPERCursor_v1 struct {
@@ -1279,6 +1460,12 @@ type NvlinkSetBwMode struct {
 	Pad_cgo_0 [3]byte
 }
 
+type NvlinkSetBwModeAsync_v1 struct {
+	BSetBest           uint32
+	BwMode             uint32
+	AsyncPollTimeoutMs uint32
+}
+
 type NvLinkInfo_v1 struct {
 	Version       uint32
 	IsNvleEnabled uint32
@@ -1306,6 +1493,20 @@ type NvLinkInfo struct {
 	Version       uint32
 	IsNvleEnabled uint32
 	FirmwareInfo  NvlinkFirmwareInfo
+}
+
+type NvlinkTelemetrySample_v1 struct {
+	LinkId      uint32
+	SampleType  uint32
+	SampleCount uint32
+	Samples     *uint64
+	NvmlReturn  uint32
+	Pad_cgo_0   [4]byte
+}
+
+type NvlinkTelemetrySamples_v1 struct {
+	TelemetryCount   uint32
+	TelemetrySamples *NvlinkTelemetrySample_v1
 }
 
 type VgpuVersion struct {
@@ -1513,7 +1714,7 @@ type nvmlGpmMetricsGetType struct {
 	NumMetrics uint32
 	Sample1    nvmlGpmSample
 	Sample2    nvmlGpmSample
-	Metrics    [333]GpmMetric
+	Metrics    [477]GpmMetric
 }
 
 type GpmSupport struct {
@@ -1612,4 +1813,16 @@ type PowerSmoothingState_v1 struct {
 type PowerSmoothingState struct {
 	Version uint32
 	State   uint32
+}
+
+type EccBankRemapperHistogram_v1 struct {
+	MaxSpareGroupCount uint32
+	NoSpareGroupCount  uint32
+}
+
+type EccBankRemapperStatus_v1 struct {
+	ActiveRemappings   uint32
+	InactiveRemappings uint32
+	BPending           uint32
+	Histogram          EccBankRemapperHistogram_v1
 }

--- a/pkg/nvml/zz_generated.api.go
+++ b/pkg/nvml/zz_generated.api.go
@@ -20,398 +20,413 @@ package nvml
 
 // The variables below represent package level methods from the library type.
 var (
-	ComputeInstanceDestroy                           = libnvml.ComputeInstanceDestroy
-	ComputeInstanceGetInfo                           = libnvml.ComputeInstanceGetInfo
-	DeviceClearAccountingPids                        = libnvml.DeviceClearAccountingPids
-	DeviceClearCpuAffinity                           = libnvml.DeviceClearCpuAffinity
-	DeviceClearEccErrorCounts                        = libnvml.DeviceClearEccErrorCounts
-	DeviceClearFieldValues                           = libnvml.DeviceClearFieldValues
-	DeviceCreateGpuInstance                          = libnvml.DeviceCreateGpuInstance
-	DeviceCreateGpuInstanceWithPlacement             = libnvml.DeviceCreateGpuInstanceWithPlacement
-	DeviceDiscoverGpus                               = libnvml.DeviceDiscoverGpus
-	DeviceFreezeNvLinkUtilizationCounter             = libnvml.DeviceFreezeNvLinkUtilizationCounter
-	DeviceGetAPIRestriction                          = libnvml.DeviceGetAPIRestriction
-	DeviceGetAccountingBufferSize                    = libnvml.DeviceGetAccountingBufferSize
-	DeviceGetAccountingMode                          = libnvml.DeviceGetAccountingMode
-	DeviceGetAccountingPids                          = libnvml.DeviceGetAccountingPids
-	DeviceGetAccountingStats                         = libnvml.DeviceGetAccountingStats
-	DeviceGetAccountingStats_v2                      = libnvml.DeviceGetAccountingStats_v2
-	DeviceGetActiveVgpus                             = libnvml.DeviceGetActiveVgpus
-	DeviceGetAdaptiveClockInfoStatus                 = libnvml.DeviceGetAdaptiveClockInfoStatus
-	DeviceGetAddressingMode                          = libnvml.DeviceGetAddressingMode
-	DeviceGetApplicationsClock                       = libnvml.DeviceGetApplicationsClock
-	DeviceGetArchitecture                            = libnvml.DeviceGetArchitecture
-	DeviceGetAttributes                              = libnvml.DeviceGetAttributes
-	DeviceGetAutoBoostedClocksEnabled                = libnvml.DeviceGetAutoBoostedClocksEnabled
-	DeviceGetBAR1MemoryInfo                          = libnvml.DeviceGetBAR1MemoryInfo
-	DeviceGetBBXTimeData_v1                          = libnvml.DeviceGetBBXTimeData_v1
-	DeviceGetBoardId                                 = libnvml.DeviceGetBoardId
-	DeviceGetBoardPartNumber                         = libnvml.DeviceGetBoardPartNumber
-	DeviceGetBrand                                   = libnvml.DeviceGetBrand
-	DeviceGetBridgeChipInfo                          = libnvml.DeviceGetBridgeChipInfo
-	DeviceGetBusType                                 = libnvml.DeviceGetBusType
-	DeviceGetC2cModeInfoV                            = libnvml.DeviceGetC2cModeInfoV
-	DeviceGetCapabilities                            = libnvml.DeviceGetCapabilities
-	DeviceGetClkMonStatus                            = libnvml.DeviceGetClkMonStatus
-	DeviceGetClock                                   = libnvml.DeviceGetClock
-	DeviceGetClockInfo                               = libnvml.DeviceGetClockInfo
-	DeviceGetClockOffsets                            = libnvml.DeviceGetClockOffsets
-	DeviceGetComputeInstanceId                       = libnvml.DeviceGetComputeInstanceId
-	DeviceGetComputeMode                             = libnvml.DeviceGetComputeMode
-	DeviceGetComputeRunningProcesses                 = libnvml.DeviceGetComputeRunningProcesses
-	DeviceGetConfComputeGpuAttestationReport         = libnvml.DeviceGetConfComputeGpuAttestationReport
-	DeviceGetConfComputeGpuCertificate               = libnvml.DeviceGetConfComputeGpuCertificate
-	DeviceGetConfComputeMemSizeInfo                  = libnvml.DeviceGetConfComputeMemSizeInfo
-	DeviceGetConfComputeProtectedMemoryUsage         = libnvml.DeviceGetConfComputeProtectedMemoryUsage
-	DeviceGetCoolerInfo                              = libnvml.DeviceGetCoolerInfo
-	DeviceGetCount                                   = libnvml.DeviceGetCount
-	DeviceGetCpuAffinity                             = libnvml.DeviceGetCpuAffinity
-	DeviceGetCpuAffinityWithinScope                  = libnvml.DeviceGetCpuAffinityWithinScope
-	DeviceGetCreatableVgpus                          = libnvml.DeviceGetCreatableVgpus
-	DeviceGetCudaComputeCapability                   = libnvml.DeviceGetCudaComputeCapability
-	DeviceGetCurrPcieLinkGeneration                  = libnvml.DeviceGetCurrPcieLinkGeneration
-	DeviceGetCurrPcieLinkWidth                       = libnvml.DeviceGetCurrPcieLinkWidth
-	DeviceGetCurrentClockFreqs                       = libnvml.DeviceGetCurrentClockFreqs
-	DeviceGetCurrentClocksEventReasons               = libnvml.DeviceGetCurrentClocksEventReasons
-	DeviceGetCurrentClocksThrottleReasons            = libnvml.DeviceGetCurrentClocksThrottleReasons
-	DeviceGetDecoderUtilization                      = libnvml.DeviceGetDecoderUtilization
-	DeviceGetDefaultApplicationsClock                = libnvml.DeviceGetDefaultApplicationsClock
-	DeviceGetDefaultEccMode                          = libnvml.DeviceGetDefaultEccMode
-	DeviceGetDetailedEccErrors                       = libnvml.DeviceGetDetailedEccErrors
-	DeviceGetDeviceHandleFromMigDeviceHandle         = libnvml.DeviceGetDeviceHandleFromMigDeviceHandle
-	DeviceGetDisplayActive                           = libnvml.DeviceGetDisplayActive
-	DeviceGetDisplayMode                             = libnvml.DeviceGetDisplayMode
-	DeviceGetDramEncryptionMode                      = libnvml.DeviceGetDramEncryptionMode
-	DeviceGetDriverModel                             = libnvml.DeviceGetDriverModel
-	DeviceGetDriverModel_v2                          = libnvml.DeviceGetDriverModel_v2
-	DeviceGetDynamicPstatesInfo                      = libnvml.DeviceGetDynamicPstatesInfo
-	DeviceGetEccMode                                 = libnvml.DeviceGetEccMode
-	DeviceGetEncoderCapacity                         = libnvml.DeviceGetEncoderCapacity
-	DeviceGetEncoderSessions                         = libnvml.DeviceGetEncoderSessions
-	DeviceGetEncoderStats                            = libnvml.DeviceGetEncoderStats
-	DeviceGetEncoderUtilization                      = libnvml.DeviceGetEncoderUtilization
-	DeviceGetEnforcedPowerLimit                      = libnvml.DeviceGetEnforcedPowerLimit
-	DeviceGetFBCSessions                             = libnvml.DeviceGetFBCSessions
-	DeviceGetFBCStats                                = libnvml.DeviceGetFBCStats
-	DeviceGetFanControlPolicy_v2                     = libnvml.DeviceGetFanControlPolicy_v2
-	DeviceGetFanSpeed                                = libnvml.DeviceGetFanSpeed
-	DeviceGetFanSpeedRPM                             = libnvml.DeviceGetFanSpeedRPM
-	DeviceGetFanSpeed_v2                             = libnvml.DeviceGetFanSpeed_v2
-	DeviceGetFieldValues                             = libnvml.DeviceGetFieldValues
-	DeviceGetGpcClkMinMaxVfOffset                    = libnvml.DeviceGetGpcClkMinMaxVfOffset
-	DeviceGetGpcClkVfOffset                          = libnvml.DeviceGetGpcClkVfOffset
-	DeviceGetGpuFabricInfo                           = libnvml.DeviceGetGpuFabricInfo
-	DeviceGetGpuFabricInfoV                          = libnvml.DeviceGetGpuFabricInfoV
-	DeviceGetGpuInstanceById                         = libnvml.DeviceGetGpuInstanceById
-	DeviceGetGpuInstanceId                           = libnvml.DeviceGetGpuInstanceId
-	DeviceGetGpuInstancePossiblePlacements           = libnvml.DeviceGetGpuInstancePossiblePlacements
-	DeviceGetGpuInstanceProfileInfo                  = libnvml.DeviceGetGpuInstanceProfileInfo
-	DeviceGetGpuInstanceProfileInfoByIdV             = libnvml.DeviceGetGpuInstanceProfileInfoByIdV
-	DeviceGetGpuInstanceProfileInfoV                 = libnvml.DeviceGetGpuInstanceProfileInfoV
-	DeviceGetGpuInstanceRemainingCapacity            = libnvml.DeviceGetGpuInstanceRemainingCapacity
-	DeviceGetGpuInstances                            = libnvml.DeviceGetGpuInstances
-	DeviceGetGpuMaxPcieLinkGeneration                = libnvml.DeviceGetGpuMaxPcieLinkGeneration
-	DeviceGetGpuOperationMode                        = libnvml.DeviceGetGpuOperationMode
-	DeviceGetGraphicsRunningProcesses                = libnvml.DeviceGetGraphicsRunningProcesses
-	DeviceGetGridLicensableFeatures                  = libnvml.DeviceGetGridLicensableFeatures
-	DeviceGetGspFirmwareMode                         = libnvml.DeviceGetGspFirmwareMode
-	DeviceGetGspFirmwareVersion                      = libnvml.DeviceGetGspFirmwareVersion
-	DeviceGetHandleByIndex                           = libnvml.DeviceGetHandleByIndex
-	DeviceGetHandleByPciBusId                        = libnvml.DeviceGetHandleByPciBusId
-	DeviceGetHandleBySerial                          = libnvml.DeviceGetHandleBySerial
-	DeviceGetHandleByUUID                            = libnvml.DeviceGetHandleByUUID
-	DeviceGetHandleByUUIDV                           = libnvml.DeviceGetHandleByUUIDV
-	DeviceGetHostVgpuMode                            = libnvml.DeviceGetHostVgpuMode
-	DeviceGetHostname_v1                             = libnvml.DeviceGetHostname_v1
-	DeviceGetIndex                                   = libnvml.DeviceGetIndex
-	DeviceGetInforomConfigurationChecksum            = libnvml.DeviceGetInforomConfigurationChecksum
-	DeviceGetInforomImageVersion                     = libnvml.DeviceGetInforomImageVersion
-	DeviceGetInforomVersion                          = libnvml.DeviceGetInforomVersion
-	DeviceGetIrqNum                                  = libnvml.DeviceGetIrqNum
-	DeviceGetJpgUtilization                          = libnvml.DeviceGetJpgUtilization
-	DeviceGetLastBBXFlushTime                        = libnvml.DeviceGetLastBBXFlushTime
-	DeviceGetMPSComputeRunningProcesses              = libnvml.DeviceGetMPSComputeRunningProcesses
-	DeviceGetMarginTemperature                       = libnvml.DeviceGetMarginTemperature
-	DeviceGetMaxClockInfo                            = libnvml.DeviceGetMaxClockInfo
-	DeviceGetMaxCustomerBoostClock                   = libnvml.DeviceGetMaxCustomerBoostClock
-	DeviceGetMaxMigDeviceCount                       = libnvml.DeviceGetMaxMigDeviceCount
-	DeviceGetMaxPcieLinkGeneration                   = libnvml.DeviceGetMaxPcieLinkGeneration
-	DeviceGetMaxPcieLinkWidth                        = libnvml.DeviceGetMaxPcieLinkWidth
-	DeviceGetMemClkMinMaxVfOffset                    = libnvml.DeviceGetMemClkMinMaxVfOffset
-	DeviceGetMemClkVfOffset                          = libnvml.DeviceGetMemClkVfOffset
-	DeviceGetMemoryAffinity                          = libnvml.DeviceGetMemoryAffinity
-	DeviceGetMemoryBusWidth                          = libnvml.DeviceGetMemoryBusWidth
-	DeviceGetMemoryErrorCounter                      = libnvml.DeviceGetMemoryErrorCounter
-	DeviceGetMemoryInfo                              = libnvml.DeviceGetMemoryInfo
-	DeviceGetMemoryInfo_v2                           = libnvml.DeviceGetMemoryInfo_v2
-	DeviceGetMigDeviceHandleByIndex                  = libnvml.DeviceGetMigDeviceHandleByIndex
-	DeviceGetMigMode                                 = libnvml.DeviceGetMigMode
-	DeviceGetMinMaxClockOfPState                     = libnvml.DeviceGetMinMaxClockOfPState
-	DeviceGetMinMaxFanSpeed                          = libnvml.DeviceGetMinMaxFanSpeed
-	DeviceGetMinorNumber                             = libnvml.DeviceGetMinorNumber
-	DeviceGetModuleId                                = libnvml.DeviceGetModuleId
-	DeviceGetMultiGpuBoard                           = libnvml.DeviceGetMultiGpuBoard
-	DeviceGetName                                    = libnvml.DeviceGetName
-	DeviceGetNumFans                                 = libnvml.DeviceGetNumFans
-	DeviceGetNumGpuCores                             = libnvml.DeviceGetNumGpuCores
-	DeviceGetNumaNodeId                              = libnvml.DeviceGetNumaNodeId
-	DeviceGetNvLinkCapability                        = libnvml.DeviceGetNvLinkCapability
-	DeviceGetNvLinkErrorCounter                      = libnvml.DeviceGetNvLinkErrorCounter
-	DeviceGetNvLinkInfo                              = libnvml.DeviceGetNvLinkInfo
-	DeviceGetNvLinkRemoteDeviceType                  = libnvml.DeviceGetNvLinkRemoteDeviceType
-	DeviceGetNvLinkRemotePciInfo                     = libnvml.DeviceGetNvLinkRemotePciInfo
-	DeviceGetNvLinkState                             = libnvml.DeviceGetNvLinkState
-	DeviceGetNvLinkUtilizationControl                = libnvml.DeviceGetNvLinkUtilizationControl
-	DeviceGetNvLinkUtilizationCounter                = libnvml.DeviceGetNvLinkUtilizationCounter
-	DeviceGetNvLinkVersion                           = libnvml.DeviceGetNvLinkVersion
-	DeviceGetNvlinkBwMode                            = libnvml.DeviceGetNvlinkBwMode
-	DeviceGetNvlinkSupportedBwModes                  = libnvml.DeviceGetNvlinkSupportedBwModes
-	DeviceGetOfaUtilization                          = libnvml.DeviceGetOfaUtilization
-	DeviceGetP2PStatus                               = libnvml.DeviceGetP2PStatus
-	DeviceGetPciInfo                                 = libnvml.DeviceGetPciInfo
-	DeviceGetPciInfoExt                              = libnvml.DeviceGetPciInfoExt
-	DeviceGetPcieLinkMaxSpeed                        = libnvml.DeviceGetPcieLinkMaxSpeed
-	DeviceGetPcieReplayCounter                       = libnvml.DeviceGetPcieReplayCounter
-	DeviceGetPcieSpeed                               = libnvml.DeviceGetPcieSpeed
-	DeviceGetPcieThroughput                          = libnvml.DeviceGetPcieThroughput
-	DeviceGetPdi                                     = libnvml.DeviceGetPdi
-	DeviceGetPerformanceModes                        = libnvml.DeviceGetPerformanceModes
-	DeviceGetPerformanceState                        = libnvml.DeviceGetPerformanceState
-	DeviceGetPersistenceMode                         = libnvml.DeviceGetPersistenceMode
-	DeviceGetPgpuMetadataString                      = libnvml.DeviceGetPgpuMetadataString
-	DeviceGetPlatformInfo                            = libnvml.DeviceGetPlatformInfo
-	DeviceGetPowerManagementDefaultLimit             = libnvml.DeviceGetPowerManagementDefaultLimit
-	DeviceGetPowerManagementLimit                    = libnvml.DeviceGetPowerManagementLimit
-	DeviceGetPowerManagementLimitConstraints         = libnvml.DeviceGetPowerManagementLimitConstraints
-	DeviceGetPowerManagementMode                     = libnvml.DeviceGetPowerManagementMode
-	DeviceGetPowerMizerMode_v1                       = libnvml.DeviceGetPowerMizerMode_v1
-	DeviceGetPowerSource                             = libnvml.DeviceGetPowerSource
-	DeviceGetPowerState                              = libnvml.DeviceGetPowerState
-	DeviceGetPowerUsage                              = libnvml.DeviceGetPowerUsage
-	DeviceGetProcessUtilization                      = libnvml.DeviceGetProcessUtilization
-	DeviceGetProcessesUtilizationInfo                = libnvml.DeviceGetProcessesUtilizationInfo
-	DeviceGetRemappedRows                            = libnvml.DeviceGetRemappedRows
-	DeviceGetRemappedRows_v2                         = libnvml.DeviceGetRemappedRows_v2
-	DeviceGetRepairStatus                            = libnvml.DeviceGetRepairStatus
-	DeviceGetRetiredPages                            = libnvml.DeviceGetRetiredPages
-	DeviceGetRetiredPagesPendingStatus               = libnvml.DeviceGetRetiredPagesPendingStatus
-	DeviceGetRetiredPages_v2                         = libnvml.DeviceGetRetiredPages_v2
-	DeviceGetRowRemapperHistogram                    = libnvml.DeviceGetRowRemapperHistogram
-	DeviceGetRunningProcessDetailList                = libnvml.DeviceGetRunningProcessDetailList
-	DeviceGetSamples                                 = libnvml.DeviceGetSamples
-	DeviceGetSerial                                  = libnvml.DeviceGetSerial
-	DeviceGetSramEccErrorStatus                      = libnvml.DeviceGetSramEccErrorStatus
-	DeviceGetSramUniqueUncorrectedEccErrorCounts     = libnvml.DeviceGetSramUniqueUncorrectedEccErrorCounts
-	DeviceGetSupportedClocksEventReasons             = libnvml.DeviceGetSupportedClocksEventReasons
-	DeviceGetSupportedClocksThrottleReasons          = libnvml.DeviceGetSupportedClocksThrottleReasons
-	DeviceGetSupportedEventTypes                     = libnvml.DeviceGetSupportedEventTypes
-	DeviceGetSupportedGraphicsClocks                 = libnvml.DeviceGetSupportedGraphicsClocks
-	DeviceGetSupportedMemoryClocks                   = libnvml.DeviceGetSupportedMemoryClocks
-	DeviceGetSupportedPerformanceStates              = libnvml.DeviceGetSupportedPerformanceStates
-	DeviceGetSupportedVgpus                          = libnvml.DeviceGetSupportedVgpus
-	DeviceGetTargetFanSpeed                          = libnvml.DeviceGetTargetFanSpeed
-	DeviceGetTemperature                             = libnvml.DeviceGetTemperature
-	DeviceGetTemperatureThreshold                    = libnvml.DeviceGetTemperatureThreshold
-	DeviceGetTemperatureV                            = libnvml.DeviceGetTemperatureV
-	DeviceGetThermalSettings                         = libnvml.DeviceGetThermalSettings
-	DeviceGetTopologyCommonAncestor                  = libnvml.DeviceGetTopologyCommonAncestor
-	DeviceGetTopologyNearestGpus                     = libnvml.DeviceGetTopologyNearestGpus
-	DeviceGetTotalEccErrors                          = libnvml.DeviceGetTotalEccErrors
-	DeviceGetTotalEnergyConsumption                  = libnvml.DeviceGetTotalEnergyConsumption
-	DeviceGetUUID                                    = libnvml.DeviceGetUUID
-	DeviceGetUnrepairableMemoryFlag_v1               = libnvml.DeviceGetUnrepairableMemoryFlag_v1
-	DeviceGetUtilizationRates                        = libnvml.DeviceGetUtilizationRates
-	DeviceGetVbiosVersion                            = libnvml.DeviceGetVbiosVersion
-	DeviceGetVgpuCapabilities                        = libnvml.DeviceGetVgpuCapabilities
-	DeviceGetVgpuHeterogeneousMode                   = libnvml.DeviceGetVgpuHeterogeneousMode
-	DeviceGetVgpuInstancesUtilizationInfo            = libnvml.DeviceGetVgpuInstancesUtilizationInfo
-	DeviceGetVgpuMetadata                            = libnvml.DeviceGetVgpuMetadata
-	DeviceGetVgpuProcessUtilization                  = libnvml.DeviceGetVgpuProcessUtilization
-	DeviceGetVgpuProcessesUtilizationInfo            = libnvml.DeviceGetVgpuProcessesUtilizationInfo
-	DeviceGetVgpuSchedulerCapabilities               = libnvml.DeviceGetVgpuSchedulerCapabilities
-	DeviceGetVgpuSchedulerLog                        = libnvml.DeviceGetVgpuSchedulerLog
-	DeviceGetVgpuSchedulerLog_v2                     = libnvml.DeviceGetVgpuSchedulerLog_v2
-	DeviceGetVgpuSchedulerState                      = libnvml.DeviceGetVgpuSchedulerState
-	DeviceGetVgpuSchedulerState_v2                   = libnvml.DeviceGetVgpuSchedulerState_v2
-	DeviceGetVgpuTypeCreatablePlacements             = libnvml.DeviceGetVgpuTypeCreatablePlacements
-	DeviceGetVgpuTypeSupportedPlacements             = libnvml.DeviceGetVgpuTypeSupportedPlacements
-	DeviceGetVgpuUtilization                         = libnvml.DeviceGetVgpuUtilization
-	DeviceGetViolationStatus                         = libnvml.DeviceGetViolationStatus
-	DeviceGetVirtualizationMode                      = libnvml.DeviceGetVirtualizationMode
-	DeviceIsMigDeviceHandle                          = libnvml.DeviceIsMigDeviceHandle
-	DeviceModifyDrainState                           = libnvml.DeviceModifyDrainState
-	DeviceOnSameBoard                                = libnvml.DeviceOnSameBoard
-	DevicePowerSmoothingActivatePresetProfile        = libnvml.DevicePowerSmoothingActivatePresetProfile
-	DevicePowerSmoothingSetState                     = libnvml.DevicePowerSmoothingSetState
-	DevicePowerSmoothingUpdatePresetProfileParam     = libnvml.DevicePowerSmoothingUpdatePresetProfileParam
-	DeviceQueryDrainState                            = libnvml.DeviceQueryDrainState
-	DeviceReadPRMCounters_v1                         = libnvml.DeviceReadPRMCounters_v1
-	DeviceReadWritePRM_v1                            = libnvml.DeviceReadWritePRM_v1
-	DeviceRegisterEvents                             = libnvml.DeviceRegisterEvents
-	DeviceRemoveGpu                                  = libnvml.DeviceRemoveGpu
-	DeviceRemoveGpu_v2                               = libnvml.DeviceRemoveGpu_v2
-	DeviceResetApplicationsClocks                    = libnvml.DeviceResetApplicationsClocks
-	DeviceResetGpuLockedClocks                       = libnvml.DeviceResetGpuLockedClocks
-	DeviceResetMemoryLockedClocks                    = libnvml.DeviceResetMemoryLockedClocks
-	DeviceResetNvLinkErrorCounters                   = libnvml.DeviceResetNvLinkErrorCounters
-	DeviceResetNvLinkUtilizationCounter              = libnvml.DeviceResetNvLinkUtilizationCounter
-	DeviceSetAPIRestriction                          = libnvml.DeviceSetAPIRestriction
-	DeviceSetAccountingMode                          = libnvml.DeviceSetAccountingMode
-	DeviceSetApplicationsClocks                      = libnvml.DeviceSetApplicationsClocks
-	DeviceSetAutoBoostedClocksEnabled                = libnvml.DeviceSetAutoBoostedClocksEnabled
-	DeviceSetClockOffsets                            = libnvml.DeviceSetClockOffsets
-	DeviceSetComputeMode                             = libnvml.DeviceSetComputeMode
-	DeviceSetConfComputeUnprotectedMemSize           = libnvml.DeviceSetConfComputeUnprotectedMemSize
-	DeviceSetCpuAffinity                             = libnvml.DeviceSetCpuAffinity
-	DeviceSetDefaultAutoBoostedClocksEnabled         = libnvml.DeviceSetDefaultAutoBoostedClocksEnabled
-	DeviceSetDefaultFanSpeed_v2                      = libnvml.DeviceSetDefaultFanSpeed_v2
-	DeviceSetDramEncryptionMode                      = libnvml.DeviceSetDramEncryptionMode
-	DeviceSetDriverModel                             = libnvml.DeviceSetDriverModel
-	DeviceSetEccMode                                 = libnvml.DeviceSetEccMode
-	DeviceSetFanControlPolicy                        = libnvml.DeviceSetFanControlPolicy
-	DeviceSetFanSpeed_v2                             = libnvml.DeviceSetFanSpeed_v2
-	DeviceSetGpcClkVfOffset                          = libnvml.DeviceSetGpcClkVfOffset
-	DeviceSetGpuLockedClocks                         = libnvml.DeviceSetGpuLockedClocks
-	DeviceSetGpuOperationMode                        = libnvml.DeviceSetGpuOperationMode
-	DeviceSetHostname_v1                             = libnvml.DeviceSetHostname_v1
-	DeviceSetMemClkVfOffset                          = libnvml.DeviceSetMemClkVfOffset
-	DeviceSetMemoryLockedClocks                      = libnvml.DeviceSetMemoryLockedClocks
-	DeviceSetMigMode                                 = libnvml.DeviceSetMigMode
-	DeviceSetNvLinkDeviceLowPowerThreshold           = libnvml.DeviceSetNvLinkDeviceLowPowerThreshold
-	DeviceSetNvLinkUtilizationControl                = libnvml.DeviceSetNvLinkUtilizationControl
-	DeviceSetNvlinkBwMode                            = libnvml.DeviceSetNvlinkBwMode
-	DeviceSetPersistenceMode                         = libnvml.DeviceSetPersistenceMode
-	DeviceSetPowerManagementLimit                    = libnvml.DeviceSetPowerManagementLimit
-	DeviceSetPowerManagementLimit_v2                 = libnvml.DeviceSetPowerManagementLimit_v2
-	DeviceSetRusdSettings_v1                         = libnvml.DeviceSetRusdSettings_v1
-	DeviceSetTemperatureThreshold                    = libnvml.DeviceSetTemperatureThreshold
-	DeviceSetVgpuCapabilities                        = libnvml.DeviceSetVgpuCapabilities
-	DeviceSetVgpuHeterogeneousMode                   = libnvml.DeviceSetVgpuHeterogeneousMode
-	DeviceSetVgpuSchedulerState                      = libnvml.DeviceSetVgpuSchedulerState
-	DeviceSetVgpuSchedulerState_v2                   = libnvml.DeviceSetVgpuSchedulerState_v2
-	DeviceSetVirtualizationMode                      = libnvml.DeviceSetVirtualizationMode
-	DeviceValidateInforom                            = libnvml.DeviceValidateInforom
-	DeviceVgpuForceGspUnload                         = libnvml.DeviceVgpuForceGspUnload
-	DeviceWorkloadPowerProfileClearRequestedProfiles = libnvml.DeviceWorkloadPowerProfileClearRequestedProfiles
-	DeviceWorkloadPowerProfileGetCurrentProfiles     = libnvml.DeviceWorkloadPowerProfileGetCurrentProfiles
-	DeviceWorkloadPowerProfileGetProfilesInfo        = libnvml.DeviceWorkloadPowerProfileGetProfilesInfo
-	DeviceWorkloadPowerProfileSetRequestedProfiles   = libnvml.DeviceWorkloadPowerProfileSetRequestedProfiles
-	DeviceWorkloadPowerProfileUpdateProfiles_v1      = libnvml.DeviceWorkloadPowerProfileUpdateProfiles_v1
-	ErrorString                                      = libnvml.ErrorString
-	EventSetCreate                                   = libnvml.EventSetCreate
-	EventSetFree                                     = libnvml.EventSetFree
-	EventSetWait                                     = libnvml.EventSetWait
-	Extensions                                       = libnvml.Extensions
-	GetExcludedDeviceCount                           = libnvml.GetExcludedDeviceCount
-	GetExcludedDeviceInfoByIndex                     = libnvml.GetExcludedDeviceInfoByIndex
-	GetVgpuCompatibility                             = libnvml.GetVgpuCompatibility
-	GetVgpuDriverCapabilities                        = libnvml.GetVgpuDriverCapabilities
-	GetVgpuVersion                                   = libnvml.GetVgpuVersion
-	GpmMetricsGet                                    = libnvml.GpmMetricsGet
-	GpmMetricsGetV                                   = libnvml.GpmMetricsGetV
-	GpmMigSampleGet                                  = libnvml.GpmMigSampleGet
-	GpmQueryDeviceSupport                            = libnvml.GpmQueryDeviceSupport
-	GpmQueryDeviceSupportV                           = libnvml.GpmQueryDeviceSupportV
-	GpmQueryIfStreamingEnabled                       = libnvml.GpmQueryIfStreamingEnabled
-	GpmSampleAlloc                                   = libnvml.GpmSampleAlloc
-	GpmSampleFree                                    = libnvml.GpmSampleFree
-	GpmSampleGet                                     = libnvml.GpmSampleGet
-	GpmSetStreamingEnabled                           = libnvml.GpmSetStreamingEnabled
-	GpuInstanceCreateComputeInstance                 = libnvml.GpuInstanceCreateComputeInstance
-	GpuInstanceCreateComputeInstanceWithPlacement    = libnvml.GpuInstanceCreateComputeInstanceWithPlacement
-	GpuInstanceDestroy                               = libnvml.GpuInstanceDestroy
-	GpuInstanceGetActiveVgpus                        = libnvml.GpuInstanceGetActiveVgpus
-	GpuInstanceGetComputeInstanceById                = libnvml.GpuInstanceGetComputeInstanceById
-	GpuInstanceGetComputeInstancePossiblePlacements  = libnvml.GpuInstanceGetComputeInstancePossiblePlacements
-	GpuInstanceGetComputeInstanceProfileInfo         = libnvml.GpuInstanceGetComputeInstanceProfileInfo
-	GpuInstanceGetComputeInstanceProfileInfoV        = libnvml.GpuInstanceGetComputeInstanceProfileInfoV
-	GpuInstanceGetComputeInstanceRemainingCapacity   = libnvml.GpuInstanceGetComputeInstanceRemainingCapacity
-	GpuInstanceGetComputeInstances                   = libnvml.GpuInstanceGetComputeInstances
-	GpuInstanceGetCreatableVgpus                     = libnvml.GpuInstanceGetCreatableVgpus
-	GpuInstanceGetInfo                               = libnvml.GpuInstanceGetInfo
-	GpuInstanceGetVgpuHeterogeneousMode              = libnvml.GpuInstanceGetVgpuHeterogeneousMode
-	GpuInstanceGetVgpuSchedulerLog                   = libnvml.GpuInstanceGetVgpuSchedulerLog
-	GpuInstanceGetVgpuSchedulerLog_v2                = libnvml.GpuInstanceGetVgpuSchedulerLog_v2
-	GpuInstanceGetVgpuSchedulerState                 = libnvml.GpuInstanceGetVgpuSchedulerState
-	GpuInstanceGetVgpuSchedulerState_v2              = libnvml.GpuInstanceGetVgpuSchedulerState_v2
-	GpuInstanceGetVgpuTypeCreatablePlacements        = libnvml.GpuInstanceGetVgpuTypeCreatablePlacements
-	GpuInstanceSetVgpuHeterogeneousMode              = libnvml.GpuInstanceSetVgpuHeterogeneousMode
-	GpuInstanceSetVgpuSchedulerState                 = libnvml.GpuInstanceSetVgpuSchedulerState
-	GpuInstanceSetVgpuSchedulerState_v2              = libnvml.GpuInstanceSetVgpuSchedulerState_v2
-	Init                                             = libnvml.Init
-	InitWithFlags                                    = libnvml.InitWithFlags
-	SetVgpuVersion                                   = libnvml.SetVgpuVersion
-	Shutdown                                         = libnvml.Shutdown
-	SystemEventSetCreate                             = libnvml.SystemEventSetCreate
-	SystemEventSetFree                               = libnvml.SystemEventSetFree
-	SystemEventSetWait                               = libnvml.SystemEventSetWait
-	SystemGetCPER_v1                                 = libnvml.SystemGetCPER_v1
-	SystemGetConfComputeCapabilities                 = libnvml.SystemGetConfComputeCapabilities
-	SystemGetConfComputeGpusReadyState               = libnvml.SystemGetConfComputeGpusReadyState
-	SystemGetConfComputeKeyRotationThresholdInfo     = libnvml.SystemGetConfComputeKeyRotationThresholdInfo
-	SystemGetConfComputeSettings                     = libnvml.SystemGetConfComputeSettings
-	SystemGetConfComputeState                        = libnvml.SystemGetConfComputeState
-	SystemGetCudaDriverVersion                       = libnvml.SystemGetCudaDriverVersion
-	SystemGetCudaDriverVersion_v2                    = libnvml.SystemGetCudaDriverVersion_v2
-	SystemGetDriverBranch                            = libnvml.SystemGetDriverBranch
-	SystemGetDriverVersion                           = libnvml.SystemGetDriverVersion
-	SystemGetHicVersion                              = libnvml.SystemGetHicVersion
-	SystemGetNVMLVersion                             = libnvml.SystemGetNVMLVersion
-	SystemGetNvlinkBwMode                            = libnvml.SystemGetNvlinkBwMode
-	SystemGetProcessName                             = libnvml.SystemGetProcessName
-	SystemGetTopologyGpuSet                          = libnvml.SystemGetTopologyGpuSet
-	SystemRegisterEvents                             = libnvml.SystemRegisterEvents
-	SystemSetConfComputeGpusReadyState               = libnvml.SystemSetConfComputeGpusReadyState
-	SystemSetConfComputeKeyRotationThresholdInfo     = libnvml.SystemSetConfComputeKeyRotationThresholdInfo
-	SystemSetNvlinkBwMode                            = libnvml.SystemSetNvlinkBwMode
-	UnitGetCount                                     = libnvml.UnitGetCount
-	UnitGetDevices                                   = libnvml.UnitGetDevices
-	UnitGetFanSpeedInfo                              = libnvml.UnitGetFanSpeedInfo
-	UnitGetHandleByIndex                             = libnvml.UnitGetHandleByIndex
-	UnitGetLedState                                  = libnvml.UnitGetLedState
-	UnitGetPsuInfo                                   = libnvml.UnitGetPsuInfo
-	UnitGetTemperature                               = libnvml.UnitGetTemperature
-	UnitGetUnitInfo                                  = libnvml.UnitGetUnitInfo
-	UnitSetLedState                                  = libnvml.UnitSetLedState
-	VgpuInstanceClearAccountingPids                  = libnvml.VgpuInstanceClearAccountingPids
-	VgpuInstanceGetAccountingMode                    = libnvml.VgpuInstanceGetAccountingMode
-	VgpuInstanceGetAccountingPids                    = libnvml.VgpuInstanceGetAccountingPids
-	VgpuInstanceGetAccountingStats                   = libnvml.VgpuInstanceGetAccountingStats
-	VgpuInstanceGetEccMode                           = libnvml.VgpuInstanceGetEccMode
-	VgpuInstanceGetEncoderCapacity                   = libnvml.VgpuInstanceGetEncoderCapacity
-	VgpuInstanceGetEncoderSessions                   = libnvml.VgpuInstanceGetEncoderSessions
-	VgpuInstanceGetEncoderStats                      = libnvml.VgpuInstanceGetEncoderStats
-	VgpuInstanceGetFBCSessions                       = libnvml.VgpuInstanceGetFBCSessions
-	VgpuInstanceGetFBCStats                          = libnvml.VgpuInstanceGetFBCStats
-	VgpuInstanceGetFbUsage                           = libnvml.VgpuInstanceGetFbUsage
-	VgpuInstanceGetFrameRateLimit                    = libnvml.VgpuInstanceGetFrameRateLimit
-	VgpuInstanceGetGpuInstanceId                     = libnvml.VgpuInstanceGetGpuInstanceId
-	VgpuInstanceGetGpuPciId                          = libnvml.VgpuInstanceGetGpuPciId
-	VgpuInstanceGetLicenseInfo                       = libnvml.VgpuInstanceGetLicenseInfo
-	VgpuInstanceGetLicenseStatus                     = libnvml.VgpuInstanceGetLicenseStatus
-	VgpuInstanceGetMdevUUID                          = libnvml.VgpuInstanceGetMdevUUID
-	VgpuInstanceGetMetadata                          = libnvml.VgpuInstanceGetMetadata
-	VgpuInstanceGetRuntimeStateSize                  = libnvml.VgpuInstanceGetRuntimeStateSize
-	VgpuInstanceGetType                              = libnvml.VgpuInstanceGetType
-	VgpuInstanceGetUUID                              = libnvml.VgpuInstanceGetUUID
-	VgpuInstanceGetVmDriverVersion                   = libnvml.VgpuInstanceGetVmDriverVersion
-	VgpuInstanceGetVmID                              = libnvml.VgpuInstanceGetVmID
-	VgpuInstanceSetEncoderCapacity                   = libnvml.VgpuInstanceSetEncoderCapacity
-	VgpuTypeGetBAR1Info                              = libnvml.VgpuTypeGetBAR1Info
-	VgpuTypeGetCapabilities                          = libnvml.VgpuTypeGetCapabilities
-	VgpuTypeGetClass                                 = libnvml.VgpuTypeGetClass
-	VgpuTypeGetDeviceID                              = libnvml.VgpuTypeGetDeviceID
-	VgpuTypeGetFrameRateLimit                        = libnvml.VgpuTypeGetFrameRateLimit
-	VgpuTypeGetFramebufferSize                       = libnvml.VgpuTypeGetFramebufferSize
-	VgpuTypeGetGpuInstanceProfileId                  = libnvml.VgpuTypeGetGpuInstanceProfileId
-	VgpuTypeGetID                                    = libnvml.VgpuTypeGetID
-	VgpuTypeGetLicense                               = libnvml.VgpuTypeGetLicense
-	VgpuTypeGetMaxInstances                          = libnvml.VgpuTypeGetMaxInstances
-	VgpuTypeGetMaxInstancesPerGpuInstance            = libnvml.VgpuTypeGetMaxInstancesPerGpuInstance
-	VgpuTypeGetMaxInstancesPerVm                     = libnvml.VgpuTypeGetMaxInstancesPerVm
-	VgpuTypeGetName                                  = libnvml.VgpuTypeGetName
-	VgpuTypeGetNumDisplayHeads                       = libnvml.VgpuTypeGetNumDisplayHeads
-	VgpuTypeGetResolution                            = libnvml.VgpuTypeGetResolution
+	ComputeInstanceDestroy                            = libnvml.ComputeInstanceDestroy
+	ComputeInstanceGetInfo                            = libnvml.ComputeInstanceGetInfo
+	DeviceClearAccountingPids                         = libnvml.DeviceClearAccountingPids
+	DeviceClearCpuAffinity                            = libnvml.DeviceClearCpuAffinity
+	DeviceClearEccErrorCounts                         = libnvml.DeviceClearEccErrorCounts
+	DeviceClearFieldValues                            = libnvml.DeviceClearFieldValues
+	DeviceCreateGpuInstance                           = libnvml.DeviceCreateGpuInstance
+	DeviceCreateGpuInstanceWithPlacement              = libnvml.DeviceCreateGpuInstanceWithPlacement
+	DeviceDiscoverGpus                                = libnvml.DeviceDiscoverGpus
+	DeviceFreezeNvLinkUtilizationCounter              = libnvml.DeviceFreezeNvLinkUtilizationCounter
+	DeviceGetAPIRestriction                           = libnvml.DeviceGetAPIRestriction
+	DeviceGetAccountingBufferSize                     = libnvml.DeviceGetAccountingBufferSize
+	DeviceGetAccountingMode                           = libnvml.DeviceGetAccountingMode
+	DeviceGetAccountingPids                           = libnvml.DeviceGetAccountingPids
+	DeviceGetAccountingStats                          = libnvml.DeviceGetAccountingStats
+	DeviceGetAccountingStats_v2                       = libnvml.DeviceGetAccountingStats_v2
+	DeviceGetActiveVgpus                              = libnvml.DeviceGetActiveVgpus
+	DeviceGetAdaptiveClockInfoStatus                  = libnvml.DeviceGetAdaptiveClockInfoStatus
+	DeviceGetAdaptiveTgpModeInfo_v1                   = libnvml.DeviceGetAdaptiveTgpModeInfo_v1
+	DeviceGetAddressingMode                           = libnvml.DeviceGetAddressingMode
+	DeviceGetApplicationsClock                        = libnvml.DeviceGetApplicationsClock
+	DeviceGetArchitecture                             = libnvml.DeviceGetArchitecture
+	DeviceGetAttributes                               = libnvml.DeviceGetAttributes
+	DeviceGetAutoBoostedClocksEnabled                 = libnvml.DeviceGetAutoBoostedClocksEnabled
+	DeviceGetBAR1MemoryInfo                           = libnvml.DeviceGetBAR1MemoryInfo
+	DeviceGetBBXTimeData_v1                           = libnvml.DeviceGetBBXTimeData_v1
+	DeviceGetBankRemapperStatus_v1                    = libnvml.DeviceGetBankRemapperStatus_v1
+	DeviceGetBoardId                                  = libnvml.DeviceGetBoardId
+	DeviceGetBoardPartNumber                          = libnvml.DeviceGetBoardPartNumber
+	DeviceGetBrand                                    = libnvml.DeviceGetBrand
+	DeviceGetBridgeChipInfo                           = libnvml.DeviceGetBridgeChipInfo
+	DeviceGetBusType                                  = libnvml.DeviceGetBusType
+	DeviceGetC2cModeInfoV                             = libnvml.DeviceGetC2cModeInfoV
+	DeviceGetCapabilities                             = libnvml.DeviceGetCapabilities
+	DeviceGetClkMonStatus                             = libnvml.DeviceGetClkMonStatus
+	DeviceGetClock                                    = libnvml.DeviceGetClock
+	DeviceGetClockInfo                                = libnvml.DeviceGetClockInfo
+	DeviceGetClockOffsets                             = libnvml.DeviceGetClockOffsets
+	DeviceGetComputeInstanceId                        = libnvml.DeviceGetComputeInstanceId
+	DeviceGetComputeMode                              = libnvml.DeviceGetComputeMode
+	DeviceGetComputeRunningProcesses                  = libnvml.DeviceGetComputeRunningProcesses
+	DeviceGetConfComputeGpuAttestationReport          = libnvml.DeviceGetConfComputeGpuAttestationReport
+	DeviceGetConfComputeGpuCertificate                = libnvml.DeviceGetConfComputeGpuCertificate
+	DeviceGetConfComputeMemSizeInfo                   = libnvml.DeviceGetConfComputeMemSizeInfo
+	DeviceGetConfComputeProtectedMemoryUsage          = libnvml.DeviceGetConfComputeProtectedMemoryUsage
+	DeviceGetCoolerInfo                               = libnvml.DeviceGetCoolerInfo
+	DeviceGetCount                                    = libnvml.DeviceGetCount
+	DeviceGetCpuAffinity                              = libnvml.DeviceGetCpuAffinity
+	DeviceGetCpuAffinityWithinScope                   = libnvml.DeviceGetCpuAffinityWithinScope
+	DeviceGetCreatableVgpus                           = libnvml.DeviceGetCreatableVgpus
+	DeviceGetCudaComputeCapability                    = libnvml.DeviceGetCudaComputeCapability
+	DeviceGetCurrPcieLinkGeneration                   = libnvml.DeviceGetCurrPcieLinkGeneration
+	DeviceGetCurrPcieLinkWidth                        = libnvml.DeviceGetCurrPcieLinkWidth
+	DeviceGetCurrentClockFreqs                        = libnvml.DeviceGetCurrentClockFreqs
+	DeviceGetCurrentClocksEventReasons                = libnvml.DeviceGetCurrentClocksEventReasons
+	DeviceGetCurrentClocksThrottleReasons             = libnvml.DeviceGetCurrentClocksThrottleReasons
+	DeviceGetDecoderUtilization                       = libnvml.DeviceGetDecoderUtilization
+	DeviceGetDefaultApplicationsClock                 = libnvml.DeviceGetDefaultApplicationsClock
+	DeviceGetDefaultEccMode                           = libnvml.DeviceGetDefaultEccMode
+	DeviceGetDetailedEccErrors                        = libnvml.DeviceGetDetailedEccErrors
+	DeviceGetDeviceHandleFromMigDeviceHandle          = libnvml.DeviceGetDeviceHandleFromMigDeviceHandle
+	DeviceGetDisplayActive                            = libnvml.DeviceGetDisplayActive
+	DeviceGetDisplayMode                              = libnvml.DeviceGetDisplayMode
+	DeviceGetDramEncryptionMode                       = libnvml.DeviceGetDramEncryptionMode
+	DeviceGetDriverModel                              = libnvml.DeviceGetDriverModel
+	DeviceGetDriverModel_v2                           = libnvml.DeviceGetDriverModel_v2
+	DeviceGetDynamicPstatesInfo                       = libnvml.DeviceGetDynamicPstatesInfo
+	DeviceGetEccMode                                  = libnvml.DeviceGetEccMode
+	DeviceGetEncoderCapacity                          = libnvml.DeviceGetEncoderCapacity
+	DeviceGetEncoderSessions                          = libnvml.DeviceGetEncoderSessions
+	DeviceGetEncoderStats                             = libnvml.DeviceGetEncoderStats
+	DeviceGetEncoderUtilization                       = libnvml.DeviceGetEncoderUtilization
+	DeviceGetEnforcedPowerLimit                       = libnvml.DeviceGetEnforcedPowerLimit
+	DeviceGetFBCSessions                              = libnvml.DeviceGetFBCSessions
+	DeviceGetFBCStats                                 = libnvml.DeviceGetFBCStats
+	DeviceGetFanControlPolicy_v2                      = libnvml.DeviceGetFanControlPolicy_v2
+	DeviceGetFanSpeed                                 = libnvml.DeviceGetFanSpeed
+	DeviceGetFanSpeedRPM                              = libnvml.DeviceGetFanSpeedRPM
+	DeviceGetFanSpeed_v2                              = libnvml.DeviceGetFanSpeed_v2
+	DeviceGetFieldValues                              = libnvml.DeviceGetFieldValues
+	DeviceGetGpcClkMinMaxVfOffset                     = libnvml.DeviceGetGpcClkMinMaxVfOffset
+	DeviceGetGpcClkVfOffset                           = libnvml.DeviceGetGpcClkVfOffset
+	DeviceGetGpuFabricInfo                            = libnvml.DeviceGetGpuFabricInfo
+	DeviceGetGpuFabricInfoV                           = libnvml.DeviceGetGpuFabricInfoV
+	DeviceGetGpuFabricInfo_v4                         = libnvml.DeviceGetGpuFabricInfo_v4
+	DeviceGetGpuInstanceById                          = libnvml.DeviceGetGpuInstanceById
+	DeviceGetGpuInstanceId                            = libnvml.DeviceGetGpuInstanceId
+	DeviceGetGpuInstancePossiblePlacements            = libnvml.DeviceGetGpuInstancePossiblePlacements
+	DeviceGetGpuInstanceProfileInfo                   = libnvml.DeviceGetGpuInstanceProfileInfo
+	DeviceGetGpuInstanceProfileInfoByIdV              = libnvml.DeviceGetGpuInstanceProfileInfoByIdV
+	DeviceGetGpuInstanceProfileInfoV                  = libnvml.DeviceGetGpuInstanceProfileInfoV
+	DeviceGetGpuInstanceRemainingCapacity             = libnvml.DeviceGetGpuInstanceRemainingCapacity
+	DeviceGetGpuInstances                             = libnvml.DeviceGetGpuInstances
+	DeviceGetGpuMaxPcieLinkGeneration                 = libnvml.DeviceGetGpuMaxPcieLinkGeneration
+	DeviceGetGpuOperationMode                         = libnvml.DeviceGetGpuOperationMode
+	DeviceGetGraphicsRunningProcesses                 = libnvml.DeviceGetGraphicsRunningProcesses
+	DeviceGetGridLicensableFeatures                   = libnvml.DeviceGetGridLicensableFeatures
+	DeviceGetGspFirmwareMode                          = libnvml.DeviceGetGspFirmwareMode
+	DeviceGetGspFirmwareVersion                       = libnvml.DeviceGetGspFirmwareVersion
+	DeviceGetHandleByIndex                            = libnvml.DeviceGetHandleByIndex
+	DeviceGetHandleByPciBusId                         = libnvml.DeviceGetHandleByPciBusId
+	DeviceGetHandleBySerial                           = libnvml.DeviceGetHandleBySerial
+	DeviceGetHandleByUUID                             = libnvml.DeviceGetHandleByUUID
+	DeviceGetHandleByUUIDV                            = libnvml.DeviceGetHandleByUUIDV
+	DeviceGetHostVgpuMode                             = libnvml.DeviceGetHostVgpuMode
+	DeviceGetHostname_v1                              = libnvml.DeviceGetHostname_v1
+	DeviceGetIndex                                    = libnvml.DeviceGetIndex
+	DeviceGetInforomConfigurationChecksum             = libnvml.DeviceGetInforomConfigurationChecksum
+	DeviceGetInforomImageVersion                      = libnvml.DeviceGetInforomImageVersion
+	DeviceGetInforomVersion                           = libnvml.DeviceGetInforomVersion
+	DeviceGetIrqNum                                   = libnvml.DeviceGetIrqNum
+	DeviceGetJpgUtilization                           = libnvml.DeviceGetJpgUtilization
+	DeviceGetLastBBXFlushTime                         = libnvml.DeviceGetLastBBXFlushTime
+	DeviceGetMPSComputeRunningProcesses               = libnvml.DeviceGetMPSComputeRunningProcesses
+	DeviceGetMarginTemperature                        = libnvml.DeviceGetMarginTemperature
+	DeviceGetMaxClockInfo                             = libnvml.DeviceGetMaxClockInfo
+	DeviceGetMaxCustomerBoostClock                    = libnvml.DeviceGetMaxCustomerBoostClock
+	DeviceGetMaxMigDeviceCount                        = libnvml.DeviceGetMaxMigDeviceCount
+	DeviceGetMaxPcieLinkGeneration                    = libnvml.DeviceGetMaxPcieLinkGeneration
+	DeviceGetMaxPcieLinkWidth                         = libnvml.DeviceGetMaxPcieLinkWidth
+	DeviceGetMemClkMinMaxVfOffset                     = libnvml.DeviceGetMemClkMinMaxVfOffset
+	DeviceGetMemClkVfOffset                           = libnvml.DeviceGetMemClkVfOffset
+	DeviceGetMemoryAffinity                           = libnvml.DeviceGetMemoryAffinity
+	DeviceGetMemoryBusWidth                           = libnvml.DeviceGetMemoryBusWidth
+	DeviceGetMemoryErrorCounter                       = libnvml.DeviceGetMemoryErrorCounter
+	DeviceGetMemoryInfo                               = libnvml.DeviceGetMemoryInfo
+	DeviceGetMemoryInfo_v2                            = libnvml.DeviceGetMemoryInfo_v2
+	DeviceGetMemoryLimits_v1                          = libnvml.DeviceGetMemoryLimits_v1
+	DeviceGetMigDeviceHandleByIndex                   = libnvml.DeviceGetMigDeviceHandleByIndex
+	DeviceGetMigMode                                  = libnvml.DeviceGetMigMode
+	DeviceGetMinMaxClockOfPState                      = libnvml.DeviceGetMinMaxClockOfPState
+	DeviceGetMinMaxFanSpeed                           = libnvml.DeviceGetMinMaxFanSpeed
+	DeviceGetMinorNumber                              = libnvml.DeviceGetMinorNumber
+	DeviceGetModuleId                                 = libnvml.DeviceGetModuleId
+	DeviceGetMultiGpuBoard                            = libnvml.DeviceGetMultiGpuBoard
+	DeviceGetName                                     = libnvml.DeviceGetName
+	DeviceGetNumFans                                  = libnvml.DeviceGetNumFans
+	DeviceGetNumGpuCores                              = libnvml.DeviceGetNumGpuCores
+	DeviceGetNumaNodeId                               = libnvml.DeviceGetNumaNodeId
+	DeviceGetNvLinkCapability                         = libnvml.DeviceGetNvLinkCapability
+	DeviceGetNvLinkErrorCounter                       = libnvml.DeviceGetNvLinkErrorCounter
+	DeviceGetNvLinkInfo                               = libnvml.DeviceGetNvLinkInfo
+	DeviceGetNvLinkRemoteDeviceType                   = libnvml.DeviceGetNvLinkRemoteDeviceType
+	DeviceGetNvLinkRemotePciInfo                      = libnvml.DeviceGetNvLinkRemotePciInfo
+	DeviceGetNvLinkState                              = libnvml.DeviceGetNvLinkState
+	DeviceGetNvLinkTelemetrySamples_v1                = libnvml.DeviceGetNvLinkTelemetrySamples_v1
+	DeviceGetNvLinkUtilizationControl                 = libnvml.DeviceGetNvLinkUtilizationControl
+	DeviceGetNvLinkUtilizationCounter                 = libnvml.DeviceGetNvLinkUtilizationCounter
+	DeviceGetNvLinkVersion                            = libnvml.DeviceGetNvLinkVersion
+	DeviceGetNvlinkBwMode                             = libnvml.DeviceGetNvlinkBwMode
+	DeviceGetNvlinkSupportedBwModes                   = libnvml.DeviceGetNvlinkSupportedBwModes
+	DeviceGetOfaUtilization                           = libnvml.DeviceGetOfaUtilization
+	DeviceGetP2PStatus                                = libnvml.DeviceGetP2PStatus
+	DeviceGetPciInfo                                  = libnvml.DeviceGetPciInfo
+	DeviceGetPciInfoExt                               = libnvml.DeviceGetPciInfoExt
+	DeviceGetPcieLinkMaxSpeed                         = libnvml.DeviceGetPcieLinkMaxSpeed
+	DeviceGetPcieReplayCounter                        = libnvml.DeviceGetPcieReplayCounter
+	DeviceGetPcieSpeed                                = libnvml.DeviceGetPcieSpeed
+	DeviceGetPcieThroughput                           = libnvml.DeviceGetPcieThroughput
+	DeviceGetPdi                                      = libnvml.DeviceGetPdi
+	DeviceGetPerformanceModes                         = libnvml.DeviceGetPerformanceModes
+	DeviceGetPerformanceState                         = libnvml.DeviceGetPerformanceState
+	DeviceGetPersistenceMode                          = libnvml.DeviceGetPersistenceMode
+	DeviceGetPgpuMetadataString                       = libnvml.DeviceGetPgpuMetadataString
+	DeviceGetPlatformInfo                             = libnvml.DeviceGetPlatformInfo
+	DeviceGetPowerManagementDefaultLimit              = libnvml.DeviceGetPowerManagementDefaultLimit
+	DeviceGetPowerManagementLimit                     = libnvml.DeviceGetPowerManagementLimit
+	DeviceGetPowerManagementLimitConstraints          = libnvml.DeviceGetPowerManagementLimitConstraints
+	DeviceGetPowerManagementMode                      = libnvml.DeviceGetPowerManagementMode
+	DeviceGetPowerMizerMode_v1                        = libnvml.DeviceGetPowerMizerMode_v1
+	DeviceGetPowerSource                              = libnvml.DeviceGetPowerSource
+	DeviceGetPowerState                               = libnvml.DeviceGetPowerState
+	DeviceGetPowerUsage                               = libnvml.DeviceGetPowerUsage
+	DeviceGetProcessUtilization                       = libnvml.DeviceGetProcessUtilization
+	DeviceGetProcessesUtilizationInfo                 = libnvml.DeviceGetProcessesUtilizationInfo
+	DeviceGetRemappedRows                             = libnvml.DeviceGetRemappedRows
+	DeviceGetRemappedRows_v2                          = libnvml.DeviceGetRemappedRows_v2
+	DeviceGetRepairStatus                             = libnvml.DeviceGetRepairStatus
+	DeviceGetRetiredPages                             = libnvml.DeviceGetRetiredPages
+	DeviceGetRetiredPagesPendingStatus                = libnvml.DeviceGetRetiredPagesPendingStatus
+	DeviceGetRetiredPages_v2                          = libnvml.DeviceGetRetiredPages_v2
+	DeviceGetRowRemapperHistogram                     = libnvml.DeviceGetRowRemapperHistogram
+	DeviceGetRunningProcessDetailList                 = libnvml.DeviceGetRunningProcessDetailList
+	DeviceGetSamples                                  = libnvml.DeviceGetSamples
+	DeviceGetSerial                                   = libnvml.DeviceGetSerial
+	DeviceGetSramEccErrorStatus                       = libnvml.DeviceGetSramEccErrorStatus
+	DeviceGetSramUniqueUncorrectedEccErrorCounts      = libnvml.DeviceGetSramUniqueUncorrectedEccErrorCounts
+	DeviceGetSupportedClocksEventReasons              = libnvml.DeviceGetSupportedClocksEventReasons
+	DeviceGetSupportedClocksThrottleReasons           = libnvml.DeviceGetSupportedClocksThrottleReasons
+	DeviceGetSupportedEventTypes                      = libnvml.DeviceGetSupportedEventTypes
+	DeviceGetSupportedGraphicsClocks                  = libnvml.DeviceGetSupportedGraphicsClocks
+	DeviceGetSupportedMemoryClocks                    = libnvml.DeviceGetSupportedMemoryClocks
+	DeviceGetSupportedPerformanceStates               = libnvml.DeviceGetSupportedPerformanceStates
+	DeviceGetSupportedVgpus                           = libnvml.DeviceGetSupportedVgpus
+	DeviceGetTargetFanSpeed                           = libnvml.DeviceGetTargetFanSpeed
+	DeviceGetTemperature                              = libnvml.DeviceGetTemperature
+	DeviceGetTemperatureThreshold                     = libnvml.DeviceGetTemperatureThreshold
+	DeviceGetTemperatureV                             = libnvml.DeviceGetTemperatureV
+	DeviceGetThermalSettings                          = libnvml.DeviceGetThermalSettings
+	DeviceGetTopologyCommonAncestor                   = libnvml.DeviceGetTopologyCommonAncestor
+	DeviceGetTopologyNearestGpus                      = libnvml.DeviceGetTopologyNearestGpus
+	DeviceGetTotalEccErrors                           = libnvml.DeviceGetTotalEccErrors
+	DeviceGetTotalEnergyConsumption                   = libnvml.DeviceGetTotalEnergyConsumption
+	DeviceGetUUID                                     = libnvml.DeviceGetUUID
+	DeviceGetUnrepairableMemoryFlag_v1                = libnvml.DeviceGetUnrepairableMemoryFlag_v1
+	DeviceGetUtilizationRates                         = libnvml.DeviceGetUtilizationRates
+	DeviceGetVbiosVersion                             = libnvml.DeviceGetVbiosVersion
+	DeviceGetVgpuCapabilities                         = libnvml.DeviceGetVgpuCapabilities
+	DeviceGetVgpuHeterogeneousMode                    = libnvml.DeviceGetVgpuHeterogeneousMode
+	DeviceGetVgpuInstancesUtilizationInfo             = libnvml.DeviceGetVgpuInstancesUtilizationInfo
+	DeviceGetVgpuMetadata                             = libnvml.DeviceGetVgpuMetadata
+	DeviceGetVgpuProcessUtilization                   = libnvml.DeviceGetVgpuProcessUtilization
+	DeviceGetVgpuProcessesUtilizationInfo             = libnvml.DeviceGetVgpuProcessesUtilizationInfo
+	DeviceGetVgpuSchedulerCapabilities                = libnvml.DeviceGetVgpuSchedulerCapabilities
+	DeviceGetVgpuSchedulerLog                         = libnvml.DeviceGetVgpuSchedulerLog
+	DeviceGetVgpuSchedulerLog_v2                      = libnvml.DeviceGetVgpuSchedulerLog_v2
+	DeviceGetVgpuSchedulerState                       = libnvml.DeviceGetVgpuSchedulerState
+	DeviceGetVgpuSchedulerState_v2                    = libnvml.DeviceGetVgpuSchedulerState_v2
+	DeviceGetVgpuTypeCreatablePlacements              = libnvml.DeviceGetVgpuTypeCreatablePlacements
+	DeviceGetVgpuTypeSupportedPlacements              = libnvml.DeviceGetVgpuTypeSupportedPlacements
+	DeviceGetVgpuUtilization                          = libnvml.DeviceGetVgpuUtilization
+	DeviceGetViolationStatus                          = libnvml.DeviceGetViolationStatus
+	DeviceGetVirtualizationMode                       = libnvml.DeviceGetVirtualizationMode
+	DeviceIsMigDeviceHandle                           = libnvml.DeviceIsMigDeviceHandle
+	DeviceModifyDrainState                            = libnvml.DeviceModifyDrainState
+	DeviceOnSameBoard                                 = libnvml.DeviceOnSameBoard
+	DevicePerfMetricsGetSamples_v1                    = libnvml.DevicePerfMetricsGetSamples_v1
+	DevicePowerSmoothingActivatePresetProfile         = libnvml.DevicePowerSmoothingActivatePresetProfile
+	DevicePowerSmoothingSetState                      = libnvml.DevicePowerSmoothingSetState
+	DevicePowerSmoothingUpdatePresetProfileParam      = libnvml.DevicePowerSmoothingUpdatePresetProfileParam
+	DeviceQueryDrainState                             = libnvml.DeviceQueryDrainState
+	DeviceReadPRMCounters_v1                          = libnvml.DeviceReadPRMCounters_v1
+	DeviceReadWritePRM_v1                             = libnvml.DeviceReadWritePRM_v1
+	DeviceRegisterEvents                              = libnvml.DeviceRegisterEvents
+	DeviceRemoveGpu                                   = libnvml.DeviceRemoveGpu
+	DeviceRemoveGpu_v2                                = libnvml.DeviceRemoveGpu_v2
+	DeviceResetApplicationsClocks                     = libnvml.DeviceResetApplicationsClocks
+	DeviceResetGpuLockedClocks                        = libnvml.DeviceResetGpuLockedClocks
+	DeviceResetMemoryLockedClocks                     = libnvml.DeviceResetMemoryLockedClocks
+	DeviceResetNvLinkErrorCounters                    = libnvml.DeviceResetNvLinkErrorCounters
+	DeviceResetNvLinkUtilizationCounter               = libnvml.DeviceResetNvLinkUtilizationCounter
+	DeviceSetAPIRestriction                           = libnvml.DeviceSetAPIRestriction
+	DeviceSetAccountingMode                           = libnvml.DeviceSetAccountingMode
+	DeviceSetAdaptiveTgpMode_v1                       = libnvml.DeviceSetAdaptiveTgpMode_v1
+	DeviceSetApplicationsClocks                       = libnvml.DeviceSetApplicationsClocks
+	DeviceSetAutoBoostedClocksEnabled                 = libnvml.DeviceSetAutoBoostedClocksEnabled
+	DeviceSetClockOffsets                             = libnvml.DeviceSetClockOffsets
+	DeviceSetComputeMode                              = libnvml.DeviceSetComputeMode
+	DeviceSetConfComputeUnprotectedMemSize            = libnvml.DeviceSetConfComputeUnprotectedMemSize
+	DeviceSetCpuAffinity                              = libnvml.DeviceSetCpuAffinity
+	DeviceSetDefaultAutoBoostedClocksEnabled          = libnvml.DeviceSetDefaultAutoBoostedClocksEnabled
+	DeviceSetDefaultFanSpeed_v2                       = libnvml.DeviceSetDefaultFanSpeed_v2
+	DeviceSetDramEncryptionMode                       = libnvml.DeviceSetDramEncryptionMode
+	DeviceSetDriverModel                              = libnvml.DeviceSetDriverModel
+	DeviceSetEccMode                                  = libnvml.DeviceSetEccMode
+	DeviceSetFanControlPolicy                         = libnvml.DeviceSetFanControlPolicy
+	DeviceSetFanSpeed_v2                              = libnvml.DeviceSetFanSpeed_v2
+	DeviceSetGpcClkVfOffset                           = libnvml.DeviceSetGpcClkVfOffset
+	DeviceSetGpuLockedClocks                          = libnvml.DeviceSetGpuLockedClocks
+	DeviceSetGpuOperationMode                         = libnvml.DeviceSetGpuOperationMode
+	DeviceSetHostname_v1                              = libnvml.DeviceSetHostname_v1
+	DeviceSetMemClkVfOffset                           = libnvml.DeviceSetMemClkVfOffset
+	DeviceSetMemoryLimits_v1                          = libnvml.DeviceSetMemoryLimits_v1
+	DeviceSetMemoryLockedClocks                       = libnvml.DeviceSetMemoryLockedClocks
+	DeviceSetMigMode                                  = libnvml.DeviceSetMigMode
+	DeviceSetNvLinkDeviceLowPowerThreshold            = libnvml.DeviceSetNvLinkDeviceLowPowerThreshold
+	DeviceSetNvLinkUtilizationControl                 = libnvml.DeviceSetNvLinkUtilizationControl
+	DeviceSetNvlinkBwMode                             = libnvml.DeviceSetNvlinkBwMode
+	DeviceSetNvlinkBwModeAsync_v1                     = libnvml.DeviceSetNvlinkBwModeAsync_v1
+	DeviceSetPersistenceMode                          = libnvml.DeviceSetPersistenceMode
+	DeviceSetPowerManagementLimit                     = libnvml.DeviceSetPowerManagementLimit
+	DeviceSetPowerManagementLimit_v2                  = libnvml.DeviceSetPowerManagementLimit_v2
+	DeviceSetRusdSettings_v1                          = libnvml.DeviceSetRusdSettings_v1
+	DeviceSetTemperatureThreshold                     = libnvml.DeviceSetTemperatureThreshold
+	DeviceSetVgpuCapabilities                         = libnvml.DeviceSetVgpuCapabilities
+	DeviceSetVgpuHeterogeneousMode                    = libnvml.DeviceSetVgpuHeterogeneousMode
+	DeviceSetVgpuSchedulerState                       = libnvml.DeviceSetVgpuSchedulerState
+	DeviceSetVgpuSchedulerState_v2                    = libnvml.DeviceSetVgpuSchedulerState_v2
+	DeviceSetVirtualizationMode                       = libnvml.DeviceSetVirtualizationMode
+	DeviceValidateInforom                             = libnvml.DeviceValidateInforom
+	DeviceVgpuForceGspUnload                          = libnvml.DeviceVgpuForceGspUnload
+	DeviceWorkloadPowerProfileClearRequestedProfiles  = libnvml.DeviceWorkloadPowerProfileClearRequestedProfiles
+	DeviceWorkloadPowerProfileGetCurrentProfiles      = libnvml.DeviceWorkloadPowerProfileGetCurrentProfiles
+	DeviceWorkloadPowerProfileGetProfilesInfo         = libnvml.DeviceWorkloadPowerProfileGetProfilesInfo
+	DeviceWorkloadPowerProfileSetRequestedProfiles    = libnvml.DeviceWorkloadPowerProfileSetRequestedProfiles
+	DeviceWorkloadPowerProfileUpdateProfiles_v1       = libnvml.DeviceWorkloadPowerProfileUpdateProfiles_v1
+	ErrorString                                       = libnvml.ErrorString
+	EventSetCreate                                    = libnvml.EventSetCreate
+	EventSetFree                                      = libnvml.EventSetFree
+	EventSetGetContextCount_v1                        = libnvml.EventSetGetContextCount_v1
+	EventSetGetContextData_v1                         = libnvml.EventSetGetContextData_v1
+	EventSetGetContextInfo_v1                         = libnvml.EventSetGetContextInfo_v1
+	EventSetGetGpuOperationalEventContextLegacyXid_v1 = libnvml.EventSetGetGpuOperationalEventContextLegacyXid_v1
+	EventSetRegisterGpuOperationalEvents_v1           = libnvml.EventSetRegisterGpuOperationalEvents_v1
+	EventSetWait                                      = libnvml.EventSetWait
+	EventSetWait_v3                                   = libnvml.EventSetWait_v3
+	Extensions                                        = libnvml.Extensions
+	GetExcludedDeviceCount                            = libnvml.GetExcludedDeviceCount
+	GetExcludedDeviceInfoByIndex                      = libnvml.GetExcludedDeviceInfoByIndex
+	GetVgpuCompatibility                              = libnvml.GetVgpuCompatibility
+	GetVgpuDriverCapabilities                         = libnvml.GetVgpuDriverCapabilities
+	GetVgpuVersion                                    = libnvml.GetVgpuVersion
+	GpmMetricsGet                                     = libnvml.GpmMetricsGet
+	GpmMetricsGetV                                    = libnvml.GpmMetricsGetV
+	GpmMigSampleGet                                   = libnvml.GpmMigSampleGet
+	GpmQueryDeviceSupport                             = libnvml.GpmQueryDeviceSupport
+	GpmQueryDeviceSupportV                            = libnvml.GpmQueryDeviceSupportV
+	GpmQueryIfStreamingEnabled                        = libnvml.GpmQueryIfStreamingEnabled
+	GpmSampleAlloc                                    = libnvml.GpmSampleAlloc
+	GpmSampleFree                                     = libnvml.GpmSampleFree
+	GpmSampleGet                                      = libnvml.GpmSampleGet
+	GpmSetStreamingEnabled                            = libnvml.GpmSetStreamingEnabled
+	GpuInstanceCreateComputeInstance                  = libnvml.GpuInstanceCreateComputeInstance
+	GpuInstanceCreateComputeInstanceWithPlacement     = libnvml.GpuInstanceCreateComputeInstanceWithPlacement
+	GpuInstanceDestroy                                = libnvml.GpuInstanceDestroy
+	GpuInstanceGetActiveVgpus                         = libnvml.GpuInstanceGetActiveVgpus
+	GpuInstanceGetComputeInstanceById                 = libnvml.GpuInstanceGetComputeInstanceById
+	GpuInstanceGetComputeInstancePossiblePlacements   = libnvml.GpuInstanceGetComputeInstancePossiblePlacements
+	GpuInstanceGetComputeInstanceProfileInfo          = libnvml.GpuInstanceGetComputeInstanceProfileInfo
+	GpuInstanceGetComputeInstanceProfileInfoV         = libnvml.GpuInstanceGetComputeInstanceProfileInfoV
+	GpuInstanceGetComputeInstanceRemainingCapacity    = libnvml.GpuInstanceGetComputeInstanceRemainingCapacity
+	GpuInstanceGetComputeInstances                    = libnvml.GpuInstanceGetComputeInstances
+	GpuInstanceGetCreatableVgpus                      = libnvml.GpuInstanceGetCreatableVgpus
+	GpuInstanceGetInfo                                = libnvml.GpuInstanceGetInfo
+	GpuInstanceGetVgpuHeterogeneousMode               = libnvml.GpuInstanceGetVgpuHeterogeneousMode
+	GpuInstanceGetVgpuSchedulerLog                    = libnvml.GpuInstanceGetVgpuSchedulerLog
+	GpuInstanceGetVgpuSchedulerLog_v2                 = libnvml.GpuInstanceGetVgpuSchedulerLog_v2
+	GpuInstanceGetVgpuSchedulerState                  = libnvml.GpuInstanceGetVgpuSchedulerState
+	GpuInstanceGetVgpuSchedulerState_v2               = libnvml.GpuInstanceGetVgpuSchedulerState_v2
+	GpuInstanceGetVgpuTypeCreatablePlacements         = libnvml.GpuInstanceGetVgpuTypeCreatablePlacements
+	GpuInstanceSetVgpuHeterogeneousMode               = libnvml.GpuInstanceSetVgpuHeterogeneousMode
+	GpuInstanceSetVgpuSchedulerState                  = libnvml.GpuInstanceSetVgpuSchedulerState
+	GpuInstanceSetVgpuSchedulerState_v2               = libnvml.GpuInstanceSetVgpuSchedulerState_v2
+	Init                                              = libnvml.Init
+	InitWithFlags                                     = libnvml.InitWithFlags
+	SetVgpuVersion                                    = libnvml.SetVgpuVersion
+	Shutdown                                          = libnvml.Shutdown
+	SystemEventSetCreate                              = libnvml.SystemEventSetCreate
+	SystemEventSetFree                                = libnvml.SystemEventSetFree
+	SystemEventSetWait                                = libnvml.SystemEventSetWait
+	SystemGetCPER_v1                                  = libnvml.SystemGetCPER_v1
+	SystemGetConfComputeCapabilities                  = libnvml.SystemGetConfComputeCapabilities
+	SystemGetConfComputeGpusReadyState                = libnvml.SystemGetConfComputeGpusReadyState
+	SystemGetConfComputeKeyRotationThresholdInfo      = libnvml.SystemGetConfComputeKeyRotationThresholdInfo
+	SystemGetConfComputeSettings                      = libnvml.SystemGetConfComputeSettings
+	SystemGetConfComputeState                         = libnvml.SystemGetConfComputeState
+	SystemGetCudaDriverVersion                        = libnvml.SystemGetCudaDriverVersion
+	SystemGetCudaDriverVersion_v2                     = libnvml.SystemGetCudaDriverVersion_v2
+	SystemGetDriverBranch                             = libnvml.SystemGetDriverBranch
+	SystemGetDriverVersion                            = libnvml.SystemGetDriverVersion
+	SystemGetHicVersion                               = libnvml.SystemGetHicVersion
+	SystemGetNVMLVersion                              = libnvml.SystemGetNVMLVersion
+	SystemGetNvlinkBwMode                             = libnvml.SystemGetNvlinkBwMode
+	SystemGetProcessName                              = libnvml.SystemGetProcessName
+	SystemGetTopologyGpuSet                           = libnvml.SystemGetTopologyGpuSet
+	SystemRegisterEvents                              = libnvml.SystemRegisterEvents
+	SystemSetConfComputeGpusReadyState                = libnvml.SystemSetConfComputeGpusReadyState
+	SystemSetConfComputeKeyRotationThresholdInfo      = libnvml.SystemSetConfComputeKeyRotationThresholdInfo
+	SystemSetNvlinkBwMode                             = libnvml.SystemSetNvlinkBwMode
+	UnitGetCount                                      = libnvml.UnitGetCount
+	UnitGetDevices                                    = libnvml.UnitGetDevices
+	UnitGetFanSpeedInfo                               = libnvml.UnitGetFanSpeedInfo
+	UnitGetHandleByIndex                              = libnvml.UnitGetHandleByIndex
+	UnitGetLedState                                   = libnvml.UnitGetLedState
+	UnitGetPsuInfo                                    = libnvml.UnitGetPsuInfo
+	UnitGetTemperature                                = libnvml.UnitGetTemperature
+	UnitGetUnitInfo                                   = libnvml.UnitGetUnitInfo
+	UnitSetLedState                                   = libnvml.UnitSetLedState
+	VgpuInstanceClearAccountingPids                   = libnvml.VgpuInstanceClearAccountingPids
+	VgpuInstanceGetAccountingMode                     = libnvml.VgpuInstanceGetAccountingMode
+	VgpuInstanceGetAccountingPids                     = libnvml.VgpuInstanceGetAccountingPids
+	VgpuInstanceGetAccountingStats                    = libnvml.VgpuInstanceGetAccountingStats
+	VgpuInstanceGetEccMode                            = libnvml.VgpuInstanceGetEccMode
+	VgpuInstanceGetEncoderCapacity                    = libnvml.VgpuInstanceGetEncoderCapacity
+	VgpuInstanceGetEncoderSessions                    = libnvml.VgpuInstanceGetEncoderSessions
+	VgpuInstanceGetEncoderStats                       = libnvml.VgpuInstanceGetEncoderStats
+	VgpuInstanceGetFBCSessions                        = libnvml.VgpuInstanceGetFBCSessions
+	VgpuInstanceGetFBCStats                           = libnvml.VgpuInstanceGetFBCStats
+	VgpuInstanceGetFbUsage                            = libnvml.VgpuInstanceGetFbUsage
+	VgpuInstanceGetFrameRateLimit                     = libnvml.VgpuInstanceGetFrameRateLimit
+	VgpuInstanceGetGpuInstanceId                      = libnvml.VgpuInstanceGetGpuInstanceId
+	VgpuInstanceGetGpuPciId                           = libnvml.VgpuInstanceGetGpuPciId
+	VgpuInstanceGetLicenseInfo                        = libnvml.VgpuInstanceGetLicenseInfo
+	VgpuInstanceGetLicenseStatus                      = libnvml.VgpuInstanceGetLicenseStatus
+	VgpuInstanceGetMdevUUID                           = libnvml.VgpuInstanceGetMdevUUID
+	VgpuInstanceGetMetadata                           = libnvml.VgpuInstanceGetMetadata
+	VgpuInstanceGetRuntimeStateSize                   = libnvml.VgpuInstanceGetRuntimeStateSize
+	VgpuInstanceGetType                               = libnvml.VgpuInstanceGetType
+	VgpuInstanceGetUUID                               = libnvml.VgpuInstanceGetUUID
+	VgpuInstanceGetVmDriverVersion                    = libnvml.VgpuInstanceGetVmDriverVersion
+	VgpuInstanceGetVmID                               = libnvml.VgpuInstanceGetVmID
+	VgpuInstanceSetEncoderCapacity                    = libnvml.VgpuInstanceSetEncoderCapacity
+	VgpuTypeGetBAR1Info                               = libnvml.VgpuTypeGetBAR1Info
+	VgpuTypeGetCapabilities                           = libnvml.VgpuTypeGetCapabilities
+	VgpuTypeGetClass                                  = libnvml.VgpuTypeGetClass
+	VgpuTypeGetDeviceID                               = libnvml.VgpuTypeGetDeviceID
+	VgpuTypeGetFrameRateLimit                         = libnvml.VgpuTypeGetFrameRateLimit
+	VgpuTypeGetFramebufferSize                        = libnvml.VgpuTypeGetFramebufferSize
+	VgpuTypeGetGpuInstanceProfileId                   = libnvml.VgpuTypeGetGpuInstanceProfileId
+	VgpuTypeGetID                                     = libnvml.VgpuTypeGetID
+	VgpuTypeGetLicense                                = libnvml.VgpuTypeGetLicense
+	VgpuTypeGetMaxInstances                           = libnvml.VgpuTypeGetMaxInstances
+	VgpuTypeGetMaxInstancesPerGpuInstance             = libnvml.VgpuTypeGetMaxInstancesPerGpuInstance
+	VgpuTypeGetMaxInstancesPerVm                      = libnvml.VgpuTypeGetMaxInstancesPerVm
+	VgpuTypeGetName                                   = libnvml.VgpuTypeGetName
+	VgpuTypeGetNumDisplayHeads                        = libnvml.VgpuTypeGetNumDisplayHeads
+	VgpuTypeGetResolution                             = libnvml.VgpuTypeGetResolution
 )
 
 // Interface represents the interface for the library type.
@@ -436,6 +451,7 @@ type Interface interface {
 	DeviceGetAccountingStats_v2(Device, uint32) (AccountingStats_v2, Return)
 	DeviceGetActiveVgpus(Device) ([]VgpuInstance, Return)
 	DeviceGetAdaptiveClockInfoStatus(Device) (uint32, Return)
+	DeviceGetAdaptiveTgpModeInfo_v1(Device) (AdaptiveTgpModeInfo_v1, Return)
 	DeviceGetAddressingMode(Device) (DeviceAddressingMode, Return)
 	DeviceGetApplicationsClock(Device, ClockType) (uint32, Return)
 	DeviceGetArchitecture(Device) (DeviceArchitecture, Return)
@@ -443,6 +459,7 @@ type Interface interface {
 	DeviceGetAutoBoostedClocksEnabled(Device) (EnableState, EnableState, Return)
 	DeviceGetBAR1MemoryInfo(Device) (BAR1Memory, Return)
 	DeviceGetBBXTimeData_v1(Device) (BBXTimeData_v1, Return)
+	DeviceGetBankRemapperStatus_v1(Device) (EccBankRemapperStatus_v1, Return)
 	DeviceGetBoardId(Device) (uint32, Return)
 	DeviceGetBoardPartNumber(Device) (string, Return)
 	DeviceGetBrand(Device) (BrandType, Return)
@@ -500,6 +517,7 @@ type Interface interface {
 	DeviceGetGpcClkVfOffset(Device) (int, Return)
 	DeviceGetGpuFabricInfo(Device) (GpuFabricInfo, Return)
 	DeviceGetGpuFabricInfoV(Device) GpuFabricInfoHandler
+	DeviceGetGpuFabricInfo_v4(Device) (GpuFabricInfo_v4, Return)
 	DeviceGetGpuInstanceById(Device, int) (GpuInstance, Return)
 	DeviceGetGpuInstanceId(Device) (int, Return)
 	DeviceGetGpuInstancePossiblePlacements(Device, *GpuInstanceProfileInfo) ([]GpuInstancePlacement, Return)
@@ -542,6 +560,7 @@ type Interface interface {
 	DeviceGetMemoryErrorCounter(Device, MemoryErrorType, EccCounterType, MemoryLocation) (uint64, Return)
 	DeviceGetMemoryInfo(Device) (Memory, Return)
 	DeviceGetMemoryInfo_v2(Device) (Memory_v2, Return)
+	DeviceGetMemoryLimits_v1(Device, string) (MemoryLimits_v1, Return)
 	DeviceGetMigDeviceHandleByIndex(Device, int) (Device, Return)
 	DeviceGetMigMode(Device) (int, int, Return)
 	DeviceGetMinMaxClockOfPState(Device, ClockType, Pstates) (uint32, uint32, Return)
@@ -559,6 +578,7 @@ type Interface interface {
 	DeviceGetNvLinkRemoteDeviceType(Device, int) (IntNvLinkDeviceType, Return)
 	DeviceGetNvLinkRemotePciInfo(Device, int) (PciInfo, Return)
 	DeviceGetNvLinkState(Device, int) (EnableState, Return)
+	DeviceGetNvLinkTelemetrySamples_v1(Device, NvlinkTelemetrySamples_v1) (NvlinkTelemetrySamples_v1, Return)
 	DeviceGetNvLinkUtilizationControl(Device, int, int) (NvLinkUtilizationControl, Return)
 	DeviceGetNvLinkUtilizationCounter(Device, int, int) (uint64, uint64, Return)
 	DeviceGetNvLinkVersion(Device, int) (uint32, Return)
@@ -639,6 +659,7 @@ type Interface interface {
 	DeviceIsMigDeviceHandle(Device) (bool, Return)
 	DeviceModifyDrainState(*PciInfo, EnableState) Return
 	DeviceOnSameBoard(Device, Device) (int, Return)
+	DevicePerfMetricsGetSamples_v1(Device) (PerfMetricsSamples_v1, Return)
 	DevicePowerSmoothingActivatePresetProfile(Device, *PowerSmoothingProfile) Return
 	DevicePowerSmoothingSetState(Device, *PowerSmoothingState) Return
 	DevicePowerSmoothingUpdatePresetProfileParam(Device, *PowerSmoothingProfile) Return
@@ -655,6 +676,7 @@ type Interface interface {
 	DeviceResetNvLinkUtilizationCounter(Device, int, int) Return
 	DeviceSetAPIRestriction(Device, RestrictedAPI, EnableState) Return
 	DeviceSetAccountingMode(Device, EnableState) Return
+	DeviceSetAdaptiveTgpMode_v1(Device, EnableState) Return
 	DeviceSetApplicationsClocks(Device, uint32, uint32) Return
 	DeviceSetAutoBoostedClocksEnabled(Device, EnableState) Return
 	DeviceSetClockOffsets(Device, ClockOffset) Return
@@ -673,11 +695,13 @@ type Interface interface {
 	DeviceSetGpuOperationMode(Device, GpuOperationMode) Return
 	DeviceSetHostname_v1(Device, string) Return
 	DeviceSetMemClkVfOffset(Device, int) Return
+	DeviceSetMemoryLimits_v1(Device, string, uint64, uint64) Return
 	DeviceSetMemoryLockedClocks(Device, uint32, uint32) Return
 	DeviceSetMigMode(Device, int) (Return, Return)
 	DeviceSetNvLinkDeviceLowPowerThreshold(Device, *NvLinkPowerThres) Return
 	DeviceSetNvLinkUtilizationControl(Device, int, int, *NvLinkUtilizationControl, bool) Return
 	DeviceSetNvlinkBwMode(Device, *NvlinkSetBwMode) Return
+	DeviceSetNvlinkBwModeAsync_v1(Device, *NvlinkSetBwModeAsync_v1) Return
 	DeviceSetPersistenceMode(Device, EnableState) Return
 	DeviceSetPowerManagementLimit(Device, uint32) Return
 	DeviceSetPowerManagementLimit_v2(Device, *PowerValue_v2) Return
@@ -698,7 +722,13 @@ type Interface interface {
 	ErrorString(Return) string
 	EventSetCreate() (EventSet, Return)
 	EventSetFree(EventSet) Return
+	EventSetGetContextCount_v1(EventSet) (GetContextCount_v1, Return)
+	EventSetGetContextData_v1(EventSet, GetContextData_v1) (GetContextData_v1, Return)
+	EventSetGetContextInfo_v1(EventSet, uint32) (GetContextInfo_v1, Return)
+	EventSetGetGpuOperationalEventContextLegacyXid_v1(EventSet, uint32) (uint32, Return)
+	EventSetRegisterGpuOperationalEvents_v1(EventSet, *GpuOperationalEventConfig_v1) Return
 	EventSetWait(EventSet, uint32) (EventData, Return)
+	EventSetWait_v3(EventSet, uint32) (EventSetWaitData_v3, Return)
 	Extensions() ExtendedInterface
 	GetExcludedDeviceCount() (int, Return)
 	GetExcludedDeviceInfoByIndex(int) (ExcludedDeviceInfo, Return)
@@ -831,6 +861,7 @@ type Device interface {
 	GetAccountingStats_v2(uint32) (AccountingStats_v2, Return)
 	GetActiveVgpus() ([]VgpuInstance, Return)
 	GetAdaptiveClockInfoStatus() (uint32, Return)
+	GetAdaptiveTgpModeInfo_v1() (AdaptiveTgpModeInfo_v1, Return)
 	GetAddressingMode() (DeviceAddressingMode, Return)
 	GetApplicationsClock(ClockType) (uint32, Return)
 	GetArchitecture() (DeviceArchitecture, Return)
@@ -838,6 +869,7 @@ type Device interface {
 	GetAutoBoostedClocksEnabled() (EnableState, EnableState, Return)
 	GetBAR1MemoryInfo() (BAR1Memory, Return)
 	GetBBXTimeData_v1() (BBXTimeData_v1, Return)
+	GetBankRemapperStatus_v1() (EccBankRemapperStatus_v1, Return)
 	GetBoardId() (uint32, Return)
 	GetBoardPartNumber() (string, Return)
 	GetBrand() (BrandType, Return)
@@ -894,6 +926,7 @@ type Device interface {
 	GetGpcClkVfOffset() (int, Return)
 	GetGpuFabricInfo() (GpuFabricInfo, Return)
 	GetGpuFabricInfoV() GpuFabricInfoHandler
+	GetGpuFabricInfo_v4() (GpuFabricInfo_v4, Return)
 	GetGpuInstanceById(int) (GpuInstance, Return)
 	GetGpuInstanceId() (int, Return)
 	GetGpuInstancePossiblePlacements(*GpuInstanceProfileInfo) ([]GpuInstancePlacement, Return)
@@ -931,6 +964,7 @@ type Device interface {
 	GetMemoryErrorCounter(MemoryErrorType, EccCounterType, MemoryLocation) (uint64, Return)
 	GetMemoryInfo() (Memory, Return)
 	GetMemoryInfo_v2() (Memory_v2, Return)
+	GetMemoryLimits_v1(string) (MemoryLimits_v1, Return)
 	GetMigDeviceHandleByIndex(int) (Device, Return)
 	GetMigMode() (int, int, Return)
 	GetMinMaxClockOfPState(ClockType, Pstates) (uint32, uint32, Return)
@@ -948,6 +982,7 @@ type Device interface {
 	GetNvLinkRemoteDeviceType(int) (IntNvLinkDeviceType, Return)
 	GetNvLinkRemotePciInfo(int) (PciInfo, Return)
 	GetNvLinkState(int) (EnableState, Return)
+	GetNvLinkTelemetrySamples_v1(NvlinkTelemetrySamples_v1) (NvlinkTelemetrySamples_v1, Return)
 	GetNvLinkUtilizationControl(int, int) (NvLinkUtilizationControl, Return)
 	GetNvLinkUtilizationCounter(int, int) (uint64, uint64, Return)
 	GetNvLinkVersion(int) (uint32, Return)
@@ -1033,6 +1068,7 @@ type Device interface {
 	GpmSetStreamingEnabled(uint32) Return
 	IsMigDeviceHandle() (bool, Return)
 	OnSameBoard(Device) (int, Return)
+	PerfMetricsGetSamples_v1() (PerfMetricsSamples_v1, Return)
 	PowerSmoothingActivatePresetProfile(*PowerSmoothingProfile) Return
 	PowerSmoothingSetState(*PowerSmoothingState) Return
 	PowerSmoothingUpdatePresetProfileParam(*PowerSmoothingProfile) Return
@@ -1046,6 +1082,7 @@ type Device interface {
 	ResetNvLinkUtilizationCounter(int, int) Return
 	SetAPIRestriction(RestrictedAPI, EnableState) Return
 	SetAccountingMode(EnableState) Return
+	SetAdaptiveTgpMode_v1(EnableState) Return
 	SetApplicationsClocks(uint32, uint32) Return
 	SetAutoBoostedClocksEnabled(EnableState) Return
 	SetClockOffsets(ClockOffset) Return
@@ -1064,11 +1101,13 @@ type Device interface {
 	SetGpuOperationMode(GpuOperationMode) Return
 	SetHostname_v1(string) Return
 	SetMemClkVfOffset(int) Return
+	SetMemoryLimits_v1(string, uint64, uint64) Return
 	SetMemoryLockedClocks(uint32, uint32) Return
 	SetMigMode(int) (Return, Return)
 	SetNvLinkDeviceLowPowerThreshold(*NvLinkPowerThres) Return
 	SetNvLinkUtilizationControl(int, int, *NvLinkUtilizationControl, bool) Return
 	SetNvlinkBwMode(*NvlinkSetBwMode) Return
+	SetNvlinkBwModeAsync_v1(*NvlinkSetBwModeAsync_v1) Return
 	SetPersistenceMode(EnableState) Return
 	SetPowerManagementLimit(uint32) Return
 	SetPowerManagementLimit_v2(*PowerValue_v2) Return
@@ -1129,7 +1168,13 @@ type ComputeInstance interface {
 //go:generate moq -out mock/eventset.go -pkg mock . EventSet:EventSet
 type EventSet interface {
 	Free() Return
+	GetContextCount_v1() (GetContextCount_v1, Return)
+	GetContextData_v1(GetContextData_v1) (GetContextData_v1, Return)
+	GetContextInfo_v1(uint32) (GetContextInfo_v1, Return)
+	GetGpuOperationalEventContextLegacyXid_v1(uint32) (uint32, Return)
+	RegisterGpuOperationalEvents_v1(*GpuOperationalEventConfig_v1) Return
 	Wait(uint32) (EventData, Return)
+	Wait_v3(uint32) (EventSetWaitData_v3, Return)
 }
 
 // GpmSample represents the interface for the nvmlGpmSample type.


### PR DESCRIPTION
This PR adds Go bindings for new NVML methods from CUDA 13.4.1.

- Add device APIs for memory limits, adaptive TGP mode, perf metrics, GPU fabric v4, NVLink telemetry, and bank remapper status.
- Add EventSet APIs for GPU operational event registration, waiting, and context retrieval.
- Expand GPM metric array from 333 to 477 entries to cover NVLink L36–L71.
- Introduce int8PtrToString and stringToCPtr helpers for C string interop in memory-limits wrappers.
- Update constants, generated interfaces, and mocks to match the CUDA 13.4.1 nvml.h header.