### PR TITLE
device: reject an empty slice in GetFieldValues/ClearFieldValues

### DIFF
--- a/pkg/nvml/device.go
+++ b/pkg/nvml/device.go
@@ -1945,6 +1945,9 @@ func (l *library) DeviceGetFieldValues(device Device, values []FieldValue) Retur
 
 func (device nvmlDevice) GetFieldValues(values []FieldValue) Return {
 	valuesCount := len(values)
+	if valuesCount == 0 {
+		return ERROR_INVALID_ARGUMENT
+	}
 	return nvmlDeviceGetFieldValues(device, int32(valuesCount), &values[0])
 }
 
@@ -2907,6 +2910,9 @@ func (l *library) DeviceClearFieldValues(device Device, values []FieldValue) Ret
 
 func (device nvmlDevice) ClearFieldValues(values []FieldValue) Return {
 	valuesCount := len(values)
+	if valuesCount == 0 {
+		return ERROR_INVALID_ARGUMENT
+	}
 	return nvmlDeviceClearFieldValues(device, int32(valuesCount), &values[0])
 }
 


### PR DESCRIPTION
## Problem

`Device.GetFieldValues` and `Device.ClearFieldValues` take the caller's `[]FieldValue` and immediately take the address of its first element:

```go
valuesCount := len(values)
return nvmlDeviceGetFieldValues(device, int32(valuesCount), &values[0])
```

With an empty slice `&values[0]` panics with an index-out-of-range instead of returning a `Return` code, so a caller that builds its field list dynamically (and ends up with none) crashes rather than getting an error it can handle.

## Fix

Return `ERROR_INVALID_ARGUMENT` for an empty slice, matching how the package already treats this case elsewhere: the caller-provided `prmCounters` slice is guarded with `if len(prmCounters) == 0 { return nil, ERROR_INVALID_ARGUMENT }`, and the zero instance-count guards added in #204 do the same.

No behaviour change for non-empty input.

Disclosure: this contribution was authored with an AI coding assistant (Claude) and reviewed before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
